### PR TITLE
feat(recorder): edit affordances — rename/delete/edit-value/edit-assertion-text (slice #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The `/mobile-automator:record` recorder feature is being built incrementally per [PRD #21](https://github.com/sh3lan93/mobile-automator/issues/21). Slices land here under `[Unreleased]` and are gated behind `MOBILE_AUTOMATOR_RECORDER=1` until the v0.12.0 graduation cut. Entries collapse into a single coherent v0.12.0 note when the feature graduates.
 
+### Recorder Slice #7 — Edit affordances: rename / delete / edit-value / edit-assertion-text (#28)
+
+- GUI: per-row "⋯" menu with type-filtered actions (Rename, Delete, Edit value on `type` steps, Edit text on assertion rows). No reorder / insert / type-change is ever surfaced.
+- GUI: inline editors (Enter/blur commit, Escape cancel); delete prompt — plain confirm with no anchored assertions, 3-option (re-anchor default / cascade / cancel) when assertions are anchored.
+- GUI: display-only mutation on server confirmation; `data-step-id` never rewritten client-side; `data-anchor-step-id` added to assertion rows.
+- Sidecar: `rename-step` / `delete-step` / `edit-value` / `edit-assertion-text` WS handlers append a canonical `edits.jsonl` record (`{op, target_step_id|target_assertion_id, …, ts}`); boundary validation rejects empty text and unknown policy.
+- Reconcile: new pure `apply-edits.js` engine — chronological replay deriving the effective event/assertion lists; the executable spec the aware recorder SKILL.md mirrors.
+- Skill (aware): step 2 rewritten for the 4 ops with cascade/reanchor (first-step ⇒ next-surviving fallback) and unparseable-line skip; steps 5 & 8 note rename ⇒ new slug and edit-text-before-classify; integer-position identity purged in favour of the `step_id` slug.
+- Tests: `apply-edits`, `session-handlers-edits`, `web-edit-affordances` unit suites + `edit-affordances-flow` integration; stale artifacts edit fixture aligned to the canonical shape.
+
 ### Recorder Slice #6 — Add Assertion modal + AI classification at Save (#27)
 
 - GUI: **Add Assertion** button in the recorder header (disabled until first step is captured).

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.12.0-rc.5",
+  "version": "0.12.0-rc.6",
   "description": "Mobile QA automation with test generation and execution using mobile-mcp",
   "author": "Mohamed Shalan",
   "repository": "https://github.com/sh3lan93/mobile-automator",

--- a/templates/mobile-automator-recorder/aware/SKILL.md
+++ b/templates/mobile-automator-recorder/aware/SKILL.md
@@ -14,7 +14,7 @@ You inherit the rules of the generator skill by reference. **Do not re-decide as
 
 ## Persona: Mobile QA Synthesizer
 - **Faithful to the recording:** Translate exactly what the sidecar captured — no extra steps, no inferred user intent beyond what events express.
-- **Edit-aware:** The user may have renamed steps, deleted events, reordered, or annotated assertions during the recording session. Apply edits in chronological order before reasoning about the effective event list.
+- **Edit-aware:** During recording the user may have renamed a step, deleted a step, edited a typed value, or edited an assertion's text. Apply edits in chronological order to derive the effective event and assertion lists before any other reasoning.
 - **Schema-driven:** Every emitted scenario must validate against the v2.0 schema. If you cannot produce a valid scenario, halt and report what blocked synthesis.
 
 ## Tech Stack & Environment
@@ -46,7 +46,7 @@ mobile-automator/.recorder/<scenario_id>/
 **Read order:**
 1. `metadata.json` first — gives you `scenario_id`, `app_version`, `environment`, `started_at`, `app_package`, recording mode.
 2. `events.jsonl` — primary timeline; each line is `{seq, timestamp_ms, kind, target_hint, value?, screenshot_ref, hierarchy_ref, ...}`.
-3. `edits.jsonl` — user mutations: `{seq, timestamp_ms, op: "rename" | "delete" | "reorder" | "annotate", target_seq, payload}`.
+3. `edits.jsonl` — append-only user edits, one JSON object per line. Canonical record: `{op, target_step_id | target_assertion_id, op-specific fields, ts}` where `op` is one of `rename | delete | edit-value | edit-assertion-text` and `ts` is an ISO-8601 timestamp. Apply edits in `ts` chronological order.
 4. `assertions.json` — array of natural-language assertions added by the user during recording. Each entry has `{ id, nl_text, screenshot, anchor_step_id, captured_at }`. The AI classifies the NL text in step 8. Handle the empty case gracefully.
 
 If any required file is **missing or unreadable**, HALT and report which file is missing. Do not attempt to synthesize a partial scenario.
@@ -57,28 +57,30 @@ Apply these steps in order. Most rules referenced here are defined in the genera
 
 1. **Load metadata.** Read `metadata.json` and use it to populate the scenario's top-level metadata block (`app_version`, `environment`). Do NOT include `device_model`, `api_level`, or `timestamp` in scenario metadata — those belong in result reports, not scenarios.
 
-2. **Reconcile edits.** Read `events.jsonl` and `edits.jsonl` into memory. Apply edits in `timestamp_ms` order to derive the **effective event list**:
-   - `rename` → update the target event's `display_name`.
-   - `delete` → remove the target event from the effective list.
-   - `reorder` → move the target event to its new position.
-   - `annotate` → attach the annotation payload to the target event for later use in `expected_state`.
+2. **Reconcile edits.** Read `events.jsonl`, `assertions.json`, and `edits.jsonl` into memory. Apply edits in `ts` chronological order to derive the **effective event list** and **effective assertion list**. Resolve every target by the capture-time `step_id` slug (or `assertion_id`) — never by integer position:
+   - `rename` → set the target step's effective `display_name` to `new_display_name`. The `step_id` itself is re-derived in step 5 from this new display name.
+   - `delete` → remove the target step from the effective event list, then resolve its anchored assertions by `assertion_policy`: `none` → nothing; `cascade` → those assertions are not emitted; `reanchor` → re-point them to the **previous surviving step**; if the deleted step was the first (no previous surviving step), re-point to the **next surviving step**; if no step survives at all, drop those assertions and report it.
+   - `edit-value` → set the target `type` step's effective typed value to `new_value`.
+   - `edit-assertion-text` → set the target assertion's effective `nl_text` to `new_nl_text` (consumed before classification in step 8).
+   - Any unrecognized `op` → ignore it and report it (forward-compatible with future slices).
+   - Replay semantics: a later edit on the same target supersedes an earlier one; an edit targeting an already-deleted or already-cascaded entity is a silent no-op; re-anchor and rename resolve against the effective list at that edit's position in the chronological replay, not the original capture. If a line in `edits.jsonl` is not valid JSON (e.g. a partial trailing line from an interrupted write), skip that line and report it — do not halt synthesis for one unparseable edit.
 
 3. **Resolve element identity.** For each effective event, locate the hierarchy snapshot in `hierarchy/` whose padded-millis filename is the **most recent** at or before the event's `timestamp_ms`. Use `target_hint` from the event plus this snapshot to confirm the element. If the event's `display_name` is missing or marked `is_unnamed: true`, use AI vision over the event's screenshot (referenced by `screenshot_ref`) to suggest a concise descriptive name (e.g., "Login button", "Email input"). Never invent a target that has no evidence in the hierarchy snapshot.
 
 4. **Map events to schema actions.** For each effective event, use the **Step Translation Guide** in `.gemini/skills/mobile-automator-generator/SKILL.md` to map the event `kind` to a schema action type (`tap`, `type`, `swipe`, `press_button`, `launch_app`, `open_url`, `long_press`, `double_tap`, `scroll_to_element`, `clear_app_data`, etc.). Do not invent action types — only emit values that appear in the generator skill's translation guide.
 
-5. **Generate step IDs.** For each step, derive a snake_case `step_id` from `<action>_<short_target>` (e.g., `tap_login`, `type_email`, `swipe_carousel_left`). Ensure IDs are unique within the scenario; if a collision occurs, suffix with `_2`, `_3`, etc.
+5. **Generate step IDs.** For each effective step, derive a snake_case `step_id` from `<action>_<short_target>` (e.g., `tap_login`, `type_email`, `swipe_carousel_left`). A renamed step's effective `display_name` feeds this derivation, so a rename naturally produces a new `step_id` at Save. Ensure IDs are unique within the scenario; if a collision occurs (including two capture-time same-named steps), suffix with `_2`, `_3`, etc.
 
 6. **Insert loading waits.** Between any two consecutive effective events, scan the hierarchy snapshots that fall in the gap. If snapshots in that interval contain elements whose class or text matches `{{loading_indicators}}` continuously for ≥300ms, insert a `wait_for_loading_complete` step before the second event. This mirrors the generator skill's loading-wait policy — see Section "Detecting and Encoding Patterns" in the generator skill for the canonical rule.
 
 7. **Apply auto-assertion rule.** After every state-changing action (`tap`, `type` on submit-style inputs, `press_button`), automatically emit a `visual_state: "loaded"` or `element_exists` assertion for the resulting screen, marked `[auto-generated]` in its `description`. The full rule lives in the generator skill at Section "Auto-Assertion Rule" — do not re-derive it here.
 
-8. **Classify user assertions.** Each entry in `assertions.json` has shape `{ id, nl_text, screenshot, anchor_step_id, captured_at }` — the user provided natural language, not a pre-typed assertion. For each entry:
+8. **Classify user assertions.** Each entry in `assertions.json` has shape `{ id, nl_text, screenshot, anchor_step_id, captured_at }`. First apply any `edit-assertion-text` edit so `nl_text` reflects the user's correction, then classify — the user provided natural language, not a pre-typed assertion. For each entry:
    1. Apply the generator skill's **Two-Pass Semantic Intent Model** (see cross-reference below). Pass 1 always classifies as Assertion here — the recorder GUI already separated actions from assertions. Run Pass 2 to select the best-fit type from the **Assertion Type Decision Table** (see cross-reference).
    2. Emit the typed assertion with the correct fields for the selected type.
    3. **For visual assertion types** (`screenshot_match`, `visual_state`, `element_fully_visible`, `color_style`) — populate `reference_screenshot` with the path `mobile-automator/screenshots/<scenario_id>/assert_<id>.png`. This is the screenshot the executor will use for image comparison at replay time.
    4. **For non-visual types** — do NOT include `reference_screenshot`. The PNG is preserved in the screenshots directory as evidence but is not referenced in the assertion.
-   5. Anchor the assertion via `after_step: <anchor_step_id>` from the entry. Validate that `anchor_step_id` matches a step ID in the effective event list; if it does not (e.g., the anchored step was deleted by a user edit), drop the assertion and report it.
+   5. Resolve the assertion's effective `anchor_step_id` through edit reconciliation (honoring `reanchor` moves and the rename ⇒ new-slug derivation), then anchor it via `after_step: <resolved_step_id>`. If after reconciliation the anchor still matches no step in the effective event list (e.g., it was cascade-deleted or genuinely orphaned), drop the assertion and report it.
 
    If `assertions.json` is empty, emit `"assertions": []` — this is a valid scenario.
 

--- a/tests/integration/recorder/edit-affordances-flow.test.js
+++ b/tests/integration/recorder/edit-affordances-flow.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { ArtifactsStore } = require('../../../tools/recorder/src/artifacts');
+const {
+  handleRenameStep, handleDeleteStep, handleEditValue, handleEditAssertionText,
+} = require('../../../tools/recorder/src/session-handlers');
+const { applyEdits } = require('../../../tools/recorder/src/reconcile/apply-edits');
+
+describe('edit affordances end-to-end (sidecar bundle → reconcile)', () => {
+  let projectRoot;
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'rec-e2e-'));
+    fs.mkdirSync(path.join(projectRoot, 'mobile-automator'));
+  });
+  afterEach(() => fs.rmSync(projectRoot, { recursive: true, force: true }));
+
+  test('handlers persist a canonical edits.jsonl the AI reconcile engine consumes', () => {
+    const store = new ArtifactsStore({ projectRoot, scenarioId: 'login_flow' });
+    store.init({ mode: 'platform-aware', scenario_id: 'login_flow' });
+
+    store.appendEvent({ step_id: 'type_email', kind: 'type', value: 'usr@acme', field_label: 'Email' });
+    store.appendEvent({ step_id: 'tap_skip', kind: 'tap', target: 'Skip' });
+    store.appendEvent({ step_id: 'tap_submit', kind: 'tap', target: 'Submit' });
+    store.appendAssertion({ id: 'a1', anchor_step_id: 'tap_submit', nl_text: 'dshbd shown', screenshot: 'screenshots/assert_a1.png', captured_at: '2026-05-16T09:00:00.000Z' });
+
+    const broadcast = () => {};
+    handleEditValue({ store, broadcast, msg: { step_id: 'type_email', new_value: 'user@acme.io' } });
+    handleRenameStep({ store, broadcast, msg: { step_id: 'tap_submit', new_display_name: 'Tap the Submit button' } });
+    handleEditAssertionText({ store, broadcast, msg: { assertion_id: 'a1', new_nl_text: 'Dashboard is shown' } });
+    handleDeleteStep({ store, broadcast, msg: { step_id: 'tap_skip', assertion_policy: 'none' } });
+
+    const root = path.join(projectRoot, 'mobile-automator/.recorder/login_flow');
+    const events = fs.readFileSync(path.join(root, 'events.jsonl'), 'utf8').trim().split('\n').map(JSON.parse);
+    const edits = fs.readFileSync(path.join(root, 'edits.jsonl'), 'utf8').trim().split('\n').map(JSON.parse);
+    const assertions = JSON.parse(fs.readFileSync(path.join(root, 'assertions.json'), 'utf8'));
+
+    expect(edits.map((e) => e.op)).toEqual(['edit-value', 'rename', 'edit-assertion-text', 'delete']);
+    edits.forEach((e) => expect(typeof e.ts).toBe('string'));
+
+    const eff = applyEdits({ events, assertions, edits });
+    expect(eff.steps.map((s) => s.step_id)).toEqual(['type_email', 'tap_submit']);
+    expect(eff.steps.find((s) => s.step_id === 'type_email').value).toBe('user@acme.io');
+    expect(eff.steps.find((s) => s.step_id === 'tap_submit').display_name).toBe('Tap the Submit button');
+    expect(eff.assertions[0].nl_text).toBe('Dashboard is shown');
+    expect(eff.assertions[0].anchor_step_id).toBe('tap_submit');
+  });
+
+  test('delete + reanchor end-to-end moves the assertion to the previous surviving step', () => {
+    const store = new ArtifactsStore({ projectRoot, scenarioId: 's' });
+    store.init({ mode: 'platform-aware', scenario_id: 's' });
+    store.appendEvent({ step_id: 'tap_a', kind: 'tap', target: 'A' });
+    store.appendEvent({ step_id: 'tap_b', kind: 'tap', target: 'B' });
+    store.appendEvent({ step_id: 'tap_c', kind: 'tap', target: 'C' });
+    store.appendAssertion({ id: 'a1', anchor_step_id: 'tap_b', nl_text: 'x', screenshot: 'screenshots/assert_a1.png', captured_at: '2026-05-16T09:00:00.000Z' });
+
+    handleDeleteStep({ store, broadcast: () => {}, msg: { step_id: 'tap_b', assertion_policy: 'reanchor' } });
+
+    const root = path.join(projectRoot, 'mobile-automator/.recorder/s');
+    const events = fs.readFileSync(path.join(root, 'events.jsonl'), 'utf8').trim().split('\n').map(JSON.parse);
+    const edits = fs.readFileSync(path.join(root, 'edits.jsonl'), 'utf8').trim().split('\n').map(JSON.parse);
+    const assertions = JSON.parse(fs.readFileSync(path.join(root, 'assertions.json'), 'utf8'));
+    const eff = applyEdits({ events, assertions, edits });
+
+    expect(eff.steps.map((s) => s.step_id)).toEqual(['tap_a', 'tap_c']);
+    expect(eff.assertions[0].anchor_step_id).toBe('tap_a');
+  });
+});

