### PR TITLE
fix: Deterministic skill installation via Node.js script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ prototypes/
 .planning-archive/
 site/
 .worktrees/
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.1] - 2026-03-28
+
+### 🐛 Fixed
+
+- **Deterministic Skill Installation** — Replaced the AI-mediated file copy/replace in setup Section 6.0 with a Node.js script (`scripts/install-skills.js`) that handles all template operations deterministically.
+  - Fixes silent file corruption (truncation, missing sections, garbled schemas) during skill installation
+  - Placeholder replacement now uses `split().join()` in Node.js instead of in-memory AI reproduction
+  - Schema files copied byte-perfect with `fs.copyFileSync` instead of AI read/write
+  - Runtime placeholders (`{{capture_to}}`, `{{variable_name}}`) in executor skill are now correctly preserved
+  - Added `scenario_schema_v2.json` to template verification (was previously missing)
+  - Verification now checks file existence, non-zero size, and setup-placeholder absence
+  - Setup Section 6.0 reduced from ~100 lines to ~30 lines
+
+---
+
 ## [0.8.0] - 2026-03-27
 
 ### 🗑️ Removed

--- a/commands/mobile-automator/setup.toml
+++ b/commands/mobile-automator/setup.toml
@@ -439,99 +439,37 @@ CRITICAL: This setup process is entirely file-based. It does NOT require a conne
 ---
 
 ## 6.0 SKILL INSTALLATION
-**PROTOCOL: Copy skill templates from the extension into the project's `.gemini/skills/` directory and populate all placeholders with the gathered project knowledge.**
+**PROTOCOL: Install skill templates from the extension into the project's `.gemini/skills/` directory using the automated installation script.**
 
-### 6.1 Create Skill Directories
+### 6.1 Run Installation Script
 1.  **Announce Action:** "Installing QA automation skills into your project..."
-2.  **Execute:**
-    ```
-    mkdir -p .gemini/skills/mobile-automator-generator/references
-    mkdir -p .gemini/skills/mobile-automator-executor/references
-    mkdir -p .gemini/skills/references
-    ```
+2.  **Execute the installation script:**
+    -   First, try running:
+        ```
+        node ~/.gemini/extensions/mobile-automator/scripts/install-skills.js
+        ```
+    -   If the command fails because the script file does not exist:
+        -   Read `~/.gemini/extensions/mobile-automator/.gemini-extension-install.json`.
+        -   If the JSON contains a `path` or `localPath` field, try:
+            ```
+            node <path_value>/scripts/install-skills.js
+            ```
+        -   If neither path works, announce:
+            > "Skill installation script not found. Please update the extension: `gemini extensions install https://github.com/sh3lan93/mobile-automator`"
+            **HALT.**
 
-### 6.2 Locate Extension Templates
-1.  **Determine the extension installation path:**
-    -   The mobile-automator extension can be installed in two ways:
+3.  **The script will automatically:**
+    -   Read project knowledge from `mobile-automator/setup_state.json`
+    -   Create `.gemini/skills/` directories
+    -   Copy skill templates with placeholder replacement
+    -   Copy reference schemas verbatim
+    -   Verify all files are installed correctly
 
-        **Method 1: Local Development (linked)**
-        - Extension directory: `~/.gemini/extensions/mobile-automator/`
-        - Contains a file: `.gemini-extension-install.json`
-        - This JSON file has a field that contains the actual path to the extension source
+### 6.2 Check Script Output
+1.  **If the script exits successfully** (exit code 0) and prints "All skills installed and verified successfully" → proceed to Section 6.3.
+2.  **If the script exits with an error** (non-zero exit code) → report the error message from the script output to the user and **HALT**.
 
