### PR TITLE
Enhance Setup Command: Auto-Detect Critical Paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.0] - 2026-03-28
+
+### ✨ Added
+
+- **Auto-Detect Business-Critical Paths** — Setup Section 5.0 now uses the `@codebase_investigator` subagent to automatically identify critical user paths from the codebase before asking the user.
+  - Analyzes navigation graphs, route definitions, screen/Activity/Fragment definitions, feature modules, and README documentation
+  - Presents detected paths for user confirmation (`yesno` prompt) instead of requiring manual input
+  - Falls back to manual text input if auto-detection finds nothing or the user rejects the detected paths
+  - Reduces setup friction — users confirm instead of typing
+
+---
+
 ## [0.8.1] - 2026-03-28
 
 ### 🐛 Fixed
@@ -604,4 +616,4 @@ Apache License 2.0
 
 ---
 
-**Mobile Automator 0.3.1** - Built with ❤️ for mobile QA engineers
+**Mobile Automator 0.9.0** - Built with ❤️ for mobile QA engineers

--- a/commands/mobile-automator/setup.toml
+++ b/commands/mobile-automator/setup.toml
@@ -374,6 +374,19 @@ CRITICAL: This setup process is entirely file-based. It does NOT require a conne
         - Compile a list of found indicator class/widget names.
         - If none found → set to `"common loading indicators (progress bars, spinners, shimmer effects)"`
 
+### 5.1.1 Auto-Detect Business-Critical Paths
+1.  **Announce Action:** "Analyzing your codebase to identify business-critical user paths..."
+2.  **Invoke `@codebase_investigator`** with the following prompt:
+
+    ```
+    @codebase_investigator Analyze this mobile app codebase to identify the business-critical user paths (the most important user-facing flows). Look at: (1) Navigation graphs, route definitions, and deep link handlers to find the main user flow destinations. (2) Screen, Activity, Fragment, ViewController, or page definitions to identify major app sections. (3) Feature module or package structure to understand the app's functional areas. (4) Patterns indicating key flows like authentication (login, signup, password reset), onboarding, checkout, payment, search, profile management, and content consumption. (5) README or documentation files describing key features. Return a concise comma-separated list of the critical user paths you identified (e.g., "onboarding, login, product search, checkout, payment"). If you cannot determine any critical paths with reasonable confidence, say "NONE_DETECTED".
+    ```
+
+3.  **Process the investigation result:**
+    -   Let the response from `@codebase_investigator` be `INVESTIGATION_RESULT`.
+    -   If `INVESTIGATION_RESULT` contains "NONE_DETECTED", is empty, or the invocation failed → set `detected_critical_paths` to `null`.
+    -   Otherwise → set `detected_critical_paths` to the comma-separated path list returned by the investigator. Clean up the list: trim whitespace, remove duplicates, and ensure it reads as a human-friendly comma-separated string (e.g., `"onboarding, login, checkout, payment"`).
+
 ### 5.2 Gather Missing Information and Confirm
 
 **CRITICAL: Consolidate data gathering using the `ask_user` tool.**
@@ -395,14 +408,30 @@ CRITICAL: This setup process is entirely file-based. It does NOT require a conne
     - Question: `Describe your app's business domain in one sentence.`
     - Placeholder: `e.g. food delivery marketplace`
 
-    **Question 4: Business-Critical Paths (type: `text`, ALWAYS ASK)**
-    - Header: `Critical Paths`
-    - Question: `What are the business-critical user paths in your app?`
-    - Placeholder: `e.g. onboarding, login, checkout`
+    **Question 4: Business-Critical Paths (CONDITIONAL based on Section 5.1.1 result)**
+
+    -   **If `detected_critical_paths` is NOT null** (paths were auto-detected):
+        -   Use type: `yesno`
+        -   Header: `Critical Paths`
+        -   Question: `I analyzed your codebase and identified these business-critical paths: [detected_critical_paths]. Are these correct?`
+
+    -   **If `detected_critical_paths` is null** (detection failed or returned nothing):
+        -   Use type: `text`
+        -   Header: `Critical Paths`
+        -   Question: `I couldn't auto-detect critical user paths from your codebase. What are the business-critical user paths in your app?`
+        -   Placeholder: `e.g. onboarding, login, checkout`
 
 2.  **Execute `ask_user`:** Call the tool with the constructed questions array.
     - Wait for the tool response in the same turn.
     - If the user indicated the auto-detected values were incorrect in Q1, follow up with another `ask_user` (type: `text`) asking them for the corrections before proceeding.
+    - **Handle Q4 response (Critical Paths):**
+        - If Q4 was `yesno` and user selected **Yes** → use `detected_critical_paths` as the final value for `business_critical_paths`.
+        - If Q4 was `yesno` and user selected **No** → follow up with an additional `ask_user` call (type: `text`):
+            - Header: `Critical Paths`
+            - Question: `Please provide the correct business-critical user paths for your app.`
+            - Placeholder: `e.g. onboarding, login, checkout`
+            - Wait for the response and use it as the final value for `business_critical_paths`.
+        - If Q4 was `text` (fallback case) → use the user's text response as `business_critical_paths`.
     
 3.  **After receiving all responses:**
     - Record their answers for use in skill generation.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.0] - 2026-03-28