--- a/tests/unit/recorder/apply-edits.test.js
+++ b/tests/unit/recorder/apply-edits.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { applyEdits } = require('../../../tools/recorder/src/reconcile/apply-edits');
+
+const ev = (step_id, extra = {}) => ({ step_id, kind: 'tap', ...extra });
+const as = (id, anchor, nl = 'x') => ({ id, anchor_step_id: anchor, nl_text: nl });
+
+describe('applyEdits', () => {
+  test('rename sets effective display_name, keeps step_id key', () => {
+    const r = applyEdits({
+      events: [ev('tap_login')],
+      assertions: [],
+      edits: [{ op: 'rename', target_step_id: 'tap_login', new_display_name: 'Tap Login button', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.steps[0].step_id).toBe('tap_login');
+    expect(r.steps[0].display_name).toBe('Tap Login button');
+  });
+
+  test('edit-value sets effective value on the type step', () => {
+    const r = applyEdits({
+      events: [ev('type_email', { kind: 'type', value: 'usr@acme' })],
+      assertions: [],
+      edits: [{ op: 'edit-value', target_step_id: 'type_email', new_value: 'user@acme.io', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.steps[0].value).toBe('user@acme.io');
+  });
+
+  test('edit-assertion-text sets effective nl_text', () => {
+    const r = applyEdits({
+      events: [ev('tap_x')],
+      assertions: [as('a1', 'tap_x', 'old')],
+      edits: [{ op: 'edit-assertion-text', target_assertion_id: 'a1', new_nl_text: 'new text', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.assertions[0].nl_text).toBe('new text');
+  });
+
+  test('delete + cascade removes the step and its anchored assertions', () => {
+    const r = applyEdits({
+      events: [ev('tap_a'), ev('tap_b')],
+      assertions: [as('a1', 'tap_b'), as('a2', 'tap_a')],
+      edits: [{ op: 'delete', target_step_id: 'tap_b', assertion_policy: 'cascade', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.steps.map((s) => s.step_id)).toEqual(['tap_a']);
+    expect(r.assertions.map((a) => a.id)).toEqual(['a2']);
+  });
+
+  test('delete + reanchor re-points anchored assertions to the previous surviving step', () => {
+    const r = applyEdits({
+      events: [ev('tap_a'), ev('tap_b'), ev('tap_c')],
+      assertions: [as('a1', 'tap_b')],
+      edits: [{ op: 'delete', target_step_id: 'tap_b', assertion_policy: 'reanchor', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.steps.map((s) => s.step_id)).toEqual(['tap_a', 'tap_c']);
+    expect(r.assertions[0].anchor_step_id).toBe('tap_a');
+  });
+
+  test('delete + reanchor on the first step falls back to the next surviving step', () => {
+    const r = applyEdits({
+      events: [ev('tap_first'), ev('tap_second')],
+      assertions: [as('a1', 'tap_first')],
+      edits: [{ op: 'delete', target_step_id: 'tap_first', assertion_policy: 'reanchor', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.assertions[0].anchor_step_id).toBe('tap_second');
+  });
+
+  test('delete + reanchor with no surviving step drops the assertions and reports', () => {
+    const r = applyEdits({
+      events: [ev('tap_only')],
+      assertions: [as('a1', 'tap_only')],
+      edits: [{ op: 'delete', target_step_id: 'tap_only', assertion_policy: 'reanchor', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.steps).toEqual([]);
+    expect(r.assertions).toEqual([]);
+    expect(r.report.some((x) => x.dropped === 'assertions')).toBe(true);
+  });
+
+  test('chronological precedence: later rename on same step wins', () => {
+    const r = applyEdits({
+      events: [ev('tap_x')],
+      assertions: [],
+      edits: [
+        { op: 'rename', target_step_id: 'tap_x', new_display_name: 'first', ts: '2026-05-16T10:00:00.000Z' },
+        { op: 'rename', target_step_id: 'tap_x', new_display_name: 'second', ts: '2026-05-16T10:00:05.000Z' },
+      ],
+    });
+    expect(r.steps[0].display_name).toBe('second');
+  });
+
+  test('edit targeting an already-deleted step is a silent no-op', () => {
+    const r = applyEdits({
+      events: [ev('tap_x')],
+      assertions: [],
+      edits: [
+        { op: 'delete', target_step_id: 'tap_x', assertion_policy: 'none', ts: '2026-05-16T10:00:00.000Z' },
+        { op: 'rename', target_step_id: 'tap_x', new_display_name: 'ghost', ts: '2026-05-16T10:00:05.000Z' },
+      ],
+    });
+    expect(r.steps).toEqual([]);
+    expect(r.report.some((x) => x.ignored === 'rename')).toBe(true);
+  });
+
+  test('unparseable / null edit entry is skipped and reported', () => {
+    const r = applyEdits({ events: [ev('tap_x')], assertions: [], edits: [null] });
+    expect(r.steps).toHaveLength(1);
+    expect(r.report.some((x) => x.skipped === 'unparseable')).toBe(true);
+  });
+
+  test('unrecognized op is ignored and reported (forward-compat)', () => {
+    const r = applyEdits({
+      events: [ev('tap_x')],
+      assertions: [],
+      edits: [{ op: 'reorder', target_step_id: 'tap_x', ts: '2026-05-16T10:00:00.000Z' }],
+    });
+    expect(r.steps).toHaveLength(1);
+    expect(r.report.some((x) => x.ignored === 'unrecognized-op')).toBe(true);
+  });
+
+  test('edits applied in ts order even if given out of order', () => {
+    const r = applyEdits({
+      events: [ev('tap_x')],
+      assertions: [],
+      edits: [
+        { op: 'rename', target_step_id: 'tap_x', new_display_name: 'late', ts: '2026-05-16T10:00:09.000Z' },
+        { op: 'rename', target_step_id: 'tap_x', new_display_name: 'early', ts: '2026-05-16T10:00:01.000Z' },
+      ],
+    });
+    expect(r.steps[0].display_name).toBe('late');
+  });
+});

--- a/tests/unit/recorder/artifacts.test.js
+++ b/tests/unit/recorder/artifacts.test.js
@@ -56,10 +56,11 @@ describe('ArtifactsStore', () => {
   test('appendEdit and appendAssertion build their respective files', () => {
     const store = new ArtifactsStore({ projectRoot, scenarioId: 's' });
     store.init({ mode: 'platform-aware' });
-    store.appendEdit({ t: 1, kind: 'rename', step_id: 'tap_x', new_name: 'tap_login' });
+    store.appendEdit({ op: 'rename', target_step_id: 'tap_x', new_display_name: 'Tap Login', ts: '2026-05-16T10:00:00.000Z' });
     store.appendAssertion({ id: 'a1', anchor_step_id: 'tap_login', nl_text: 'welcome shown' });
     const editsContent = fs.readFileSync(path.join(projectRoot, 'mobile-automator/.recorder/s/edits.jsonl'), 'utf8');
-    expect(editsContent.trim()).toContain('rename');
+    const rec = JSON.parse(editsContent.trim().split('\n')[0]);
+    expect(rec).toEqual({ op: 'rename', target_step_id: 'tap_x', new_display_name: 'Tap Login', ts: '2026-05-16T10:00:00.000Z' });
     const assertions = JSON.parse(fs.readFileSync(path.join(projectRoot, 'mobile-automator/.recorder/s/assertions.json'), 'utf8'));
     expect(assertions).toHaveLength(1);
     expect(assertions[0].nl_text).toBe('welcome shown');

--- a/tests/unit/recorder/session-handlers-edits.test.js
+++ b/tests/unit/recorder/session-handlers-edits.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const {
+  handleRenameStep,
+  handleDeleteStep,
+  handleEditValue,
+  handleEditAssertionText,
+} = require('../../../tools/recorder/src/session-handlers');
+
+describe('handleRenameStep', () => {
+  test('appends a canonical rename record and broadcasts step-renamed', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleRenameStep({ store, broadcast, msg: { type: 'rename-step', step_id: 'tap_login', new_display_name: 'Tap Login' } });
+    const rec = store.appendEdit.mock.calls[0][0];
+    expect(rec).toMatchObject({ op: 'rename', target_step_id: 'tap_login', new_display_name: 'Tap Login' });
+    expect(typeof rec.ts).toBe('string');
+    expect(broadcast).toHaveBeenCalledWith({ type: 'step-renamed', step_id: 'tap_login', new_display_name: 'Tap Login' });
+  });
+
+  test('rejects empty new_display_name (no append, no broadcast)', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleRenameStep({ store, broadcast, msg: { step_id: 'tap_login', new_display_name: '  ' } });
+    expect(store.appendEdit).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleEditValue', () => {
+  test('appends edit-value record and broadcasts value-edited', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleEditValue({ store, broadcast, msg: { step_id: 'type_email', new_value: 'user@acme.io' } });
+    expect(store.appendEdit.mock.calls[0][0]).toMatchObject({ op: 'edit-value', target_step_id: 'type_email', new_value: 'user@acme.io' });
+    expect(broadcast).toHaveBeenCalledWith({ type: 'value-edited', step_id: 'type_email', new_value: 'user@acme.io' });
+  });
+
+  test('rejects empty new_value', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleEditValue({ store, broadcast, msg: { step_id: 'type_email', new_value: '' } });
+    expect(store.appendEdit).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleEditAssertionText', () => {
+  test('appends edit-assertion-text record and broadcasts assertion-text-edited', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleEditAssertionText({ store, broadcast, msg: { assertion_id: 'a3', new_nl_text: 'Dashboard header is visible' } });
+    expect(store.appendEdit.mock.calls[0][0]).toMatchObject({ op: 'edit-assertion-text', target_assertion_id: 'a3', new_nl_text: 'Dashboard header is visible' });
+    expect(broadcast).toHaveBeenCalledWith({ type: 'assertion-text-edited', assertion_id: 'a3', new_nl_text: 'Dashboard header is visible' });
+  });
+});
+
+describe('handleDeleteStep', () => {
+  test('appends delete record with policy and broadcasts step-deleted', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleDeleteStep({ store, broadcast, msg: { step_id: 'tap_submit', assertion_policy: 'reanchor' } });
+    expect(store.appendEdit.mock.calls[0][0]).toMatchObject({ op: 'delete', target_step_id: 'tap_submit', assertion_policy: 'reanchor' });
+    expect(broadcast).toHaveBeenCalledWith({ type: 'step-deleted', step_id: 'tap_submit', assertion_policy: 'reanchor' });
+  });
+
+  test('accepts policy "none"', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleDeleteStep({ store, broadcast, msg: { step_id: 'tap_x', assertion_policy: 'none' } });
+    expect(store.appendEdit).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects unknown assertion_policy', () => {
+    const store = { appendEdit: jest.fn() };
+    const broadcast = jest.fn();
+    handleDeleteStep({ store, broadcast, msg: { step_id: 'tap_x', assertion_policy: 'bogus' } });
+    expect(store.appendEdit).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -188,3 +188,68 @@ describe('delete prompt', () => {
     expect(document.querySelector('.delete-prompt')).toBeNull();
   });
 });
+
+describe('confirmation display-effect', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="modal-root"></div><ul id="step-list"></ul>';
+  });
+
+  test('applyStepRenamed relabels the row target, keeps data-step-id', () => {
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.applyStepRenamed(document, { step_id: 'tap_login', new_display_name: 'Tap the Login button' });
+    const li = document.querySelector('[data-step-id="tap_login"]');
+    expect(li.querySelector('.step-target').textContent).toBe('Tap the Login button');
+    expect(li.getAttribute('data-step-id')).toBe('tap_login');
+  });
+
+  test('applyValueEdited updates the type step value span', () => {
+    app.appendStep({ id: 'type_email', index: 1, action: 'type', value: 'a@b', field_label: 'Email' });
+    app.applyValueEdited(document, { step_id: 'type_email', new_value: 'user@acme.io' });
+    expect(document.querySelector('[data-step-id="type_email"] .step-value').textContent).toBe('"user@acme.io"');
+  });
+
+  test('applyAssertionTextEdited updates the assertion text span', () => {
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'old', anchor_step_id: 'tap_login' });
+    app.applyAssertionTextEdited(document, { assertion_id: 'a1', new_nl_text: 'new text' });
+    expect(document.querySelector('[data-assertion-id="a1"] .assertion-text').textContent).toBe('new text');
+  });
+
+  test('applyStepDeleted cascade removes the step and its anchored assertions', () => {
+    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: '"A"' });
+    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: '"B"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'x', anchor_step_id: 'tap_b' });
+    app.applyStepDeleted(document, { step_id: 'tap_b', assertion_policy: 'cascade' });
+    expect(document.querySelector('[data-step-id="tap_b"]')).toBeNull();
+    expect(document.querySelector('[data-assertion-id="a1"]')).toBeNull();
+  });
+
+  test('applyStepDeleted reanchor moves assertions to the previous surviving step', () => {
+    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: '"A"' });
+    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: '"B"' });
+    app.appendStep({ id: 'tap_c', index: 3, action: 'tap', target: '"C"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'x', anchor_step_id: 'tap_b' });
+    app.applyStepDeleted(document, { step_id: 'tap_b', assertion_policy: 'reanchor' });
+    const a = document.querySelector('[data-assertion-id="a1"]');
+    expect(a).not.toBeNull();
+    expect(a.getAttribute('data-anchor-step-id')).toBe('tap_a');
+    expect(document.querySelector('[data-step-id="tap_b"]')).toBeNull();
+  });
+
+  test('attachWsClient routes the 4 confirmations to their handlers', () => {
+    const calls = [];
+    const FakeWS = function () { this.addEventListener = (t, fn) => { this._fn = fn; }; };
+    const ws = app.attachWsClient({
+      url: 'ws://x', WebSocketCtor: FakeWS,
+      onStepRenamed: (p) => calls.push(['r', p.step_id]),
+      onStepDeleted: (p) => calls.push(['d', p.step_id]),
+      onValueEdited: (p) => calls.push(['v', p.step_id]),
+      onAssertionTextEdited: (p) => calls.push(['a', p.assertion_id]),
+    });
+    ws._fn({ data: JSON.stringify({ type: 'step-renamed', step_id: 'tap_x', new_display_name: 'X' }) });
+    ws._fn({ data: JSON.stringify({ type: 'step-deleted', step_id: 'tap_y', assertion_policy: 'none' }) });
+    ws._fn({ data: JSON.stringify({ type: 'value-edited', step_id: 'type_z', new_value: 'v' }) });
+    ws._fn({ data: JSON.stringify({ type: 'assertion-text-edited', assertion_id: 'a9', new_nl_text: 't' }) });
+    expect(calls).toEqual([['r', 'tap_x'], ['d', 'tap_y'], ['v', 'type_z'], ['a', 'a9']]);
+  });
+});

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -32,12 +32,12 @@ describe('"⋯" menu rendering & per-row-type filtering', () => {
     expect(items).toEqual(['rename', 'delete']);
   });
 
-  test('opening the menu on a type step also shows Edit value', () => {
+  test('type step menu is Delete + Edit value (no Rename — slug derives from field)', () => {
     app.appendStep({ id: 'type_email', index: 1, action: 'type', value: 'a@b', field_label: 'Email' });
     app.attachEditAffordances({ document, sendWs: jest.fn() });
     document.querySelector('[data-step-id="type_email"] button.step-menu').click();
     const items = [...document.querySelectorAll('.step-menu-popover .menu-item')].map((b) => b.getAttribute('data-edit-action'));
-    expect(items).toEqual(['rename', 'delete', 'edit-value']);
+    expect(items).toEqual(['delete', 'edit-value']);
   });
 
   test('assertion row menu shows Edit text only (no reorder/insert/type-change anywhere)', () => {
@@ -234,6 +234,22 @@ describe('confirmation display-effect', () => {
     expect(a).not.toBeNull();
     expect(a.getAttribute('data-anchor-step-id')).toBe('tap_a');
     expect(document.querySelector('[data-step-id="tap_b"]')).toBeNull();
+  });
+
+  test('applyStepDeleted reanchor preserves relative order of multiple assertions', () => {
+    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: '"A"' });
+    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: '"B"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'first', anchor_step_id: 'tap_b' });
+    app.appendAssertionRow({ id: 'a2', nl_text: 'second', anchor_step_id: 'tap_b' });
+    const before = [...document.querySelectorAll('.assertion-row')].map((r) => r.getAttribute('data-assertion-id'));
+    app.applyStepDeleted(document, { step_id: 'tap_b', assertion_policy: 'reanchor' });
+    const after = [...document.querySelectorAll('.assertion-row')].map((r) => r.getAttribute('data-assertion-id'));
+    // The move must not reorder the assertions relative to each other.
+    expect(after).toEqual(before);
+    expect(after).toHaveLength(2);
+    after.forEach((id) => {
+      expect(document.querySelector('[data-assertion-id="' + id + '"]').getAttribute('data-anchor-step-id')).toBe('tap_a');
+    });
   });
 
   test('attachWsClient routes the 4 confirmations to their handlers', () => {

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -40,6 +40,14 @@ describe('"⋯" menu rendering & per-row-type filtering', () => {
     expect(items).toEqual(['delete', 'edit-value']);
   });
 
+  test('swipe step menu is Delete only (no Rename — row has no name span)', () => {
+    app.appendStep({ id: 'swipe_left', index: 1, action: 'swipe', direction: 'left' });
+    app.attachEditAffordances({ document, sendWs: jest.fn() });
+    document.querySelector('[data-step-id="swipe_left"] button.step-menu').click();
+    const items = [...document.querySelectorAll('.step-menu-popover .menu-item')].map((b) => b.getAttribute('data-edit-action'));
+    expect(items).toEqual(['delete']);
+  });
+
   test('assertion row menu shows Edit text only (no reorder/insert/type-change anywhere)', () => {
     app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'Shown', anchor_step_id: 'tap_login' });

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -127,3 +127,64 @@ describe('inline editors send the correct WS message', () => {
     expect(sendWs).not.toHaveBeenCalled();
   });
 });
+
+describe('delete prompt', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="modal-root"></div><ul id="step-list"></ul>';
+  });
+  function openDelete(stepSel) {
+    document.querySelector(stepSel + ' button.step-menu').click();
+    [...document.querySelectorAll('.step-menu-popover .menu-item')]
+      .find((b) => b.getAttribute('data-edit-action') === 'delete').click();
+  }
+
+  test('no anchored assertions → plain confirm → delete-step policy none', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_skip', index: 1, action: 'tap', target: '"Skip"' });
+    app.attachEditAffordances({ document, sendWs });
+    openDelete('[data-step-id="tap_skip"]');
+    const prompt = document.querySelector('.delete-prompt');
+    expect(prompt).not.toBeNull();
+    expect(prompt.querySelectorAll('.delete-option').length).toBe(0);
+    prompt.querySelector('[data-delete-confirm]').click();
+    expect(sendWs).toHaveBeenCalledWith({ type: 'delete-step', step_id: 'tap_skip', assertion_policy: 'none' });
+  });
+
+  test('anchored assertions → 3-option prompt, reanchor is the default', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: '"Submit"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'Dashboard', anchor_step_id: 'tap_submit' });
+    app.appendAssertionRow({ id: 'a2', nl_text: 'Toast', anchor_step_id: 'tap_submit' });
+    app.attachEditAffordances({ document, sendWs });
+    openDelete('[data-step-id="tap_submit"]');
+    const prompt = document.querySelector('.delete-prompt');
+    const opts = [...prompt.querySelectorAll('.delete-option')].map((o) => o.getAttribute('data-policy'));
+    expect(opts).toEqual(['reanchor', 'cascade']);
+    expect(prompt.querySelector('input[name="delete-policy"]:checked').value).toBe('reanchor');
+    prompt.querySelector('[data-delete-confirm]').click();
+    expect(sendWs).toHaveBeenCalledWith({ type: 'delete-step', step_id: 'tap_submit', assertion_policy: 'reanchor' });
+  });
+
+  test('choosing cascade sends cascade', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: '"Submit"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'Dashboard', anchor_step_id: 'tap_submit' });
+    app.attachEditAffordances({ document, sendWs });
+    openDelete('[data-step-id="tap_submit"]');
+    const prompt = document.querySelector('.delete-prompt');
+    prompt.querySelector('input[name="delete-policy"][value="cascade"]').checked = true;
+    prompt.querySelector('[data-delete-confirm]').click();
+    expect(sendWs).toHaveBeenCalledWith({ type: 'delete-step', step_id: 'tap_submit', assertion_policy: 'cascade' });
+  });
+
+  test('cancel sends nothing and removes the prompt', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: '"Submit"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'Dashboard', anchor_step_id: 'tap_submit' });
+    app.attachEditAffordances({ document, sendWs });
+    openDelete('[data-step-id="tap_submit"]');
+    document.querySelector('.delete-prompt [data-delete-cancel]').click();
+    expect(sendWs).not.toHaveBeenCalled();
+    expect(document.querySelector('.delete-prompt')).toBeNull();
+  });
+});

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+'use strict';
+
+window.__RECORDER_TEST__ = true;
+const path = require('path');
+const app = require(path.resolve(__dirname, '../../../tools/recorder/web/app.js'));
+
+describe('"⋯" menu rendering & per-row-type filtering', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="modal-root"></div><ul id="step-list"></ul>';
+  });
+
+  test('every step row gets an always-visible .step-menu button', () => {
+    const li = app.renderStepRow({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    const btn = li.querySelector('button.step-menu');
+    expect(btn).not.toBeNull();
+    expect(btn.getAttribute('aria-label')).toBe('Edit step');
+  });
+
+  test('generic step row carries data-action for filtering', () => {
+    const li = app.renderStepRow({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    expect(li.getAttribute('data-action')).toBe('tap');
+  });
+
+  test('opening the menu on a generic step shows Rename + Delete only', () => {
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.attachEditAffordances({ document, sendWs: jest.fn() });
+    document.querySelector('[data-step-id="tap_login"] button.step-menu').click();
+    const items = [...document.querySelectorAll('.step-menu-popover .menu-item')].map((b) => b.getAttribute('data-edit-action'));
+    expect(items).toEqual(['rename', 'delete']);
+  });
+
+  test('opening the menu on a type step also shows Edit value', () => {
+    app.appendStep({ id: 'type_email', index: 1, action: 'type', value: 'a@b', field_label: 'Email' });
+    app.attachEditAffordances({ document, sendWs: jest.fn() });
+    document.querySelector('[data-step-id="type_email"] button.step-menu').click();
+    const items = [...document.querySelectorAll('.step-menu-popover .menu-item')].map((b) => b.getAttribute('data-edit-action'));
+    expect(items).toEqual(['rename', 'delete', 'edit-value']);
+  });
+
+  test('assertion row menu shows Edit text only (no reorder/insert/type-change anywhere)', () => {
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'Shown', anchor_step_id: 'tap_login' });
+    app.attachEditAffordances({ document, sendWs: jest.fn() });
+    document.querySelector('[data-assertion-id="a1"] button.step-menu').click();
+    const items = [...document.querySelectorAll('.step-menu-popover .menu-item')].map((b) => b.getAttribute('data-edit-action'));
+    expect(items).toEqual(['edit-assertion-text']);
+    expect(document.body.innerHTML).not.toMatch(/reorder|insert|change-type/i);
+  });
+
+  test('assertion row carries data-anchor-step-id', () => {
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    const li = app.appendAssertionRow({ id: 'a1', nl_text: 'Shown', anchor_step_id: 'tap_login' });
+    expect(li.getAttribute('data-anchor-step-id')).toBe('tap_login');
+  });
+});

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -56,3 +56,74 @@ describe('"⋯" menu rendering & per-row-type filtering', () => {
     expect(li.getAttribute('data-anchor-step-id')).toBe('tap_login');
   });
 });
+
+describe('inline editors send the correct WS message', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="modal-root"></div><ul id="step-list"></ul>';
+  });
+
+  function openMenuAndClick(selectorRoot, action) {
+    document.querySelector(selectorRoot + ' button.step-menu').click();
+    [...document.querySelectorAll('.step-menu-popover .menu-item')]
+      .find((b) => b.getAttribute('data-edit-action') === action).click();
+  }
+
+  test('rename: commit with Enter sends rename-step', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.attachEditAffordances({ document, sendWs });
+    openMenuAndClick('[data-step-id="tap_login"]', 'rename');
+    const input = document.querySelector('[data-step-id="tap_login"] input.inline-edit');
+    expect(input).not.toBeNull();
+    input.value = 'Tap the Login button';
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(sendWs).toHaveBeenCalledWith({ type: 'rename-step', step_id: 'tap_login', new_display_name: 'Tap the Login button' });
+  });
+
+  test('rename: Escape cancels — no WS, input removed', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.attachEditAffordances({ document, sendWs });
+    openMenuAndClick('[data-step-id="tap_login"]', 'rename');
+    const input = document.querySelector('[data-step-id="tap_login"] input.inline-edit');
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    expect(sendWs).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-step-id="tap_login"] input.inline-edit')).toBeNull();
+  });
+
+  test('edit-value on type step sends edit-value', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'type_email', index: 1, action: 'type', value: 'usr@acme', field_label: 'Email' });
+    app.attachEditAffordances({ document, sendWs });
+    openMenuAndClick('[data-step-id="type_email"]', 'edit-value');
+    const input = document.querySelector('[data-step-id="type_email"] input.inline-edit');
+    expect(input.value).toBe('usr@acme');
+    input.value = 'user@acme.io';
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(sendWs).toHaveBeenCalledWith({ type: 'edit-value', step_id: 'type_email', new_value: 'user@acme.io' });
+  });
+
+  test('edit-assertion-text sends edit-assertion-text', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendAssertionRow({ id: 'a1', nl_text: 'old text', anchor_step_id: 'tap_login' });
+    app.attachEditAffordances({ document, sendWs });
+    openMenuAndClick('[data-assertion-id="a1"]', 'edit-assertion-text');
+    const input = document.querySelector('[data-assertion-id="a1"] input.inline-edit');
+    expect(input.value).toBe('old text');
+    input.value = 'new text';
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(sendWs).toHaveBeenCalledWith({ type: 'edit-assertion-text', assertion_id: 'a1', new_nl_text: 'new text' });
+  });
+
+  test('blank commit is ignored (no WS)', () => {
+    const sendWs = jest.fn();
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.attachEditAffordances({ document, sendWs });
+    openMenuAndClick('[data-step-id="tap_login"]', 'rename');
+    const input = document.querySelector('[data-step-id="tap_login"] input.inline-edit');
+    input.value = '   ';
+    input.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(sendWs).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/recorder/web-step-list.test.js
+++ b/tests/unit/recorder/web-step-list.test.js
@@ -19,7 +19,7 @@ describe('recorder GUI: step-list rendering', () => {
   });
 
   describe('renderStepRow', () => {
-    test('returns an <li> with data attributes and three child spans (no step-menu)', () => {
+    test('returns an <li> with data attributes, three child spans, and a step-menu button (slice #28)', () => {
       const li = app.renderStepRow({
         id: 'tap_login',
         index: 3,
@@ -45,8 +45,8 @@ describe('recorder GUI: step-list rendering', () => {
       expect(action.textContent).toBe('Tap');
       expect(target.textContent).toBe('"Login"');
 
-      // Per #22 AC the step-menu (edit affordances) is intentionally NOT rendered.
-      expect(li.querySelector('.step-menu')).toBeNull();
+      // Per #28 the always-visible step-menu (⋯) button is now rendered on every row.
+      expect(li.querySelector('button.step-menu')).not.toBeNull();
     });
 
     test('adds "unnamed" class when is_unnamed is true', () => {
@@ -86,7 +86,7 @@ describe('recorder GUI: step-list rendering', () => {
       expect(li.getAttribute('data-step-id')).toBe('type_email');
       expect(li.getAttribute('data-index')).toBe('4');
       expect(li.textContent).toMatch(
-        /^\s*\d+\.\s*Type\s*"test@example\.com"\s*into\s*"Email"\s*$/,
+        /^\s*\d+\.\s*Type\s*"test@example\.com"\s*into\s*"Email"\s*⋯\s*$/,
       );
     });
 
@@ -156,7 +156,7 @@ describe('recorder GUI: step-list rendering', () => {
       expect(li.getAttribute('data-step-id')).toBe('long_press_settings_icon');
       expect(li.getAttribute('data-action')).toBe('long_press');
       expect(li.textContent).toMatch(
-        /^\s*\d+\.\s*Long press\s*"Settings Icon"\s*$/,
+        /^\s*\d+\.\s*Long press\s*"Settings Icon"\s*⋯\s*$/,
       );
       const action = li.querySelector('.step-action');
       const target = li.querySelector('.step-target');
@@ -176,7 +176,7 @@ describe('recorder GUI: step-list rendering', () => {
 
       expect(li.getAttribute('data-action')).toBe('double_tap');
       expect(li.textContent).toMatch(
-        /^\s*\d+\.\s*Double tap\s*"Like Button"\s*$/,
+        /^\s*\d+\.\s*Double tap\s*"Like Button"\s*⋯\s*$/,
       );
       const action = li.querySelector('.step-action');
       const target = li.querySelector('.step-target');
@@ -194,7 +194,7 @@ describe('recorder GUI: step-list rendering', () => {
       });
 
       expect(li.getAttribute('data-action')).toBe('swipe');
-      expect(li.textContent).toMatch(/^\s*\d+\.\s*Swipe\s*up\s*$/);
+      expect(li.textContent).toMatch(/^\s*\d+\.\s*Swipe\s*up\s*⋯\s*$/);
       const action = li.querySelector('.step-action');
       expect(action.textContent).toBe('Swipe');
       // Per the issue spec the swipe label is direction-only: no target span.

--- a/tools/recorder/src/reconcile/apply-edits.js
+++ b/tools/recorder/src/reconcile/apply-edits.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Pure reconcile engine for recorder user-edits. Replays an append-only
+ * edits.jsonl in chronological (`ts`) order over the captured events and
+ * assertions, returning the effective lists plus a report of skips/drops.
+ *
+ * This is the executable specification the aware-mode recorder SKILL.md
+ * prose mirrors 1:1 (step 2 "Reconcile edits"). Final step_id re-derivation
+ * and after_step rewriting remain the AI's job at schema emission; here we
+ * only mutate the effective display_name / value / nl_text / anchor_step_id.
+ */
+function applyEdits({ events, assertions, edits }) {
+  const report = [];
+  let steps = (events || []).map((e) => ({ ...e }));
+  let asserts = (assertions || []).map((a) => ({ ...a }));
+
+  // ISO-8601 Z timestamps sort lexically == chronologically. Array.sort is
+  // stable in V8, so equal-ts edits keep append (chronological) order.
+  const sorted = (edits || []).slice().sort((a, b) => {
+    const at = a && a.ts ? String(a.ts) : '';
+    const bt = b && b.ts ? String(b.ts) : '';
+    return at < bt ? -1 : at > bt ? 1 : 0;
+  });
+
+  for (const ed of sorted) {
+    if (!ed || typeof ed !== 'object') {
+      report.push({ skipped: 'unparseable', edit: ed });
+      continue;
+    }
+    if (ed.op === 'rename') {
+      const s = steps.find((x) => x.step_id === ed.target_step_id);
+      if (!s) { report.push({ ignored: 'rename', target: ed.target_step_id }); continue; }
+      s.display_name = ed.new_display_name;
+    } else if (ed.op === 'edit-value') {
+      const s = steps.find((x) => x.step_id === ed.target_step_id);
+      if (!s) { report.push({ ignored: 'edit-value', target: ed.target_step_id }); continue; }
+      s.value = ed.new_value;
+    } else if (ed.op === 'edit-assertion-text') {
+      const a = asserts.find((x) => x.id === ed.target_assertion_id);
+      if (!a) { report.push({ ignored: 'edit-assertion-text', target: ed.target_assertion_id }); continue; }
+      a.nl_text = ed.new_nl_text;
+    } else if (ed.op === 'delete') {
+      const idx = steps.findIndex((x) => x.step_id === ed.target_step_id);
+      if (idx === -1) { report.push({ ignored: 'delete', target: ed.target_step_id }); continue; }
+      const removedId = steps[idx].step_id;
+      const anchored = asserts.filter((a) => a.anchor_step_id === removedId);
+      if (anchored.length > 0) {
+        if (ed.assertion_policy === 'cascade') {
+          asserts = asserts.filter((a) => a.anchor_step_id !== removedId);
+        } else if (ed.assertion_policy === 'reanchor') {
+          const prev = idx > 0 ? steps[idx - 1] : null;
+          const next = idx + 1 < steps.length ? steps[idx + 1] : null;
+          const target = prev || next || null;
+          if (!target) {
+            asserts = asserts.filter((a) => a.anchor_step_id !== removedId);
+            report.push({ dropped: 'assertions', reason: 'no surviving step', count: anchored.length });
+          } else {
+            for (const a of asserts) {
+              if (a.anchor_step_id === removedId) a.anchor_step_id = target.step_id;
+            }
+          }
+        } else {
+          report.push({ note: 'delete policy=none but step had anchored assertions', target: removedId });
+        }
+      }
+      steps.splice(idx, 1);
+    } else {
+      report.push({ ignored: 'unrecognized-op', op: ed.op });
+    }
+  }
+
+  return { steps, assertions: asserts, report };
+}
+
+module.exports = { applyEdits };

--- a/tools/recorder/src/session-handlers.js
+++ b/tools/recorder/src/session-handlers.js
@@ -67,4 +67,34 @@ function handleCancelAssertion({ store, msg }) {
   store.deleteAssertScreenshot(msg.assertion_id);
 }
 
-module.exports = { handleSaveMessage, handleCancelMessage, handleRequestAssertionScreenshot, handleSaveAssertion, handleCancelAssertion };
+function _nonEmpty(s) {
+  return typeof s === 'string' && s.trim().length > 0;
+}
+
+const _DELETE_POLICIES = ['none', 'reanchor', 'cascade'];
+
+function handleRenameStep({ store, broadcast, msg }) {
+  if (!_nonEmpty(msg && msg.step_id) || !_nonEmpty(msg && msg.new_display_name)) return;
+  store.appendEdit({ op: 'rename', target_step_id: msg.step_id, new_display_name: msg.new_display_name, ts: new Date().toISOString() });
+  broadcast({ type: 'step-renamed', step_id: msg.step_id, new_display_name: msg.new_display_name });
+}
+
+function handleEditValue({ store, broadcast, msg }) {
+  if (!_nonEmpty(msg && msg.step_id) || !_nonEmpty(msg && msg.new_value)) return;
+  store.appendEdit({ op: 'edit-value', target_step_id: msg.step_id, new_value: msg.new_value, ts: new Date().toISOString() });
+  broadcast({ type: 'value-edited', step_id: msg.step_id, new_value: msg.new_value });
+}
+
+function handleEditAssertionText({ store, broadcast, msg }) {
+  if (!_nonEmpty(msg && msg.assertion_id) || !_nonEmpty(msg && msg.new_nl_text)) return;
+  store.appendEdit({ op: 'edit-assertion-text', target_assertion_id: msg.assertion_id, new_nl_text: msg.new_nl_text, ts: new Date().toISOString() });
+  broadcast({ type: 'assertion-text-edited', assertion_id: msg.assertion_id, new_nl_text: msg.new_nl_text });
+}
+
+function handleDeleteStep({ store, broadcast, msg }) {
+  if (!_nonEmpty(msg && msg.step_id) || !_DELETE_POLICIES.includes(msg && msg.assertion_policy)) return;
+  store.appendEdit({ op: 'delete', target_step_id: msg.step_id, assertion_policy: msg.assertion_policy, ts: new Date().toISOString() });
+  broadcast({ type: 'step-deleted', step_id: msg.step_id, assertion_policy: msg.assertion_policy });
+}
+
+module.exports = { handleSaveMessage, handleCancelMessage, handleRequestAssertionScreenshot, handleSaveAssertion, handleCancelAssertion, handleRenameStep, handleEditValue, handleEditAssertionText, handleDeleteStep };

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -159,6 +159,10 @@
     const onAssertionScreenshotReady = opts.onAssertionScreenshotReady || null;
     const onAssertionScreenshotError = opts.onAssertionScreenshotError || null;
     const onAssertionAdded = opts.onAssertionAdded || null;
+    const onStepRenamed = opts.onStepRenamed || null;
+    const onStepDeleted = opts.onStepDeleted || null;
+    const onValueEdited = opts.onValueEdited || null;
+    const onAssertionTextEdited = opts.onAssertionTextEdited || null;
     const Ctor = opts.WebSocketCtor || root.WebSocket;
     if (!Ctor) {
       throw new Error('attachWsClient: no WebSocket constructor available');
@@ -188,6 +192,10 @@
         onAssertionAdded(payload.assertion);
         return;
       }
+      if (payload.type === 'step-renamed' && typeof onStepRenamed === 'function') { onStepRenamed(payload); return; }
+      if (payload.type === 'step-deleted' && typeof onStepDeleted === 'function') { onStepDeleted(payload); return; }
+      if (payload.type === 'value-edited' && typeof onValueEdited === 'function') { onValueEdited(payload); return; }
+      if (payload.type === 'assertion-text-edited' && typeof onAssertionTextEdited === 'function') { onAssertionTextEdited(payload); return; }
     });
     return ws;
   }
@@ -536,6 +544,53 @@
     });
   }
 
+  function applyStepRenamed(doc, p) {
+    const li = doc.querySelector('[data-step-id="' + p.step_id + '"]');
+    if (!li) return;
+    const span = li.querySelector('.step-target') || li.querySelector('.step-action');
+    if (span) span.textContent = p.new_display_name;
+  }
+
+  function applyValueEdited(doc, p) {
+    const li = doc.querySelector('[data-step-id="' + p.step_id + '"]');
+    if (!li) return;
+    const span = li.querySelector('.step-value');
+    if (span) span.textContent = '"' + p.new_value + '"';
+  }
+
+  function applyAssertionTextEdited(doc, p) {
+    const li = doc.querySelector('[data-assertion-id="' + p.assertion_id + '"]');
+    if (!li) return;
+    const span = li.querySelector('.assertion-text');
+    if (span) span.textContent = p.new_nl_text;
+  }
+
+  function applyStepDeleted(doc, p) {
+    const list = doc.getElementById('step-list');
+    if (!list) return;
+    const li = list.querySelector('[data-step-id="' + p.step_id + '"]');
+    if (!li) return;
+    const anchored = [].slice.call(list.querySelectorAll('.assertion-row[data-anchor-step-id="' + p.step_id + '"]'));
+    if (p.assertion_policy === 'cascade') {
+      anchored.forEach(function (a) { if (a.parentNode) a.parentNode.removeChild(a); });
+    } else if (p.assertion_policy === 'reanchor' && anchored.length > 0) {
+      const steps = [].slice.call(list.querySelectorAll('li.step-row'));
+      const pos = steps.indexOf(li);
+      const target = (pos > 0 ? steps[pos - 1] : null) || (pos + 1 < steps.length ? steps[pos + 1] : null);
+      if (target) {
+        const targetId = target.getAttribute('data-step-id');
+        anchored.forEach(function (a) {
+          a.setAttribute('data-anchor-step-id', targetId);
+          if (target.nextSibling) list.insertBefore(a, target.nextSibling);
+          else list.appendChild(a);
+        });
+      } else {
+        anchored.forEach(function (a) { if (a.parentNode) a.parentNode.removeChild(a); });
+      }
+    }
+    if (li.parentNode) li.parentNode.removeChild(li);
+  }
+
   // Expose to the browser global.
   root.renderStepRow = renderStepRow;
   root.appendStep = appendStep;
@@ -544,6 +599,10 @@
   root.renderAssertionModal = renderAssertionModal;
   root.appendAssertionRow = appendAssertionRow;
   root.attachEditAffordances = attachEditAffordances;
+  root.applyStepRenamed = applyStepRenamed;
+  root.applyValueEdited = applyValueEdited;
+  root.applyAssertionTextEdited = applyAssertionTextEdited;
+  root.applyStepDeleted = applyStepDeleted;
 
   // Expose to CommonJS (jest).
   if (typeof module !== 'undefined' && module.exports) {
@@ -555,6 +614,10 @@
       renderAssertionModal: renderAssertionModal,
       appendAssertionRow: appendAssertionRow,
       attachEditAffordances: attachEditAffordances,
+      applyStepRenamed: applyStepRenamed,
+      applyValueEdited: applyValueEdited,
+      applyAssertionTextEdited: applyAssertionTextEdited,
+      applyStepDeleted: applyStepDeleted,
     };
   }
 
@@ -595,6 +658,10 @@
         },
         onAssertionScreenshotError: onAssertionError,
         onAssertionAdded: appendAssertionRow,
+        onStepRenamed: function (p) { applyStepRenamed(document, p); },
+        onStepDeleted: function (p) { applyStepDeleted(document, p); },
+        onValueEdited: function (p) { applyValueEdited(document, p); },
+        onAssertionTextEdited: function (p) { applyAssertionTextEdited(document, p); },
       });
 
       wireButtons({
@@ -607,6 +674,7 @@
         },
         onAssertionScreenshotError: onAssertionError,
       });
+      attachEditAffordances({ document: document, sendWs: function (msg) { ws.send(JSON.stringify(msg)); } });
     } catch (_err) {
       // Swallow connection setup errors — the GUI will still render manually-
       // appended rows.

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -452,7 +452,89 @@
     }
   }
 
-  function _beginDelete(doc, li, sendWs) { /* Task 6 */ }
+  function _renderDeletePrompt(doc, opts) {
+    const overlay = doc.createElement('div');
+    overlay.className = 'modal-overlay delete-prompt';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    const panel = doc.createElement('div');
+    panel.className = 'modal-panel';
+
+    const title = doc.createElement('h4');
+    title.textContent = 'Delete this step?';
+    panel.appendChild(title);
+
+    let getPolicy = function () { return 'none'; };
+
+    if (opts.anchoredCount > 0) {
+      const warn = doc.createElement('div');
+      warn.className = 'delete-warn';
+      warn.textContent = '⚠ ' + opts.anchoredCount + ' assertion(s) are anchored to this step.';
+      panel.appendChild(warn);
+      const policies = [
+        ['reanchor', 'Re-anchor to previous step'],
+        ['cascade', 'Cascade-delete the assertions'],
+      ];
+      policies.forEach(function (p, i) {
+        const row = doc.createElement('label');
+        row.className = 'delete-option';
+        row.setAttribute('data-policy', p[0]);
+        const radio = doc.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'delete-policy';
+        radio.value = p[0];
+        if (i === 0) radio.checked = true;
+        const span = doc.createElement('span');
+        span.textContent = p[1];
+        row.appendChild(radio);
+        row.appendChild(span);
+        panel.appendChild(row);
+      });
+      getPolicy = function () {
+        const checked = panel.querySelector('input[name="delete-policy"]:checked');
+        return checked ? checked.value : 'reanchor';
+      };
+    }
+
+    const btnRow = doc.createElement('div');
+    btnRow.className = 'modal-btn-row';
+    const confirm = doc.createElement('button');
+    confirm.type = 'button';
+    confirm.setAttribute('data-delete-confirm', '1');
+    confirm.textContent = opts.anchoredCount > 0 ? 'Apply' : 'Delete';
+    const cancel = doc.createElement('button');
+    cancel.type = 'button';
+    cancel.setAttribute('data-delete-cancel', '1');
+    cancel.textContent = 'Cancel';
+
+    function close() { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); }
+    confirm.addEventListener('click', function () { const p = getPolicy(); close(); opts.onConfirm(p); });
+    cancel.addEventListener('click', function () { close(); opts.onCancel(); });
+
+    btnRow.appendChild(confirm);
+    btnRow.appendChild(cancel);
+    panel.appendChild(btnRow);
+    overlay.appendChild(panel);
+    const modalRoot = doc.getElementById('modal-root') || doc.body;
+    modalRoot.appendChild(overlay);
+    return overlay;
+  }
+
+  function _beginDelete(doc, li, sendWs) {
+    const stepId = li.getAttribute('data-step-id');
+    const list = doc.getElementById('step-list');
+    const anchored = list
+      ? list.querySelectorAll('.assertion-row[data-anchor-step-id="' + stepId + '"]').length
+      : 0;
+    _renderDeletePrompt(doc, {
+      step_id: stepId,
+      anchoredCount: anchored,
+      onConfirm: function (policy) {
+        sendWs({ type: 'delete-step', step_id: stepId, assertion_policy: policy });
+      },
+      onCancel: function () {},
+    });
+  }
 
   // Expose to the browser global.
   root.renderStepRow = renderStepRow;

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -386,7 +386,73 @@
     });
   }
 