-        **Method 2: GitHub Installation**
-        - Extension directory: `~/.gemini/extensions/mobile-automator/`
-        - Templates are directly at: `~/.gemini/extensions/mobile-automator/templates/`
-
-2.  **Locate the templates directory:**
-    -   **Step A:** Check if `~/.gemini/extensions/mobile-automator/.gemini-extension-install.json` exists.
-    -   **Step B:** If it exists:
-        -   Read the JSON file.
-        -   Extract the source path from the JSON (this is where the extension was linked from).
-        -   The templates directory is: `<source_path>/templates/`
-    -   **Step C:** If it does NOT exist:
-        -   The templates directory is: `~/.gemini/extensions/mobile-automator/templates/`
-    -   **Step D:** Store the resolved templates path for use in subsequent steps.
-
-3.  **Verify the templates exist:**
-    -   Check that the following files exist at the resolved templates path:
-        - `<templates_path>/mobile-automator-generator/SKILL.md`
-        - `<templates_path>/mobile-automator-executor/SKILL.md`
-        - `<templates_path>/mobile-automator-generator/references/scenario_schema.json`
-        - `<templates_path>/mobile-automator-executor/references/result_schema.json`
-        - `<templates_path>/references/mobile-mcp-tools.md`
-    -   If any file is missing, report the error and halt:
-        > "Template file not found: `<file_path>`. Please ensure the mobile-automator extension is properly installed."
-
-### 6.3 Copy and Populate Templates
-1.  **Read the current state** from `mobile-automator/setup_state.json` to get all knowledge values.
-2.  **For each skill template** (`mobile-automator-generator` and `mobile-automator-executor`):
-    -   Read the `SKILL.md` template from `<templates_path>/<skill-name>/SKILL.md` (using the templates path resolved in Section 6.2).
-    -   Replace ALL placeholders with the values from the state:
-
-        | Placeholder | Value Source |
-        |---|---|
-        | `{{project_name}}` | `knowledge.project_name` |
-        | `{{platform_details}}` | `knowledge.platform_details` |
-        | `{{build_system}}` | `knowledge.build_system` |
-        | `{{build_command}}` | `knowledge.build_command` |
-        | `{{app_package}}` | `app.android_package` and/or `app.ios_bundle_id` (format as appropriate) |
-        | `{{environments}}` | `environments` array joined as comma-separated string |
-        | `{{automation_extras}}` | `knowledge.automation_extras` |
-        | `{{architecture}}` | `knowledge.architecture` |
-        | `{{business_domain}}` | `knowledge.business_domain` |
-        | `{{business_critical_paths}}` | `knowledge.business_critical_paths` |
-        | `{{loading_indicators}}` | `knowledge.loading_indicators` |
-        | `{{protected_directories}}` | `knowledge.protected_directories` |
-        | `{{additional_resources}}` | `""` (empty string, unless user provides additional resources) |
-
-    -   Write the populated `SKILL.md` to `.gemini/skills/<skill-name>/SKILL.md`.
-
-3.  **Copy reference schemas and documentation:**
-    -   **For scenario_schema_v2.json (primary):**
-        -   Read the file `<templates_path>/mobile-automator-generator/references/scenario_schema_v2.json`.
-        -   Write the exact content to `.gemini/skills/mobile-automator-generator/references/scenario_schema_v2.json` in the workspace.
-    -   **For scenario_schema.json (legacy v1, kept for backward compatibility):**
-        -   Read the file `<templates_path>/mobile-automator-generator/references/scenario_schema.json`.
-        -   Write the exact content to `.gemini/skills/mobile-automator-generator/references/scenario_schema.json` in the workspace.
-    -   **For result_schema.json:**
-        -   Read the file `<templates_path>/mobile-automator-executor/references/result_schema.json`.
-        -   Write the exact content to `.gemini/skills/mobile-automator-executor/references/result_schema.json` in the workspace.
-    -   **For mobile-mcp-tools.md:**
-        -   Read the file `<templates_path>/references/mobile-mcp-tools.md`.
-        -   Write the exact content to `.gemini/skills/references/mobile-mcp-tools.md` in the workspace.
-
-### 6.4 Verify Installation
-1.  **Verify** that all 6 files exist:
-    - `.gemini/skills/mobile-automator-generator/SKILL.md`
-    - `.gemini/skills/mobile-automator-generator/references/scenario_schema_v2.json`
-    - `.gemini/skills/mobile-automator-generator/references/scenario_schema.json`
-    - `.gemini/skills/mobile-automator-executor/SKILL.md`
-    - `.gemini/skills/mobile-automator-executor/references/result_schema.json`
-    - `.gemini/skills/references/mobile-mcp-tools.md`
-2.  **Verify** that no `{{` placeholders remain in either SKILL.md file. If any remain, announce the error and halt.
-
-### 6.5 Update State
+### 6.3 Update State
 -   Write `mobile-automator/setup_state.json` with:
     ```json
     {
@@ -540,7 +478,7 @@ CRITICAL: This setup process is entirely file-based. It does NOT require a conne
     }
     ```
 
-5.  **Continue:** Proceed to Section 7.0.
+4.  **Continue:** Proceed to Section 7.0.
 
 ---
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Mobile QA automation with test generation and execution using mobile-mcp",
   "author": "Mohamed Shalan",
   "repository": "https://github.com/sh3lan93/mobile-automator",

