### PR TITLE
docs(claude): mandatory sample-app milestone workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,18 @@ PRD [#21](https://github.com/sh3lan93/mobile-automator/issues/21). The entire re
 - Agnostic-mode recorder is **skipped** during install; lands in slice [#29](https://github.com/sh3lan93/mobile-automator/issues/29).
 - The recorder skill synthesises scenario JSON from sidecar artifacts under `mobile-automator/.recorder/<session>/`. It defers to the generator skill for scenario shape — generator stays single source of truth.
 
+## Sample-app milestone workflow (mandatory for any agent)
+
+PRD [#44](https://github.com/sh3lan93/mobile-automator/issues/44) · milestone `sample-app` · slices #45–#49. **Any agent picking up a `sample-app`-milestone issue MUST follow this workflow in order — it is not optional:**
+
+1. **Load full context first.** Fetch the slice issue **and** PRD #44 together (`gh issue view <slice>` + `gh issue view 44`) before doing anything. Slice bodies are deliberately thin; the PRD holds the locked decisions, the slice ladder, and cross-slice constraints. Never act on a slice issue alone.
+2. **Isolate the workspace.** Before any edit, create a dedicated worktree on a new branch named `sample-app/<issue-number>-<short-slug>` (mirrors the recorder branch convention). Do not work directly in an existing checkout or on a shared branch.
+3. **Plan before code.** Produce a written implementation plan (file structure, deps, screen/widget tree, CI changes, test list) and surface it for explicit user approval. No implementation before the user confirms the plan.
+4. **Implement via subagents.** After plan approval, dispatch the implementation through subagents so the main agent's context window stays unbloated. The main agent orchestrates and reviews; it does not hand-write the bulk of the slice itself.
+5. **Open a draft PR.** When implementation is complete, open a GitHub PR in **draft** status with a full description (what/why, test plan). Put `Closes #<slice-issue>` on its own line with no intervening words; reference the PRD as `Refs #44` (never `Closes #44` — the PRD closes only when slice 5 merges).
+
+This workflow lives here (not in per-slice issue bodies) so it applies uniformly and survives issue edits.
+
 ## Schemas
 
 - Scenario: `templates/mobile-automator-generator/references/scenario_schema.json` (v2.1, 14 actions, 27 assertions, named string IDs, root-level `variables`/`preconditions`).


### PR DESCRIPTION
## Summary

Adds a **"Sample-app milestone workflow"** section to `CLAUDE.md` that any agent picking up a `sample-app`-milestone issue (#45–#49, PRD #44) **must** follow:

1. Fetch the slice issue **and** PRD #44 together for full context (slice bodies are intentionally thin).
2. Isolate work in a new worktree branch `sample-app/<issue-number>-<short-slug>`.
3. Produce a written implementation plan and get explicit user approval before coding.
4. Implement via subagents so the orchestrating agent's context window stays unbloated.
5. Open a **draft** PR with a full description, `Closes #<slice-issue>` on its own line, and `Refs #44` (never `Closes #44` — PRD closes only when slice 5 merges).

## Why standalone / why straight to main

Rule 2 has agents branch **off `main`** to start a slice. If this workflow were bundled into the slice-1 PR, it would only reach `main` *after* slice 1 is done — invisible to exactly the agents it governs. Landing it standalone on `main` first makes the rule effective before any slice work begins.

Docs-only, no extension paths touched → does not trip the `version-check.yml` version-bump gate; `CLAUDE.md` is not Vale-linted.

## Test plan

- [x] Confirm the new section renders correctly in `CLAUDE.md` on GitHub.
- [x] Confirm CI is green (no version-bump gate triggered; lint unaffected).
- [x] Mark PR ready and merge so the rule is live on `main` before slice work starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)