-  function _dispatchEditAction(doc, li, action, sendWs) { /* rename/edit-value/edit-assertion-text: Task 5; delete: Task 6 */ }
+  function _editableSpan(li) {
+    if (li.classList.contains('assertion-row')) return li.querySelector('.assertion-text');
+    if (li.getAttribute('data-action') === 'type') {
+      return li.querySelector('.step-target');
+    }
+    return li.querySelector('.step-target') || li.querySelector('.step-action');
+  }
+
+  function _beginInlineEdit(doc, li, span, currentValue, onCommit) {
+    if (!span) return;
+    const input = doc.createElement('input');
+    input.type = 'text';
+    input.className = 'inline-edit';
+    input.value = currentValue == null ? '' : String(currentValue);
+    const prevDisplay = span.style.display;
+    span.style.display = 'none';
+    span.parentNode.insertBefore(input, span.nextSibling);
+    let done = false;
+    function cleanup() {
+      if (input.parentNode) input.parentNode.removeChild(input);
+      span.style.display = prevDisplay;
+    }
+    function commit() {
+      if (done) return;
+      done = true;
+      const v = input.value.trim();
+      cleanup();
+      if (v.length > 0) onCommit(v);
+    }
+    function cancel() {
+      if (done) return;
+      done = true;
+      cleanup();
+    }
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') { e.preventDefault(); commit(); }
+      else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+    });
+    input.addEventListener('blur', commit);
+    setTimeout(function () { input.focus(); }, 0);
+  }
+
+  function _dispatchEditAction(doc, li, action, sendWs) {
+    if (action === 'rename') {
+      const span = _editableSpan(li);
+      const stepId = li.getAttribute('data-step-id');
+      _beginInlineEdit(doc, li, span, span ? span.textContent.replace(/^"|"$/g, '') : '', function (v) {
+        sendWs({ type: 'rename-step', step_id: stepId, new_display_name: v });
+      });
+    } else if (action === 'edit-value') {
+      const span = li.querySelector('.step-value');
+      const stepId = li.getAttribute('data-step-id');
+      _beginInlineEdit(doc, li, span, span ? span.textContent.replace(/^"|"$/g, '') : '', function (v) {
+        sendWs({ type: 'edit-value', step_id: stepId, new_value: v });
+      });
+    } else if (action === 'edit-assertion-text') {
+      const span = li.querySelector('.assertion-text');
+      const aid = li.getAttribute('data-assertion-id');
+      _beginInlineEdit(doc, li, span, span ? span.textContent : '', function (v) {
+        sendWs({ type: 'edit-assertion-text', assertion_id: aid, new_nl_text: v });
+      });
+    } else if (action === 'delete') {
+      _beginDelete(doc, li, sendWs);
+    }
+  }
+
+  function _beginDelete(doc, li, sendWs) { /* Task 6 */ }
 
   // Expose to the browser global.
   root.renderStepRow = renderStepRow;

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -12,6 +12,15 @@
 
   var latestStepId = null;
 