--- a/scripts/install-skills.js
+++ b/scripts/install-skills.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** The 13 setup-time placeholders. Only these are replaced in SKILL.md files.
+ *  Runtime placeholders like {{capture_to}} and {{variable_name}} are preserved. */
+const SETUP_PLACEHOLDERS = [
+  'project_name',
+  'platform_details',
+  'build_system',
+  'build_command',
+  'app_package',
+  'environments',
+  'automation_extras',
+  'architecture',
+  'business_domain',
+  'business_critical_paths',
+  'loading_indicators',
+  'protected_directories',
+  'additional_resources',
+];
+
+/** SKILL.md templates — copied with placeholder replacement. */
+const SKILL_TEMPLATES = [
+  {
+    src: 'mobile-automator-generator/SKILL.md',
+    dest: '.gemini/skills/mobile-automator-generator/SKILL.md',
+  },
+  {
+    src: 'mobile-automator-executor/SKILL.md',
+    dest: '.gemini/skills/mobile-automator-executor/SKILL.md',
+  },
+];
+
+/** Schema and reference files — copied verbatim (byte-perfect). */
+const SCHEMA_COPIES = [
+  {
+    src: 'mobile-automator-generator/references/scenario_schema_v2.json',
+    dest: '.gemini/skills/mobile-automator-generator/references/scenario_schema_v2.json',
+  },
+  {
+    src: 'mobile-automator-generator/references/scenario_schema.json',
+    dest: '.gemini/skills/mobile-automator-generator/references/scenario_schema.json',
+  },
+  {
+    src: 'mobile-automator-executor/references/result_schema.json',
+    dest: '.gemini/skills/mobile-automator-executor/references/result_schema.json',
+  },
+  {
+    src: 'references/mobile-mcp-tools.md',
+    dest: '.gemini/skills/references/mobile-mcp-tools.md',
+  },
+];
+
+/** Destination directories to create. */
+const DEST_DIRS = [
+  '.gemini/skills/mobile-automator-generator/references',
+  '.gemini/skills/mobile-automator-executor/references',
+  '.gemini/skills/references',
+];
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the {{app_package}} value from the app section of setup state.
+ * Rules:
+ *   - Android only  → `<pkg>`
+ *   - iOS only      → `<bundle>`
+ *   - Both          → Android: `<pkg>` / iOS: `<bundle>`
+ *   - Neither       → N/A
+ */
+function buildAppPackage(app) {
+  if (!app) return 'N/A';
+
+  const android = app.android_package || app.android_package_base || null;
+  const ios = app.ios_bundle_id || app.ios_bundle_id_base || null;
+
+  if (android && ios) return `Android: \`${android}\` / iOS: \`${ios}\``;
+  if (android) return `\`${android}\``;
+  if (ios) return `\`${ios}\``;
+  return 'N/A';
+}
+
+/**
+ * Build the placeholder → value map from setup state.
+ * Any undefined/null value defaults to '' with a warning.
+ */
+function buildPlaceholderMap(state) {
+  const k = state.knowledge || {};
+  const envs = Array.isArray(state.environments)
+    ? state.environments.join(', ')
+    : String(state.environments || '');
+
+  const raw = {
+    '{{project_name}}': k.project_name,
+    '{{platform_details}}': k.platform_details,
+    '{{build_system}}': k.build_system,
+    '{{build_command}}': k.build_command,
+    '{{app_package}}': buildAppPackage(state.app),
+    '{{environments}}': envs,
+    '{{automation_extras}}': k.automation_extras,
+    '{{architecture}}': k.architecture,
+    '{{business_domain}}': k.business_domain,
+    '{{business_critical_paths}}': k.business_critical_paths,
+    '{{loading_indicators}}': k.loading_indicators,
+    '{{protected_directories}}': k.protected_directories,
+    '{{additional_resources}}': k.additional_resources,
+  };
+
+  const map = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (value == null) {
+      console.warn(`  ⚠ Warning: ${key} resolved to empty (missing in setup state)`);
+      map[key] = '';
+    } else {
+      map[key] = String(value);
+    }
+  }
+  return map;
+}
+
+/**
+ * Replace placeholders using split/join (safe for special characters).
+ */
+function replacePlaceholders(content, map) {
+  let result = content;
+  for (const [placeholder, value] of Object.entries(map)) {
+    result = result.split(placeholder).join(value);
+  }
+  return result;
+}
+
+/**
+ * Check if any of the 13 setup placeholders remain unreplaced.
+ */
+function findUnreplacedSetupPlaceholders(content) {
+  const remaining = [];
+  for (const name of SETUP_PLACEHOLDERS) {
+    if (content.includes(`{{${name}}}`)) {
+      remaining.push(`{{${name}}}`);
+    }
+  }
+  return remaining;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const projectRoot = process.cwd();
+  const extensionPath = path.resolve(__dirname, '..');
+  const templatesPath = path.join(extensionPath, 'templates');
+  const stateFile = path.join(projectRoot, 'mobile-automator', 'setup_state.json');
+
+  console.log(`Project root: ${projectRoot}`);
+  console.log(`Extension path: ${extensionPath}`);
+  console.log(`Templates path: ${templatesPath}\n`);
+
+  // --- 1. Validate setup state ---
+  if (!fs.existsSync(stateFile)) {
+    console.error(`ERROR: Setup state file not found: ${stateFile}`);
+    console.error('Please complete setup sections 1-5 first.');
+    process.exit(1);
+  }
+
+  let state;
+  try {
+    state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+  } catch (e) {
+    console.error(`ERROR: Failed to parse setup state: ${e.message}`);
+    process.exit(1);
+  }
+
+  if (!state.knowledge) {
+    console.error('ERROR: Setup state is missing the "knowledge" section.');
+    console.error('Please complete section 5.0 (Project Knowledge) first.');
+    process.exit(1);
+  }
+
+  // --- 2. Verify all source templates exist ---
+  const allEntries = [...SKILL_TEMPLATES, ...SCHEMA_COPIES];
+  for (const entry of allEntries) {
+    const fullPath = path.join(templatesPath, entry.src);
+    if (!fs.existsSync(fullPath)) {
+      console.error(`ERROR: Template not found: ${fullPath}`);
+      console.error(
+        'Please ensure the mobile-automator extension is properly installed.'
+      );
+      process.exit(1);
+    }
+  }
+  console.log(`✓ All ${allEntries.length} source templates verified\n`);
+
+  // --- 3. Create destination directories ---
+  for (const dir of DEST_DIRS) {
+    fs.mkdirSync(path.join(projectRoot, dir), { recursive: true });
+  }
+  console.log('✓ Skill directories created\n');
+
+  // --- 4. Build placeholder map ---
+  const placeholderMap = buildPlaceholderMap(state);
+
+  console.log('Placeholder values:');
+  for (const [key, value] of Object.entries(placeholderMap)) {
+    const display =
+      value.length > 60 ? value.substring(0, 60) + '...' : value;
+    console.log(`  ${key} → ${display || '(empty)'}`);
+  }
+  console.log('');
+
+  // --- 5. Copy + replace SKILL.md templates ---
+  for (const skill of SKILL_TEMPLATES) {
+    const srcPath = path.join(templatesPath, skill.src);
+    const destPath = path.join(projectRoot, skill.dest);
+
+    const template = fs.readFileSync(srcPath, 'utf8');
+    const populated = replacePlaceholders(template, placeholderMap);
+
+    const unreplaced = findUnreplacedSetupPlaceholders(populated);
+    if (unreplaced.length > 0) {
+      console.error(
+        `ERROR: Unreplaced setup placeholders in ${skill.src}: ${unreplaced.join(', ')}`
+      );
+      process.exit(1);
+    }
+
+    fs.writeFileSync(destPath, populated, 'utf8');
+    console.log(`✓ Installed ${skill.dest}`);
+  }
+
+  // --- 6. Copy schema/reference files verbatim ---
+  for (const schema of SCHEMA_COPIES) {
+    const srcPath = path.join(templatesPath, schema.src);
+    const destPath = path.join(projectRoot, schema.dest);
+
+    fs.copyFileSync(srcPath, destPath);
+    console.log(`✓ Copied ${schema.dest}`);
+  }
+
+  // --- 7. Verify installation ---
+  console.log('\nVerification:');
+  let hasErrors = false;
+
+  const skillDestPaths = new Set(SKILL_TEMPLATES.map((s) => s.dest));
+
+  for (const entry of allEntries) {
+    const fullPath = path.join(projectRoot, entry.dest);
+    if (!fs.existsSync(fullPath)) {
+      console.error(`  ✗ MISSING: ${entry.dest}`);
+      hasErrors = true;
+    } else {
+      const stats = fs.statSync(fullPath);
+      if (stats.size === 0) {
+        console.error(`  ✗ EMPTY: ${entry.dest} (0 bytes)`);
+        hasErrors = true;
+      } else {
+        console.log(`  ✓ ${entry.dest} (${stats.size} bytes)`);
+        if (skillDestPaths.has(entry.dest)) {
+          const writtenContent = fs.readFileSync(fullPath, 'utf8');
+          const unreplaced = findUnreplacedSetupPlaceholders(writtenContent);
+          if (unreplaced.length > 0) {
+            console.error(
+              `  ✗ UNREPLACED PLACEHOLDERS in ${entry.dest}: ${unreplaced.join(', ')}`
+            );
+            hasErrors = true;
+          }
+        }
+      }
+    }
+  }
+
+  if (hasErrors) {
+    console.error('\nERROR: Skill installation completed with errors.');
+    process.exit(1);
+  }
+
+  console.log('\n✅ All skills installed and verified successfully.');
+}
+
+main();


