### PR TITLE
`feat: Improve execute.toml with --device and --all flags, ask_user prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,9 +164,9 @@ Asks user for:
 `commands/mobile-automator/execute.toml` is a **pre-flight wrapper** that:
 1. Verifies `mobile-automator/config.json` exists
 2. Checks that `.gemini/skills/mobile-automator-executor/SKILL.md` is installed
-3. Detects connected devices
+3. Detects connected devices (supports `--device` flag or interactive selection via `ask_user` tool)
 4. Confirms app installation
-5. Resolves which scenarios to execute (by name, ID, or tag)
+5. Resolves which scenarios to execute (supports `--all`, `--tag`, specific names/IDs, or interactive selection via `ask_user` tool)
 6. Delegates to the executor skill at `.gemini/skills/mobile-automator-executor/SKILL.md`
 
 ### Modifying Skill Templates

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Uses AI vision to compare screenshots semantically, not pixel-by-pixel.
 |---------|-------------|-------|--------------|
 | **`/mobile-automator:setup`** | One-time setup - analyzes project and installs testing skills | `> /mobile-automator:setup` | • Detects platform (Android/iOS/Flutter/React Native/KMP/CMP)<br>• Discovers build environments (staging, production, etc.)<br>• Infers app package IDs from build files<br>• Analyzes architecture patterns and business domain<br>• Installs customized QA skills<br>• Creates `mobile-automator/` test directory<br>• **Resume support:** If interrupted, run again to resume |
 | **`/mobile-automator:generate`** | **Record** test scenarios from natural language (do this once per test) | `> /mobile-automator:generate`<br><br>Options:<br>• `--set-environment="X"` (use X and save as default)<br>• `--environment="X"` (one-time override, no save) | • Connects to your device/emulator<br>• Asks for environment once, saves preference for future runs<br>• Prompts for test steps in natural language<br>• Executes steps on device while recording<br>• Captures reference screenshots<br>• Generates JSON scenario file (schema v2)<br>**Output:** `mobile-automator/scenarios/<scenario_id>.json` |
-| **`/mobile-automator:execute`** | **Replay** saved test scenarios (run repeatedly for regression testing) | `> /mobile-automator:execute <scenario_id>`<br><br>Examples:<br>• Single: `execute login_flow`<br>• Multiple: `execute login_flow checkout_flow`<br>• All: `execute` (interactive) | • Replays scenario steps on connected device<br>• Captures actual screenshots for comparison<br>• Validates assertions (element exists, text matches, visual state)<br>• Detects flakiness and retries automatically<br>• Generates detailed pass/fail report with diagnostics<br>**Output:** `mobile-automator/results/<run_id>.json` |
+| **`/mobile-automator:execute`** | **Replay** saved test scenarios (run repeatedly for regression testing) | `> /mobile-automator:execute <scenario_id>`<br><br>Examples:<br>• Single: `execute login_flow`<br>• Multiple: `execute login_flow checkout_flow`<br>• All: `execute --all`<br>• Interactive: `execute`<br><br>Options:<br>• `--device="id"` (specify device) | • Replays scenario steps on connected device<br>• Captures actual screenshots for comparison<br>• Validates assertions (element exists, text matches, visual state)<br>• Detects flakiness and retries automatically<br>• Generates detailed pass/fail report with diagnostics<br>**Output:** `mobile-automator/results/<run_id>.json` |
 | **`/mobile-automator:migrate`** | **Migrate** a v1 scenario JSON to schema v2 format | `> /mobile-automator:migrate <scenario_id>`<br><br>Examples:<br>• `migrate login_flow`<br>• `migrate` (interactive file selection) | • Analyzes existing v1 scenario<br>• Auto-converts step IDs, assertion IDs, metadata<br>• Interactively resolves ambiguous waits<br>• Creates `.v1.bak` backup before any changes<br>• Outputs valid schema v2 scenario |
 | **`/mobile-automator:list-tags`**| Lists all tags currently used in test scenarios | `> /mobile-automator:list-tags` | • Scans all JSON scenarios<br>• Displays tag counts<br>• Differentiates standard vs custom tags |
 | **`/mobile-automator:report`** | Generate aggregated test reports | `> /mobile-automator:report`<br><br>Options:<br>• `--last N` (default 10)<br>• `--format table\|json\|html`<br>• `--junit` (JUnit XML) | • Aggregates all test results<br>• Shows pass rate, flaky steps, failures<br>• Exports to JSON, HTML, or JUnit XML<br>**Output:** `mobile-automator/results/report.{json,html,xml}` |
@@ -268,6 +268,12 @@ Use the `--tag` parameter with `/mobile-automator:execute` to filter runs:
 - **Exclude tags (NOT):** `/mobile-automator:execute --tag !flaky` (excludes scenarios with this tag)
 
 If you run `/mobile-automator:execute` without arguments, the interactive menu will automatically group your scenarios by their primary tag.
+
+### Selecting a Specific Device
+Use the `--device` parameter if you have multiple devices connected and want to bypass the interactive device selection prompt:
+```bash
+> /mobile-automator:execute login_flow --device="emulator-5554"
+```
 
 ### Standard Tag Registry
 We recommend standardizing on these common tags:

--- a/commands/mobile-automator/execute.toml
+++ b/commands/mobile-automator/execute.toml
@@ -9,31 +9,52 @@ CRITICAL: Do NOT execute scenarios yourself. After pre-flight passes, follow the
 
 ## 0.0 SCHEMA VERSION DEPRECATION CHECK
 
-After loading the scenario file(s) to execute (resolved in section 2.0), for each selected scenario:
+1.  **Check if the user specified `--schema-version 1.0`** in their command invocation.
+    - Example: `/mobile-automator:execute --schema-version 1.0`
 
-1.  **Read `$schema_version` from the scenario JSON.**
-2.  **If `$schema_version` is absent or `"1.0"` (v1 scenario detected):**
+2.  **If `--schema-version 1.0` is specified:**
 
     Determine the current deprecation phase based on today's date relative to the v2 launch date of **2026-02-17**:
 
     - **Phase 1 (months 0–6, until 2026-08-17):** Non-blocking informational warning:
-      > "⚠️ **Deprecation Notice (Schema v1):** Scenario '<scenario_id>' uses schema v1, which is deprecated as of 2026-02-17. v1 scenarios will stop working after 2027-02-17 (12-month deprecation period).
-      > To migrate this scenario to v2: run `/mobile-automator:migrate <scenario_id>`
-      > Continuing execution..."
-      Continue with execution using the v1 execution path.
+      > "⚠️ **Deprecation Notice (Schema v1):** You are requesting execution in schema v1 mode. Schema v1 is deprecated as of 2026-02-17 in favor of v2 (the default). v1 will be completely removed in 12 months (2027-02-17).
+      > To migrate existing v1 scenarios: run `/mobile-automator:migrate <scenario_id>`
+      > Continuing..."
+      Continue with execution.
 
-    - **Phase 2 (months 7–11, 2026-08-17 to 2027-01-17):** Escalated warning, still allow execution but require acknowledgment:
-      > "⚠️ **Final Deprecation Warning (Schema v1):** Scenario '<scenario_id>' uses schema v1, which is in its final deprecation phase (month 7 of 12). This scenario will STOP WORKING after 2027-02-17.
-      > Migrate now to avoid test failures: run `/mobile-automator:migrate <scenario_id>`
-      > Type 'continue' to execute anyway, or 'cancel' to abort and migrate first:"
-      **WAIT for user response.** If 'continue' → proceed. If 'cancel' → halt with migration instructions.
+    - **Phase 2 (months 7–11, 2026-08-17 to 2027-01-17):** Escalated warning, block execution:
+      > "🚫 **Schema v1 Execution Blocked:** Schema v1 is in the final deprecation phase (month 7 of 12). Execution with `--schema-version 1.0` is no longer allowed.
+      > To migrate existing v1 scenarios: run `/mobile-automator:migrate <scenario_id>`"
+      **HALT.**
 
     - **Phase 3 (month 12+, after 2027-01-17):** Hard fail:
-      > "❌ **Schema v1 Execution Blocked:** Scenario '<scenario_id>' uses schema v1, which reached end-of-life on 2027-02-17.
-      > Migrate this scenario to v2 before executing: run `/mobile-automator:migrate <scenario_id>`"
-      **HALT. Do NOT execute this scenario.**
+      > "❌ **Schema v1 Removed:** Schema v1 reached end-of-life on 2027-02-17 and is no longer supported.
+      > Remove `--schema-version 1.0` from your command. To migrate existing v1 scenarios: run `/mobile-automator:migrate <scenario_id>`"
+      **HALT.**
 
-3.  **If `$schema_version` is `"2.0"`:** No action needed. Continue with v2 execution.
+3.  **If no `--schema-version` flag is specified:** Proceed normally. Per-scenario schema version checking is handled by the executor skill at `.gemini/skills/mobile-automator-executor/SKILL.md`.
+
+---
+
+## 0.1 DEVICE RESOLUTION
+
+**Purpose:** Resolve `selected_device` before pre-flight checks. This value is consumed by Section 1.2.
+
+**config.json absence guard:** If `mobile-automator/config.json` does not exist, skip Section 0.1 entirely — the `--device` flag is effectively unused because Section 1.1 will halt before device selection is needed. This is intentional: the user will receive the "Setup not found. Please run `/mobile-automator:setup` first." error from Section 1.1, which is the appropriate and actionable message. No additional warning about `--device` being ignored is needed.
+
+1.  **If `--device="<device_id>"` is present in the command:**
+    -   Call `mobile_list_available_devices()` to get the list of connected devices.
+    -   **If the returned list is empty** (no devices connected) → halt:
+        > "❌ No devices connected. Please connect a device, emulator, or simulator and try again."
+    -   **If the returned list is non-empty but the specified device ID is not found** → halt:
+        > "❌ Device not found: \"[device_id]\"\n   Connected devices: [list of connected device names/IDs]"
+    -   **If the device ID is found** → set `selected_device` to the matched device. Announce:
+        > "ℹ️  Using device: [device_name or device_id] (--device flag)"
+    -   Proceed to Section 1.0.
+
+2.  **No `--device` flag:** Leave `selected_device` unset. Section 1.2 handles interactive device discovery.
+
+**Note:** `--device` can be combined with `--all`, `--tag`, or a scenario name. It is resolved independently here and consumed by Section 1.2 regardless of which scenario selection mode is used.
 
 ---
 
@@ -47,13 +68,16 @@ After loading the scenario file(s) to execute (resolved in section 2.0), for eac
 3.  Read `mobile-automator/config.json` to load project configuration.
 
 ### 1.2 Verify Device
-1.  Use `mobile_list_available_devices()` to check for connected devices.
+1.  **If `selected_device` is already set** (resolved via `--device` in Section 0.1) → announce and proceed. No additional device check needed.
+    > "ℹ️  Using device: [device_name or device_id] (--device flag)"
+2.  Use `mobile_list_available_devices()` to check for connected devices.
     - If no devices found → "No device connected. Please connect a device, emulator, or simulator and try again." → Halt.
-2.  If multiple devices are found, present the list and ask the user to select one:
-    > "I found multiple devices:"
-    > [list devices with index]
-    > "Which device should I use?"
-3.  Confirm the selected device to the user.
+3.  If exactly **one** device is found → announce and proceed. No prompt.
+    > "✅ Using device: [device_name or device_id]"
+4.  If **multiple** devices are found, use the `ask_user` tool (type: `choice`) to ask the user to select one:
+    - Header: `Device`
+    - Question: `Which device should I use?`
+    - Options: Dynamically list the available devices using the name or identifier returned by `mobile_list_available_devices()`. For each device, use the display name as the option label and the device ID as the description (e.g., option: `Pixel 7`, description: `emulator-5554`).
 
 ### 1.3 Check Preconditions and Prepare App
 1.  **Read config:** Load `mobile-automator/config.json`.
@@ -75,14 +99,14 @@ After loading the scenario file(s) to execute (resolved in section 2.0), for eac
         -   Check if the app has ever been installed (check for app data directories)
         -   If found, uninstall and clear all app data
     -   **Otherwise (no uninstall preconditions):**
-        -   Ask the user:
-            > "I'll be testing **[app_package]** ([scenario_environment]) on **[device_name]**."
-            > "Should I build and install the app, or is it already installed?"
-            >
-            > A) Build and install (using: `[build_command]`)
-            > B) Already installed, skip build
-        -   If A → execute the build command and install
-        -   If B → verify the app is installed using `mobile_launch_app` as a check
+        -   Use the `ask_user` tool (type: `choice`) to confirm:
+            - Header: `Build & Install`
+            - Question: If the original command used `--all`, ask: `I'll be testing [app_package] on [device_name]. Should I build and install the app?` (omit environment — scenarios may span multiple environments). Otherwise ask: `I'll be testing [app_package] ([scenario_environment]) on [device_name]. Should I build and install the app?`
+            - Options:
+              - `Build and install` (description: `using: [build_command]`)
+              - `Already installed` (description: `skip build`)
+        -   If `Build and install` → execute the build command and install
+        -   If `Already installed` → verify the app is installed using `mobile_launch_app` as a check
 
 ---
 
@@ -96,8 +120,20 @@ After loading the scenario file(s) to execute (resolved in section 2.0), for eac
 
 **CRITICAL: Do NOT auto-select scenarios. If no scenario is specified in the command, ALWAYS show the interactive menu.**
 
-1.  **Check if the user specified scenarios in the command:**
-    - The command format is: `/mobile-automator:execute [scenario_name]` or `/mobile-automator:execute --tag <expression>`
+1.  **If `--all` flag is present:**
+    -   Load all `.json` files from `mobile-automator/scenarios/`.
+    -   Use the `ask_user` tool (type: `choice`) to confirm before executing:
+        - Header: `Run All Scenarios`
+        - Question: `I'll execute all [N] scenario(s): [list scenario names]. Proceed?`
+        - Options:
+          - `Proceed` (description: `Execute all [N] scenarios`)
+          - `Cancel` (description: `Do not proceed`)
+    -   If `Cancel` → halt. Do NOT proceed.
+    -   If `Proceed` → skip to Section 3.0 immediately. Do NOT continue to remaining steps in Section 2.2.
+
+2.  **Check if the user specified scenarios in the command:**
+    - The command format is: `/mobile-automator:execute [scenario_name]`, `/mobile-automator:execute --tag <expression>`, `/mobile-automator:execute --all`, or `/mobile-automator:execute` (interactive menu)
+    - `--all` can be combined with `--device` (e.g., `/mobile-automator:execute --all --device="emulator-5554"`)
     - Examples:
       - `/mobile-automator:execute login_flow` → scenario specified
       - `/mobile-automator:execute --tag smoke` → single tag filter