+
+### ✨ Added
+
+- **Auto-Detect Business-Critical Paths** — Setup Section 5.0 now uses the `@codebase_investigator` subagent to automatically identify critical user paths from the codebase before asking the user.
+  - Analyzes navigation graphs, route definitions, screen/Activity/Fragment definitions, feature modules, and README documentation
+  - Presents detected paths for user confirmation (`yesno` prompt) instead of requiring manual input
+  - Falls back to manual text input if auto-detection finds nothing or the user rejects the detected paths
+  - Reduces setup friction — users confirm instead of typing
+
+---
+
+## [0.8.1] - 2026-03-28
+
+### 🐛 Fixed
+
+- **Deterministic Skill Installation** — Replaced the AI-mediated file copy/replace in setup Section 6.0 with a Node.js script (`scripts/install-skills.js`) that handles all template operations deterministically.
+  - Fixes silent file corruption (truncation, missing sections, garbled schemas) during skill installation
+  - Placeholder replacement now uses `split().join()` in Node.js instead of in-memory AI reproduction
+  - Schema files copied byte-perfect with `fs.copyFileSync` instead of AI read/write
+  - Runtime placeholders (`{{capture_to}}`, `{{variable_name}}`) in executor skill are now correctly preserved
+  - Added `scenario_schema_v2.json` to template verification (was previously missing)
+  - Verification now checks file existence, non-zero size, and setup-placeholder absence
+  - Setup Section 6.0 reduced from ~100 lines to ~30 lines
+
+---
+
 ## [0.8.0] - 2026-03-27
 
 ### 🗑️ Removed

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -205,10 +205,12 @@ This is where mobile-automator learns the deep details of your project:
 - Helps skills focus on business-critical flows
 
 **Business-Critical User Paths:**
-- You list the most important user flows to test
+- Setup uses the `@codebase_investigator` subagent to automatically analyze your codebase for critical user flows
+- It examines navigation graphs, screen definitions, feature modules, and documentation
+- If paths are detected, you'll see them listed for confirmation (yes/no)
+- If auto-detection fails, you're asked to type them manually (same as before)
 - Examples: "onboarding, login, product search, add-to-cart, checkout, payment"
 - Skills prioritize these paths in test generation
-- Setup asks: "Enter critical user flows (comma-separated):"
 
 **Example Section 5 Interaction:**
 ```
@@ -227,8 +229,10 @@ Corrections needed? (y/n): n
 Business domain (one sentence):
 E-commerce mobile shopping app with product catalog and checkout flow
 
-Critical user paths (comma-separated):
-onboarding, login, product-search, add-to-cart, checkout, payment
+Analyzing your codebase to identify business-critical user paths...
+I analyzed your codebase and identified these business-critical paths:
+  onboarding, login, product-search, add-to-cart, checkout, payment
+Are these correct? (y/n): y
 ```
 
 **Output:** All project knowledge stored in `mobile-automator/setup_state.json`.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Mobile QA automation with test generation and execution using mobile-mcp",
   "author": "Mohamed Shalan",
   "repository": "https://github.com/sh3lan93/mobile-automator",


### PR DESCRIPTION
## Summary

- Setup Section 5.0 now uses Gemini CLI's `@codebase_investigator` subagent to automatically identify business-critical user paths from the codebase, replacing the always-manual text prompt with a detect-then-confirm flow
- Version bumped to `0.9.0`; changelogs and documentation updated

## What changed

### `commands/mobile-automator/setup.toml`

**New Section 5.1.1** — Invokes `@codebase_investigator` before the `ask_user` batch to analyze:
1. Navigation graphs, route definitions, and deep link handlers
2. Screen/Activity/Fragment/ViewController definitions
3. Feature module and package structure
4. Common flow patterns (auth, onboarding, checkout, etc.)
5. README and documentation

**Modified Section 5.2 (Question 4)** — Changed from always-`text` to conditional:
- If paths detected: `yesno` prompt showing the detected paths for confirmation
- If detection failed: `text` prompt (original behavior, no degradation)

**Extended Q4 response handling:**
- User confirms -> detected paths used as-is
- User rejects -> follow-up `text` prompt for manual entry
- Fallback `text` -> user's response used directly

### `gemini-extension.json`
- Version `0.8.1` -> `0.9.0`

### `CHANGELOG.md` / `docs/changelog.md`
- Added `[0.9.0]` entry documenting the auto-detection feature
- Synced `docs/changelog.md` with root (was missing `[0.8.1]` entry)
- Fixed stale version in changelog footer (`0.3.1` -> `0.9.0`)

### `docs/guides/setup.md`
- Updated Section 5 "Business-Critical User Paths" description to reflect auto-detection flow
- Updated example interaction to show the confirm prompt instead of manual text entry

## Test plan

- [x] Run `/mobile-automator:setup` on a project with clear navigation/screen structure — verify `@codebase_investigator` detects paths and presents them for `yesno` confirmation
- [x] Confirm detected paths (select Yes) — verify they are stored in `setup_state.json` under `knowledge.business_critical_paths`
- [x] Reject detected paths (select No) — verify follow-up text prompt appears and manual input is stored correctly
- [x] Run setup on a project with no clear navigation (e.g., a library) — verify graceful fallback to the original text prompt
- [x] Verify interrupted setup still resumes correctly from Section 5.0