### PR DESCRIPTION
### Summary

- Replaced unreliable AI-mediated file copy/replace in setup Section 6.0 with a deterministic Node.js script (`scripts/install-skills.js`)
- Fixed 6 bugs causing silent file corruption during skill installation (truncation, missing sections, placeholder remnants, garbled schemas)
- Reduced setup.toml Section 6.0 from ~100 lines to ~30 lines — the AI now runs one command instead of performing 12 sequential file I/O operations

### Problem

The setup command's skill installation step asked Gemini (an LLM) to read 6 template files (~75KB), perform 13 placeholder replacements across 2 SKILL.md templates in working memory, and reproduce the content verbatim. This is a programmatic file manipulation task — fundamentally unreliable for an AI agent.

The result: **silent corruption**. Files were truncated, sections went missing, placeholders were left unreplaced, and JSON schemas were garbled. The verification step only checked file existence and leftover `{{`, not content integrity — so corruption passed undetected. Failures varied between runs with no consistent pattern.

### Root Causes Identified

| Category | Bug | Impact |
|----------|-----|--------|
| **Prompt Bug** | Executor SKILL.md contains runtime `{{capture_to}}` and `{{variable_name}}` but verification says "no `{{` should remain" | AI either breaks skill docs or fails verification |
| **Prompt Bug** | `scenario_schema_v2.json` missing from template verification list | AI might not detect missing template |
| **Prompt Bug** | `.gemini-extension-install.json` field name never specified; `source` field contains a URL for GitHub installs, not a local path | AI may use URL as filesystem path |
| **Prompt Bug** | `{{app_package}}` formatting says "as appropriate" — vague | Different formatting each run |
| **Architecture** | 75KB of file content reproduced from AI working memory | Truncation, corruption, omission |
| **Architecture** | 12 sequential file I/O operations through AI context | Context pressure increases with each operation |
| **Architecture** | 13 placeholder replacements done as mental string manipulation | Fundamentally unreliable for LLMs |
| **Process** | Verification only checks file existence and `{{` remnants, not content integrity | Corruption passes undetected |