@@ -106,7 +142,7 @@ After loading the scenario file(s) to execute (resolved in section 2.0), for eac
       - `/mobile-automator:execute --tag !flaky` → NOT filter (exclude tag)
       - `/mobile-automator:execute` → NO scenario specified
 
-2.  **If the user specified a `--tag` parameter:**
+3.  **If the user specified a `--tag` parameter:**
     - **Step A (Format Validation):** Validate each extracted tag string against `^[a-z0-9][a-z0-9-]*$` (max 20 chars). If any tag is invalid, halt with error:
       > "❌ Invalid tag format: '[invalid_tag]'
       > Tags must be: lowercase (a-z), alphanumeric + hyphens, max 20 characters
@@ -124,12 +160,12 @@ After loading the scenario file(s) to execute (resolved in section 2.0), for eac
       > Proceed? (yes/no)"
       WAIT for "yes" before executing.
 
-3.  **If the user specified scenarios by name/ID:**
+4.  **If the user specified scenarios by name/ID:**
     - Match against `scenario_id` in each JSON file.
     - If no matches → "No scenarios found matching '[query]'. Available scenarios: [list]" → Halt.
     - Confirm execution and WAIT for "yes".
 
-4.  **If the user specified NO scenarios** (command was just `/mobile-automator:execute`), present a tag-grouped interactive menu:
+5.  **If the user specified NO scenarios** (command was just `/mobile-automator:execute`), present a tag-grouped interactive menu:
     - Group all available scenarios by their primary tag, and tally an "untagged" group.
     - Present the menu exactly like this example:
       > "Available scenarios (grouped by tags):