+  function _makeStepMenuButton(doc) {
+    const btn = doc.createElement('button');
+    btn.className = 'step-menu';
+    btn.type = 'button';
+    btn.setAttribute('aria-label', 'Edit step');
+    btn.textContent = '⋯';
+    return btn;
+  }
+
   function renderStepRow(step) {
     const doc = root.document;
     const li = doc.createElement('li');
@@ -45,6 +54,7 @@
       li.appendChild(num);
       li.appendChild(action);
       li.appendChild(target);
+      li.appendChild(_makeStepMenuButton(doc));
       return li;
     }
 
@@ -65,6 +75,7 @@
       li.appendChild(num);
       li.appendChild(action);
       li.appendChild(direction);
+      li.appendChild(_makeStepMenuButton(doc));
       return li;
     }
 
@@ -109,8 +120,11 @@
       li.appendChild(value);
       li.appendChild(into);
       li.appendChild(target);
+      li.appendChild(_makeStepMenuButton(doc));
       return li;
     }
+
+    li.setAttribute('data-action', String(step.action));
 
     const action = doc.createElement('span');
     action.className = 'step-action';
@@ -123,6 +137,7 @@
     li.appendChild(num);
     li.appendChild(action);
     li.appendChild(target);
+    li.appendChild(_makeStepMenuButton(doc));
     return li;
   }
 
