### PR TITLE
feat(recorder): wire long-press / double-tap / swipe to GUI (slice #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ The `/mobile-automator:record` recorder feature is being built incrementally per
   - Lifecycle wiring in `tools/recorder/src/lifecycle.js` routes taps inside the keyboard region to the type buffer (with focused-field observation) instead of writing them as raw taps. Non-keyboard taps follow the existing element-resolver path unchanged.
   - GUI step list now renders `Type "<value>" into "<field_label>"` for `action: 'type'` steps (with a `data-action="type"` attribute on the row). The existing tap rendering is unchanged.
   - The `sensitive` flag is propagated end-to-end (Android `inputType=textPassword` / iOS `secureTextEntry` → field → buffer → emitted event). The caution UI / mask-on-display lands in slice [#30](https://github.com/sh3lan93/mobile-automator/issues/30).
+- **Gesture vocabulary surfaced in the GUI** — slice [#24](https://github.com/sh3lan93/mobile-automator/issues/24).
+  - GUI step list now renders `Long press "<target>"`, `Double tap "<target>"`, and `Swipe <direction>` for the corresponding gestures (with `data-action` attributes on each row for CSS targeting). The classifier already detected these in slice [#22](https://github.com/sh3lan93/mobile-automator/issues/22); this slice wires them through to the user-visible surface.
+  - Integration test `tests/integration/recorder/end-to-end.test.js` exercises the full v1 gesture vocabulary via a new `tests/fixtures/recorder/scripted-session-gestures.json` fixture, asserting the synthesized scenario JSON contains all four gesture step types (tap / long_press / double_tap / swipe) and validates against the v2.1 schema. The swipe step carries its direction in the schema's `value` field.
 
 ### 🔄 Changed
 
@@ -47,9 +50,8 @@ The `/mobile-automator:record` recorder feature is being built incrementally per
 ### 📝 Notes
 
 - **Experimental gate.** Everything above is reachable only when `MOBILE_AUTOMATOR_RECORDER=1` is set in the environment. With the gate off, behaviour is identical to v0.11.0.
-- **Gate-then-graduate convention.** This `[Unreleased]` block accumulates the recorder slices in flight. When the recorder is feature-complete and ungated, all slice entries collapse into a single coherent `[0.12.0]` note in a dedicated graduation PR. No version is bumped during the slice work.
-- **Still out of scope for slices [#22](https://github.com/sh3lan93/mobile-automator/issues/22) + [#35](https://github.com/sh3lan93/mobile-automator/issues/35)** — tracked by the rest of the slice ladder under [PRD #21](https://github.com/sh3lan93/mobile-automator/issues/21):
-  - [#24](https://github.com/sh3lan93/mobile-automator/issues/24) — long-press, double-tap, and swipe detection wired through to the GUI.
+- **Gate-then-graduate convention.** This `[Unreleased]` block accumulates the recorder slices in flight. Each slice bumps `gemini-extension.json` to `0.12.0-rc.N` (incrementing N) so the version-check CI gate passes against the existing `v0.11.0` tag without prematurely graduating the feature; the `vX.Y.Z` git-tag namespace is reserved for graduated releases. When the recorder is feature-complete and ungated, the rc series collapses into a single coherent `[0.12.0]` note in a dedicated graduation PR.
+- **Still out of scope for slices [#22](https://github.com/sh3lan93/mobile-automator/issues/22) + [#35](https://github.com/sh3lan93/mobile-automator/issues/35) + [#24](https://github.com/sh3lan93/mobile-automator/issues/24)** — tracked by the rest of the slice ladder under [PRD #21](https://github.com/sh3lan93/mobile-automator/issues/21):
   - [#25](https://github.com/sh3lan93/mobile-automator/issues/25) — iOS Simulator parity.
   - [#26](https://github.com/sh3lan93/mobile-automator/issues/26) — Android hardware keys via `adb getevent`.
   - [#27](https://github.com/sh3lan93/mobile-automator/issues/27) — Add Assertion modal + AI classification at Save (HITL).

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.12.0-rc.1",
+  "version": "0.12.0-rc.2",
   "description": "Mobile QA automation with test generation and execution using mobile-mcp",
   "author": "Mohamed Shalan",
   "repository": "https://github.com/sh3lan93/mobile-automator",

--- a/tests/fixtures/recorder/scripted-session-gestures.json
+++ b/tests/fixtures/recorder/scripted-session-gestures.json
@@ -1,0 +1,45 @@
+{
+  "duration_ms": 4000,
+  "hierarchy_snapshots": [
+    {
+      "t": 0,
+      "elements": [
+        { "type": "android.widget.Button", "bounds": [100, 200, 980, 400], "text": "Item Card" }
+      ]
+    },
+    {
+      "t": 1000,
+      "elements": [
+        { "type": "android.widget.ImageButton", "bounds": [800, 100, 980, 250], "text": "Settings Icon" }
+      ]
+    },
+    {
+      "t": 2000,
+      "elements": [
+        { "type": "android.widget.Button", "bounds": [200, 600, 400, 800], "text": "Like Button" }
+      ]
+    },
+    {
+      "t": 3000,
+      "elements": [
+        { "type": "androidx.recyclerview.widget.RecyclerView", "bounds": [0, 800, 1080, 1400], "text": "Feed" }
+      ]
+    }
+  ],
+  "tap_events": [
+    { "kind": "down", "t": 100, "x": 540, "y": 300 },
+    { "kind": "up", "t": 200, "x": 540, "y": 300 },
+
+    { "kind": "down", "t": 1100, "x": 890, "y": 175 },
+    { "kind": "up", "t": 1700, "x": 890, "y": 175 },
+
+    { "kind": "down", "t": 2100, "x": 300, "y": 700 },
+    { "kind": "up", "t": 2150, "x": 300, "y": 700 },
+    { "kind": "down", "t": 2300, "x": 300, "y": 700 },
+    { "kind": "up", "t": 2350, "x": 300, "y": 700 },
+
+    { "kind": "down", "t": 3100, "x": 540, "y": 1300 },
+    { "kind": "move", "t": 3200, "x": 540, "y": 1150 },
+    { "kind": "up", "t": 3300, "x": 540, "y": 1000 }
+  ]
+}

--- a/tests/integration/recorder/end-to-end.test.js
+++ b/tests/integration/recorder/end-to-end.test.js
@@ -151,18 +151,49 @@ function validateScenarioAgainstSchema(scenario, schema) {
 function synthesizeScenario(projectRoot, scenarioId) {
   const bundleRoot = path.join(projectRoot, 'mobile-automator', '.recorder', scenarioId);
   const eventsRaw = fs.readFileSync(path.join(bundleRoot, 'events.jsonl'), 'utf8');
+  const SUPPORTED_KINDS = new Set(['tap', 'long_press', 'double_tap', 'swipe']);
   const events = eventsRaw
     .split('\n')
     .filter((l) => l.length > 0)
     .map((l) => JSON.parse(l))
-    .filter((e) => e.kind === 'tap'); // #22 tap-only
+    .filter((e) => SUPPORTED_KINDS.has(e.kind));
 
-  const steps = events.map((ev, i) => ({
-    id: ev.step_id || `tap_step_${i + 1}`,
-    action: 'tap',
-    description: `Tap ${ev.target || 'element'}.`,
-    target: ev.target || 'element',
-  }));
+  const steps = events.map((ev, i) => {
+    const target = ev.target || 'element';
+    if (ev.kind === 'long_press') {
+      return {
+        id: ev.step_id || `long_press_step_${i + 1}`,
+        action: 'long_press',
+        description: `Long press ${target}.`,
+        target,
+      };
+    }
+    if (ev.kind === 'double_tap') {
+      return {
+        id: ev.step_id || `double_tap_step_${i + 1}`,
+        action: 'double_tap',
+        description: `Double tap ${target}.`,
+        target,
+      };
+    }
+    if (ev.kind === 'swipe') {
+      const direction = ev.direction || 'up';
+      return {
+        id: ev.step_id || `swipe_step_${i + 1}`,
+        action: 'swipe',
+        description: `Swipe ${direction}.`,
+        target,
+        value: direction,
+      };
+    }
+    // Default: tap.
+    return {
+      id: ev.step_id || `tap_step_${i + 1}`,
+      action: 'tap',
+      description: `Tap ${target}.`,
+      target,
+    };
+  });
 
   const scenario = {
     $schema_version: '2.1',
@@ -289,5 +320,92 @@ describe('recorder end-to-end (record → save → cleanup)', () => {
   test('public scenarios/ directory holds exactly the expected scenario file', () => {
     const entries = fs.readdirSync(scenariosDir);
     expect(entries).toContain(`${scenarioId}.json`);
+  });
+});
+
+// Slice #24: gesture variety. Drives the same lifecycle + synthesis pipeline
+// against a fixture that exercises one of each v1 gesture (tap, long_press,
+// double_tap, swipe) and pins the invariant that all four flow through to a
+// schema-valid scenario JSON. This sits as a sibling describe to preserve
+// the existing tap-only block as a focused regression guard.
+
+const GESTURES_FIXTURE_PATH = path.join(
+  REPO_ROOT,
+  'tests',
+  'fixtures',
+  'recorder',
+  'scripted-session-gestures.json'
+);
+
+describe('recorder end-to-end (gesture variety: long-press / double-tap / swipe)', () => {
+  let tmp;
+  let scenarioId;
+  let scenarioPath;
+  let bundleRoot;
+  let scenario;
+
+  beforeAll(async () => {
+    scenarioId = 'gesture_variety';
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rec-e2e-gestures-'));
+
+    fs.mkdirSync(path.join(tmp, 'mobile-automator'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'mobile-automator', 'config.json'),
+      JSON.stringify({ mode: 'platform-aware', project_name: 'demo' })
+    );
+
+    const script = JSON.parse(fs.readFileSync(GESTURES_FIXTURE_PATH, 'utf8'));
+    await runScriptedSession({ projectRoot: tmp, scenarioId, script });
+
+    bundleRoot = path.join(tmp, 'mobile-automator', '.recorder', scenarioId);
+    expect(fs.existsSync(bundleRoot)).toBe(true);
+
+    const out = synthesizeScenario(tmp, scenarioId);
+    scenarioPath = out.scenarioPath;
+    scenario = JSON.parse(fs.readFileSync(scenarioPath, 'utf8'));
+
+    handleSaveMessage({ store: out.store, onDone: () => {} });
+  });
+
+  afterAll(() => {
+    if (tmp && fs.existsSync(tmp)) fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('scenario JSON validates against the v2.1 schema', () => {
+    const schema = JSON.parse(fs.readFileSync(SCENARIO_SCHEMA_PATH, 'utf8'));
+    const errors = validateScenarioAgainstSchema(scenario, schema);
+    if (errors.length > 0) {
+      // eslint-disable-next-line no-console
+      console.error('Schema errors:', errors);
+    }
+    expect(errors).toEqual([]);
+  });
+
+  test('scenario contains exactly one step per gesture kind', () => {
+    const actions = scenario.steps.map((s) => s.action);
+    expect(new Set(actions)).toEqual(new Set(['tap', 'long_press', 'double_tap', 'swipe']));
+    expect(actions.length).toBe(4);
+  });
+
+  test('swipe step carries direction in the value field', () => {
+    const swipe = scenario.steps.find((s) => s.action === 'swipe');
+    expect(swipe).toBeDefined();
+    expect(swipe.value).toBe('up');
+  });
+
+  test('each step targets the element under its gesture coords', () => {
+    const byAction = Object.fromEntries(scenario.steps.map((s) => [s.action, s]));
+    expect(byAction.tap.target).toBe('Item Card');
+    expect(byAction.long_press.target).toBe('Settings Icon');
+    expect(byAction.double_tap.target).toBe('Like Button');
+    expect(byAction.swipe.target).toBe('Feed');
+  });
+
+  test('step ids encode gesture kind and target', () => {
+    const ids = scenario.steps.map((s) => s.id);
+    expect(ids).toContain('tap_item_card');
+    expect(ids).toContain('long_press_settings_icon');
+    expect(ids).toContain('double_tap_like_button');
+    expect(ids).toContain('swipe_feed');
   });
 });

--- a/tests/unit/recorder/web-step-list.test.js
+++ b/tests/unit/recorder/web-step-list.test.js
@@ -138,6 +138,72 @@ describe('recorder GUI: step-list rendering', () => {
       expect(li.textContent).toContain('"user@example.com"');
       expect(li.textContent).not.toMatch(/•/);
     });
+
+    // Slice #24: long-press / double-tap / swipe rendering. The classifier
+    // already detects all three (slice #22); these tests pin the user-visible
+    // surface — the human-readable labels the issue spec calls for.
+
+    test('renders a long_press step as `Long press "<target>"`', () => {
+      const li = app.renderStepRow({
+        id: 'long_press_settings_icon',
+        index: 7,
+        action: 'long_press',
+        target: 'Settings Icon',
+      });
+
+      expect(li).toBeInstanceOf(window.HTMLLIElement);
+      expect(li.classList.contains('step-row')).toBe(true);
+      expect(li.getAttribute('data-step-id')).toBe('long_press_settings_icon');
+      expect(li.getAttribute('data-action')).toBe('long_press');
+      expect(li.textContent).toMatch(
+        /^\s*\d+\.\s*Long press\s*"Settings Icon"\s*$/,
+      );
+      const action = li.querySelector('.step-action');
+      const target = li.querySelector('.step-target');
+      expect(action).not.toBeNull();
+      expect(action.textContent).toBe('Long press');
+      expect(target).not.toBeNull();
+      expect(target.textContent).toBe('"Settings Icon"');
+    });
+
+    test('renders a double_tap step as `Double tap "<target>"`', () => {
+      const li = app.renderStepRow({
+        id: 'double_tap_like_button',
+        index: 8,
+        action: 'double_tap',
+        target: 'Like Button',
+      });
+
+      expect(li.getAttribute('data-action')).toBe('double_tap');
+      expect(li.textContent).toMatch(
+        /^\s*\d+\.\s*Double tap\s*"Like Button"\s*$/,
+      );
+      const action = li.querySelector('.step-action');
+      const target = li.querySelector('.step-target');
+      expect(action.textContent).toBe('Double tap');
+      expect(target.textContent).toBe('"Like Button"');
+    });
+
+    test('renders a swipe step as `Swipe <direction>` with no target span', () => {
+      const li = app.renderStepRow({
+        id: 'swipe_feed',
+        index: 9,
+        action: 'swipe',
+        direction: 'up',
+        target: 'Feed',
+      });
+
+      expect(li.getAttribute('data-action')).toBe('swipe');
+      expect(li.textContent).toMatch(/^\s*\d+\.\s*Swipe\s*up\s*$/);
+      const action = li.querySelector('.step-action');
+      expect(action.textContent).toBe('Swipe');
+      // Per the issue spec the swipe label is direction-only: no target span.
+      expect(li.querySelector('.step-target')).toBeNull();
+      // The direction text lives in its own span for CSS targeting.
+      const direction = li.querySelector('.step-direction');
+      expect(direction).not.toBeNull();
+      expect(direction.textContent).toBe('up');
+    });
   });
 
   describe('appendStep', () => {

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -24,6 +24,48 @@
     num.className = 'step-num';
     num.textContent = String(step.index) + '.';
 
+    // Slice #24: long-press / double-tap render as `<verb> "<target>"`. The
+    // target comes in unquoted; the renderer wraps with literal `"` chars to
+    // match the issue's user-visible spec (mirrors the type branch's quoting
+    // contract, not the legacy tap branch's caller-pre-quotes expectation).
+    if (step && (step.action === 'long_press' || step.action === 'double_tap')) {
+      const verb = step.action === 'long_press' ? 'Long press' : 'Double tap';
+      li.setAttribute('data-action', step.action);
+
+      const action = doc.createElement('span');
+      action.className = 'step-action';
+      action.textContent = verb;
+
+      const target = doc.createElement('span');
+      target.className = 'step-target';
+      target.textContent = '"' + (step.target == null ? '' : String(step.target)) + '"';
+
+      li.appendChild(num);
+      li.appendChild(action);
+      li.appendChild(target);
+      return li;
+    }
+
+    // Slice #24: swipe renders as `Swipe <direction>` — no target span. The
+    // direction lives in its own span so CSS can style it independently of the
+    // verb.
+    if (step && step.action === 'swipe') {
+      li.setAttribute('data-action', 'swipe');
+
+      const action = doc.createElement('span');
+      action.className = 'step-action';
+      action.textContent = 'Swipe';
+
+      const direction = doc.createElement('span');
+      direction.className = 'step-direction';
+      direction.textContent = step.direction == null ? '' : String(step.direction);
+
+      li.appendChild(num);
+      li.appendChild(action);
+      li.appendChild(direction);
+      return li;
+    }
+
     if (step && step.action === 'type') {
       // Render: <num>. Type "<value>" into "<field_label>"
       // Slice #35 review fix: when step.sensitive === true the value is


### PR DESCRIPTION
## Summary

Closes the wire-through gap for slice [#24](https://github.com/sh3lan93/mobile-automator/issues/24) of the recorder PRD ([#21](https://github.com/sh3lan93/mobile-automator/issues/21)). The gesture *classifier* itself was already implemented in slice #22 / PR #36 (the CHANGELOG `[Unreleased]` block at L23 explicitly notes "only \`tap\` is surfaced in the GUI for this slice"). This PR is the user-visible surface change:

- `tools/recorder/web/app.js` — three new `renderStepRow` branches:
  - `long_press` → `Long press "<target>"`
  - `double_tap` → `Double tap "<target>"`
  - `swipe` → `Swipe <direction>` (no target span — direction is the semantic carrier)
- New fixture `tests/fixtures/recorder/scripted-session-gestures.json` exercising one of each v1 gesture.
- Sibling `describe` block in `tests/integration/recorder/end-to-end.test.js` (existing tap-only block stays as a regression guard) that drives the full pipeline and pins five invariants: schema validity, all four action kinds present, swipe direction in `value`, target resolution per gesture coords, step-id encoding.
- Mock-AI synthesizer in the integration test extended to map all four gesture kinds (with the schema-required `description` field for each).

## Out of scope (deliberate)

- **Classifier code** — already complete in PR #36; the issue's first AC bullet is satisfied. Existing 6 unit tests at `tests/unit/recorder/gesture-classifier.test.js` already cover the AC's required cases (verified untouched).
- **WebSocket `step-added` broadcast producer** — there is no producer in production code today (only the GUI consumer at `app.js:109` and the `wsCtx.broadcast` primitive). The render branches added here are exercised by unit tests and indirectly via the integration synthesis path. Wiring up the live producer is a future slice.

## Conventions

- Bumped `gemini-extension.json` 0.12.0-rc.1 → 0.12.0-rc.2 per the gate-then-graduate ladder.
- Corrected the stale "no version is bumped during slice work" note in CHANGELOG (PR #36 / PR #37 both bumped per CLAUDE.md guidance — note now matches reality).

## Test plan

- [x] `npx jest tests/unit/recorder/web-step-list.test.js` — 14/14 green (3 new gesture render tests + 11 existing).
- [x] `npx jest tests/unit/recorder/gesture-classifier.test.js` — 6/6 green (regression guard for the existing classifier behaviour).
- [x] `npx jest tests/integration/recorder/end-to-end.test.js` — 11/11 green (existing tap-only block + 5 new gesture-variety tests).
- [x] `npx jest` (full suite) — 231/231 across 40 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)