@@ -152,14 +188,14 @@ After loading the scenario file(s) to execute (resolved in section 2.0), for eac
       > C) Select by number (e.g., 'C 1,3,5')
       > D) Run all scenarios"
 
-5.  **WAIT for user selection.** Do NOT proceed until the user responds.
+6.  **WAIT for user selection.** Do NOT proceed until the user responds.
 
-6.  **After user selects from the menu**, map their choice back to a scenario list. Confirm the final selection:
+7.  **After user selects from the menu**, map their choice back to a scenario list. Confirm the final selection:
     > "I'll execute the following [N] scenario(s):"
     > [list selected scenario names]
     > "Proceed? (yes/no)"
 
-7.  **WAIT for user confirmation.** Only proceed after explicit "yes" response.
+8.  **WAIT for user confirmation.** Only proceed after explicit "yes" response.
 
 ---
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Mobile QA automation with test generation and execution using mobile-mcp",
   "author": "Mohamed Shalan",
   "repository": "https://github.com/sh3lan93/mobile-automator",


### PR DESCRIPTION
### Description

This PR brings the `execute.toml` command to structural and UX parity with `generate.toml`, standardizes interactive prompts, adds requested flags to bypass interactive menus, and bumps the extension version to 0.7.0.

#### 🚀 Features & Improvements
* **Flags Support:**
  * Added `--device="<device_id>"` flag to pre-select an available device ephemerally out-of-the-box.
  * Added `--all` flag to execute all test scenarios, bypassing the interactive selection menu.
* **Structured Prompts:** Replaced plaintext prose prompts with the structured `ask_user` tool (type: `choice`) for interactive multi-device selection and app build/install confirmations.
* **Deprecation Gate Refactor:** Fixed a logical ordering contradiction in Section 0.0 by restructuring it as a pure upfront gate that checks for explicit user intent.
* **Documentation:**
  * Created the approved design specifications for `execute.toml` improvements.
  * Updated [README.md](cci:7://file:///Users/mohamedshalan/open-source/mobile-automator/README.md:0:0-0:0) and [CLAUDE.md](cci:7://file:///Users/mohamedshalan/open-source/mobile-automator/CLAUDE.md:0:0-0:0) to reflect the new command usages and updated options. 
* **Version Bump:** Bumped extension version to `0.7.0` in [gemini-extension.json](cci:7://file:///Users/mohamedshalan/open-source/mobile-automator/gemini-extension.json:0:0-0:0).

#### 📋 Testing & Verification
* Verified device resolution correctly halts or uses the provided device when running `execute` with the `--device` flag.
* Verified that `--all` correctly skips the interactive scenario selection and confirms execution of all scenarios.
* Validated that the `ask_user` choice prompts properly map selection states.