@@ -288,6 +303,7 @@
     var li = doc.createElement('li');
     li.className = 'assertion-row';
     li.setAttribute('data-assertion-id', String(assertion.id));
+    li.setAttribute('data-anchor-step-id', String(assertion.anchor_step_id));
 
     var label = doc.createElement('span');
     label.className = 'assertion-label';
@@ -299,6 +315,7 @@
 
     li.appendChild(label);
     li.appendChild(text);
+    li.appendChild(_makeStepMenuButton(doc));
 
     var list = doc.getElementById('step-list');
     if (!list) return null;
@@ -315,6 +332,62 @@
     return li;
   }
 
+  function _closeAnyPopover(doc) {
+    const open = doc.querySelector('.step-menu-popover');
+    if (open && open.parentNode) open.parentNode.removeChild(open);
+  }
+
+  function _menuActionsForRow(li) {
+    if (li.classList.contains('assertion-row')) return [['edit-assertion-text', 'Edit text']];
+    const base = [['rename', 'Rename'], ['delete', 'Delete']];
+    if (li.getAttribute('data-action') === 'type') base.push(['edit-value', 'Edit value']);
+    return base;
+  }
+
+  function attachEditAffordances(options) {
+    const opts = options || {};
+    const doc = opts.document;
+    const sendWs = opts.sendWs;
+    if (!doc || typeof sendWs !== 'function') {
+      throw new Error('attachEditAffordances: requires {document, sendWs}');
+    }
+    const list = doc.getElementById('step-list');
+    if (!list) return;
+    if (list.getAttribute('data-edit-wired') === '1') return;
+    list.setAttribute('data-edit-wired', '1');
+
+    list.addEventListener('click', function (e) {
+      const menuBtn = e.target.closest && e.target.closest('button.step-menu');
+      if (menuBtn) {
+        const li = menuBtn.closest('li');
+        const wasOpen = !!doc.querySelector('.step-menu-popover');
+        _closeAnyPopover(doc);
+        if (wasOpen) return;
+        const pop = doc.createElement('div');
+        pop.className = 'step-menu-popover';
+        for (const pair of _menuActionsForRow(li)) {
+          const item = doc.createElement('button');
+          item.type = 'button';
+          item.className = 'menu-item';
+          item.setAttribute('data-edit-action', pair[0]);
+          item.textContent = pair[1];
+          pop.appendChild(item);
+        }
+        li.appendChild(pop);
+        return;
+      }
+      const item = e.target.closest && e.target.closest('.step-menu-popover .menu-item');
+      if (item) {
+        const li = item.closest('li');
+        const action = item.getAttribute('data-edit-action');
+        _closeAnyPopover(doc);
+        _dispatchEditAction(doc, li, action, sendWs);
+      }
+    });
+  }
+
+  function _dispatchEditAction(doc, li, action, sendWs) { /* rename/edit-value/edit-assertion-text: Task 5; delete: Task 6 */ }
+
   // Expose to the browser global.
   root.renderStepRow = renderStepRow;
   root.appendStep = appendStep;