### Solution

A Node.js script (`scripts/install-skills.js`) handles all file operations deterministically:

- **Template path resolution**: Uses `__dirname` relative to the script's own location — works for both GitHub installs and locally linked extensions. No JSON parsing needed.
- **Placeholder replacement**: `split(placeholder).join(value)` on a closed list of exactly 13 setup placeholders. No regex (avoids special character issues in build commands like `./gradlew`). Runtime placeholders (`{{capture_to}}`, `{{variable_name}}`) are untouched because they're not in the list.
- **Schema copying**: `fs.copyFileSync` — byte-perfect, zero corruption risk.
- **`{{app_package}}` formatting**: Deterministic rules — Android only, iOS only, both, or N/A.
- **Verification**: File existence + non-zero size + no setup-placeholder remnants in SKILL.md files.

The AI's role in Section 6.0 is now: run one command, check exit code, update state.

### Files Changed

| File | Change |
|------|--------|
| `scripts/install-skills.js` | **New** — 290 lines, deterministic skill installer |
| `commands/mobile-automator/setup.toml` | **Edit** — Section 6.0 rewritten (92 lines removed, 30 added) |
| `gemini-extension.json` | **Edit** — Version bump 0.8.0 → 0.8.1 |
| `CHANGELOG.md` | **Edit** — Added 0.8.1 entry |

### Test Plan

- [x] Script runs successfully against real templates with mock `setup_state.json`
- [x] All 13 setup placeholders replaced correctly (`{{project_name}}` → `TestApp`, etc.)
- [x] Runtime placeholders `{{capture_to}}` and `{{variable_name}}` preserved in executor SKILL.md
- [x] Schema files are byte-perfect copies (verified with `diff`)
- [x] Missing `setup_state.json` → exit code 1 with clear error message
- [x] Missing `knowledge` section → exit code 1 with clear error message
- [x] End-to-end: run `/mobile-automator:setup` in a test mobile project and verify skills install correctly on every run