@@ -322,6 +395,7 @@
   root.wireButtons = wireButtons;
   root.renderAssertionModal = renderAssertionModal;
   root.appendAssertionRow = appendAssertionRow;
+  root.attachEditAffordances = attachEditAffordances;
 
   // Expose to CommonJS (jest).
   if (typeof module !== 'undefined' && module.exports) {
@@ -332,6 +406,7 @@
       wireButtons: wireButtons,
       renderAssertionModal: renderAssertionModal,
       appendAssertionRow: appendAssertionRow,
+      attachEditAffordances: attachEditAffordances,
     };
   }
 

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -347,9 +347,11 @@
 
   function _menuActionsForRow(li) {
     if (li.classList.contains('assertion-row')) return [['edit-assertion-text', 'Edit text']];
-    const base = [['rename', 'Rename'], ['delete', 'Delete']];
-    if (li.getAttribute('data-action') === 'type') base.push(['edit-value', 'Edit value']);
-    return base;
+    // A `type` step's slug derives from its field, not a free-text name, and its
+    // row has no dedicated name span — so it offers Edit value (the meaningful
+    // typo-fix), not Rename. All other step rows offer Rename + Delete.
+    if (li.getAttribute('data-action') === 'type') return [['delete', 'Delete'], ['edit-value', 'Edit value']];
+    return [['rename', 'Rename'], ['delete', 'Delete']];
   }
 
   function attachEditAffordances(options) {
@@ -396,9 +398,9 @@
 
   function _editableSpan(li) {
     if (li.classList.contains('assertion-row')) return li.querySelector('.assertion-text');
-    if (li.getAttribute('data-action') === 'type') {
-      return li.querySelector('.step-target');
-    }
+    // Rename is not offered on `type` rows (see _menuActionsForRow), so only
+    // generic/gesture/swipe rows reach here: prefer the target span, falling
+    // back to the action verb for swipe rows (which have no target span).
     return li.querySelector('.step-target') || li.querySelector('.step-action');
   }
 
@@ -579,10 +581,16 @@
       const target = (pos > 0 ? steps[pos - 1] : null) || (pos + 1 < steps.length ? steps[pos + 1] : null);
       if (target) {
         const targetId = target.getAttribute('data-step-id');
+        // Move with a cursor so the assertions keep their original relative
+        // order under the new anchor (matches the apply-edits engine, which
+        // preserves array order). Inserting each at target.nextSibling would
+        // reverse them.
+        let cursor = target;
         anchored.forEach(function (a) {
           a.setAttribute('data-anchor-step-id', targetId);
-          if (target.nextSibling) list.insertBefore(a, target.nextSibling);
+          if (cursor.nextSibling) list.insertBefore(a, cursor.nextSibling);
           else list.appendChild(a);
+          cursor = a;
         });
       } else {
         anchored.forEach(function (a) { if (a.parentNode) a.parentNode.removeChild(a); });

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -347,10 +347,15 @@
 
   function _menuActionsForRow(li) {
     if (li.classList.contains('assertion-row')) return [['edit-assertion-text', 'Edit text']];
-    // A `type` step's slug derives from its field, not a free-text name, and its
-    // row has no dedicated name span — so it offers Edit value (the meaningful
-    // typo-fix), not Rename. All other step rows offer Rename + Delete.
-    if (li.getAttribute('data-action') === 'type') return [['delete', 'Delete'], ['edit-value', 'Edit value']];
+    const action = li.getAttribute('data-action');
+    // A `type` step's slug derives from its field, not a free-text name, and
+    // its row has no dedicated name span — so it offers Edit value (the
+    // meaningful typo-fix), not Rename.
+    if (action === 'type') return [['delete', 'Delete'], ['edit-value', 'Edit value']];
+    // A `swipe` row has no target/name span (renders "Swipe <direction>"), so
+    // Rename has nothing sensible to edit — Delete only, same rationale as type.
+    if (action === 'swipe') return [['delete', 'Delete']];
+    // tap / long_press / double_tap / press_button rows have a target span.
     return [['rename', 'Rename'], ['delete', 'Delete']];
   }
 

--- a/tools/recorder/web/style.css
+++ b/tools/recorder/web/style.css
@@ -100,3 +100,33 @@ button { padding: 8px 16px; }
 .assertion-text {
   color: #444;
 }
+
+/* Slice #28 — edit affordances */
+.step-row, .assertion-row { position: relative; }
+button.step-menu {
+  margin-left: auto; background: transparent; border: 0; cursor: pointer;
+  font-weight: 700; letter-spacing: 1px; opacity: 0.55; padding: 2px 8px;
+  border-radius: 5px; color: inherit;
+}
+button.step-menu:hover { opacity: 1; background: rgba(127,127,127,0.18); }
+.step-menu-popover {
+  position: absolute; right: 8px; top: 100%; z-index: 20; min-width: 170px;
+  background: #1f2433; color: #fff; border: 1px solid rgba(255,255,255,0.16);
+  border-radius: 7px; padding: 5px; box-shadow: 0 6px 18px rgba(0,0,0,0.35);
+}
+.step-menu-popover .menu-item {
+  display: block; width: 100%; text-align: left; background: transparent;
+  border: 0; color: inherit; padding: 7px 10px; border-radius: 5px;
+  cursor: pointer; font: inherit;
+}
+.step-menu-popover .menu-item:hover { background: rgba(255,255,255,0.12); }
+input.inline-edit { font: inherit; padding: 3px 6px; min-width: 12rem; }
+.delete-prompt .modal-panel h4 { margin: 0 0 8px; }
+.delete-warn {
+  color: #b45309; background: #fef3c7; border-radius: 6px;
+  padding: 6px 9px; font-size: 0.85rem; margin-bottom: 10px;
+}
+.delete-option {
+  display: flex; gap: 8px; align-items: center; padding: 7px 9px;
+  border: 1px solid rgba(127,127,127,0.3); border-radius: 6px; margin-bottom: 6px;
+}


### PR DESCRIPTION
## Summary

Recorder slice 7 (PRD #21): per-row edit affordances in the recorder GUI — **rename**, **delete**, **edit-value** (type steps), **edit-assertion-text** — recorded to an append-only `edits.jsonl` and replayed by the AI at Save via a pure reconcile engine.

Gated behind `MOBILE_AUTOMATOR_RECORDER=1` (gate-then-graduate; `gemini-extension.json` → `0.12.0-rc.6`, `[Unreleased]` not collapsed).

Design + plan (gitignored local working docs, repo convention):
- `docs/superpowers/specs/2026-05-16-recorder-28-edit-affordances-design.md`
- `docs/superpowers/plans/2026-05-16-recorder-28-edit-affordances.md`

## Locked decisions

- Always-visible per-row "⋯" menu, filtered by row type. Reorder / insert / type-change never surfaced.
- Delete: plain confirm when no anchored assertions; 3-option prompt (re-anchor **default** / cascade / cancel) when anchored. First-step delete + reanchor → next surviving step; no survivor → drop+report.
- One identity end-to-end: capture-time `step_id` slug (GUI rows = edit targets = assertion anchors). Zero change to slice #27.
- Append-only `edits.jsonl`; sidecar only records; AI reconciles at Save. Pure `apply-edits.js` is the executable spec the aware SKILL.md mirrors.
- GUI display-only on confirmation; `data-step-id` never rewritten client-side.

## What changed

- `tools/recorder/src/reconcile/apply-edits.js` — new pure chronological reconcile engine.
- `tools/recorder/src/session-handlers.js` — 4 WS edit handlers with boundary validation.
- `tools/recorder/web/app.js` + `style.css` — "⋯" menu, inline editors, delete prompt, WS confirmation branches + display-effect.
- `templates/mobile-automator-recorder/aware/SKILL.md` — step 2 reconcile spec rewritten for the 4 ops; `target_seq`/`reorder`/`annotate` purged; steps 5 & 8 tightened.
- Tests: `apply-edits`, `session-handlers-edits`, `web-edit-affordances` unit suites + `edit-affordances-flow` integration; stale artifacts fixture aligned.
- `gemini-extension.json` `0.12.0-rc.6`; CHANGELOG `Recorder Slice #7` entry under `[Unreleased]`.

A final holistic code review flagged only minor display-only issues (rename-on-type-row, multi-assertion reanchor ordering); both fixed in the last commit.

## Test plan

- [x] `npx jest` full suite — **359 passed, 53 suites**
- [x] `apply-edits` unit (12), `session-handlers-edits` (8), `web-edit-affordances` (22), `edit-affordances-flow` integration (2)
- [x] `tests/lint/*` + `ai-skill-ingestion` green (no Vale section-symbol, placeholders intact)
- [x] CI: extension-change detect, Vale prompt-hygiene, version-bump gate, test — all pass

Closes #28
Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)