### PR TITLE
Recorder slice #9: sensitive-input caution markers + Save confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The `/mobile-automator:record` recorder feature is being built incrementally per [PRD #21](https://github.com/sh3lan93/mobile-automator/issues/21). Slices land here under `[Unreleased]` and are gated behind `MOBILE_AUTOMATOR_RECORDER=1` until the v0.12.0 graduation cut. Entries collapse into a single coherent v0.12.0 note when the feature graduates.
 
+### Recorder Slice #9 — Sensitive-input caution markers + Save-time confirmation (#30)
+
+- GUI: `type` step rows where the underlying event has `sensitive: true` render an inline ⚠ `.caution` span with the tooltip *"Sensitive input. Click to edit value before Save."* placed between the masked value and the `into` span.
+- GUI: on Save with one or more flagged steps still holding their captured literal, an inline `#save-sensitive-confirm` panel appears in `<footer>` (`role="alert"`, `[data-action="save-anyway"|"cancel"]`) with the count — *"N sensitive step(s) captured as literal value(s). Save anyway?"* Cancel suppresses the WS frame; Save anyway sends `{type:'save'}`. The handler is idempotent against rapid double-click.
+- GUI: editing a flagged step's value via the existing ⋯ → **Edit value** affordance (slice #7) clears its caution marker. Intent-based — the act of opening the editor is the user's affirmation, independent of whether the new string differs from the literal.
+- Server: `startHttpServer` accepts an `allowSensitiveInput` option and threads it into the `/api/mode` JSON payload as `allow_sensitive_input`. Piggybacks on the existing endpoint instead of adding a sibling.
+- Flag: `--allow-sensitive-input` (already declared in `tools/recorder/src/index.js` and forwarded by `commands/mobile-automator/record.toml`) reaches the GUI via the `/api/mode` payload and suppresses both the markers and the Save-time confirmation. Bullet-masking from slice #35 still applies — that's an orthogonal "never render the literal in the DOM" guarantee.
+- Docs: `README.md` and `tools/recorder/README.md` document the UX, the `${env.VAR}` runtime-substitution convention being user-owned, and the `--allow-sensitive-input` escape hatch.
+- Tests: `web-sensitive-markers`, `web-save-sensitive-confirm` unit suites + extended `http-server-mode` payload assertions.
+
 ### Recorder Slice #8 — Agnostic mode emit + semantic action detection (#29)
 
 - Sidecar: `runScriptedSession` reads `mobile-automator/config.json` mode at startup (was hardcoded `platform-aware`); pre-field configs still default to `platform-aware`.

--- a/README.md
+++ b/README.md
@@ -464,6 +464,19 @@ The command launches a small local sidecar that hosts a browser-based recorder G
 - **Platform-aware mode only** — the agnostic recorder template lands in a later slice.
 - Browser-disconnect tolerance (60-second reconnect window) and clean teardown on Ctrl+C.
 
+### Sensitive input handling
+
+The recorder detects password fields (Android `secureTextEntry` / iOS `XCUIElementTypeSecureTextField`) and marks captured `type` events with `sensitive: true`. In the GUI:
+
+- The typed value is **masked with bullet characters** in the step list, never the literal — even before Save.
+- A **⚠ caution marker** sits next to the masked value with the tooltip *"Sensitive input. Click to edit value before Save."*
+- On **Save & Generate**, if any flagged step still holds its captured literal, the GUI prompts inline: *"N sensitive step(s) captured as literal value(s). Save anyway?"* You must confirm or cancel before the scenario is generated.
+- Clicking **Edit value** on a flagged step's ⋯ menu clears its caution marker. The typical replacement is `${env.PASSWORD}` (or any `${env.VAR}`) syntax.
+
+`${env.VAR}` is a **runtime convention enforced by the executor**, not a schema construct — the recorder neither validates nor substitutes references; whether your test runner resolves `${env.PASSWORD}` at replay time is your responsibility.
+
+For users with intentionally-hardcoded test fixtures, `--allow-sensitive-input` suppresses both the marker and the Save-time prompt (the value-masking is unaffected — that always applies once `sensitive: true` reaches the renderer).
+
 ### What does NOT work yet
 
 These are tracked as separate slices under [PRD #21](https://github.com/sh3lan93/mobile-automator/issues/21):
@@ -475,7 +488,6 @@ These are tracked as separate slices under [PRD #21](https://github.com/sh3lan93
 - Authoring assertions from the GUI (Add Assertion modal + AI classification) — [#27](https://github.com/sh3lan93/mobile-automator/issues/27).
 - Edit affordances (rename / delete / edit-value / edit-assertion-text) — [#28](https://github.com/sh3lan93/mobile-automator/issues/28).
 - Platform-agnostic recorder + semantic-action detection — [#29](https://github.com/sh3lan93/mobile-automator/issues/29).
-- Sensitive-input caution markers + Save-time confirmation — [#30](https://github.com/sh3lan93/mobile-automator/issues/30).
 - Failure modes (device disconnect / app crash / browser disconnect beyond the 60s window) — [#31](https://github.com/sh3lan93/mobile-automator/issues/31).
 - `--overwrite` (replace an existing scenario) and `--verify` (replay-on-save) flags — [#32](https://github.com/sh3lan93/mobile-automator/issues/32).
 - C3 protocol listener + spec + B-mode fallback — [#33](https://github.com/sh3lan93/mobile-automator/issues/33).

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.12.0-rc.7",
+  "version": "0.12.0-rc.8",
   "description": "Mobile QA automation with test generation and execution using mobile-mcp",
   "author": "Mohamed Shalan",
   "repository": "https://github.com/sh3lan93/mobile-automator",

--- a/tests/unit/recorder/http-server-mode.test.js
+++ b/tests/unit/recorder/http-server-mode.test.js
@@ -24,18 +24,32 @@ describe('GET /api/mode', () => {
   });
   afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
 
-  test('returns the session mode as JSON', async () => {
+  test('returns the session mode as JSON (allow_sensitive_input defaults to false)', async () => {
     const srv = await startHttpServer({ projectRoot: root, scenarioId: 's', mode: 'platform-agnostic' });
     const res = await get(srv.port, '/api/mode');
     expect(res.status).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ mode: 'platform-agnostic' });
+    expect(JSON.parse(res.body)).toEqual({ mode: 'platform-agnostic', allow_sensitive_input: false });
     await srv.close();
   });
 
-  test('defaults to platform-aware when mode not supplied', async () => {
+  test('defaults to platform-aware when mode not supplied (allow_sensitive_input defaults to false)', async () => {
     const srv = await startHttpServer({ projectRoot: root, scenarioId: 's' });
     const res = await get(srv.port, '/api/mode');
-    expect(JSON.parse(res.body)).toEqual({ mode: 'platform-aware' });
+    expect(JSON.parse(res.body)).toEqual({ mode: 'platform-aware', allow_sensitive_input: false });
+    await srv.close();
+  });
+
+  test('reflects allowSensitiveInput=true in the payload (slice #9)', async () => {
+    const srv = await startHttpServer({ projectRoot: root, scenarioId: 's', allowSensitiveInput: true });
+    const res = await get(srv.port, '/api/mode');
+    expect(JSON.parse(res.body)).toEqual({ mode: 'platform-aware', allow_sensitive_input: true });
+    await srv.close();
+  });
+
+  test('coerces truthy/falsy allowSensitiveInput to a boolean', async () => {
+    const srv = await startHttpServer({ projectRoot: root, scenarioId: 's', allowSensitiveInput: 1 });
+    const res = await get(srv.port, '/api/mode');
+    expect(JSON.parse(res.body).allow_sensitive_input).toBe(true);
     await srv.close();
   });
 });

--- a/tests/unit/recorder/web-save-sensitive-confirm.test.js
+++ b/tests/unit/recorder/web-save-sensitive-confirm.test.js
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+// Mark the environment so app.js does not auto-connect a real WebSocket.
+window.__RECORDER_TEST__ = true;
+
+const path = require('path');
+const appPath = path.resolve(__dirname, '../../../tools/recorder/web/app.js');
+
+// eslint-disable-next-line import/no-dynamic-require
+const app = require(appPath);
+
+function setupDom() {
+  document.body.innerHTML = `
+    <ul id="step-list"></ul>
+    <footer>
+      <button id="btn-cancel"></button>
+      <button id="btn-save"></button>
+    </footer>
+  `;
+}
+
+function clickSave() {
+  document.getElementById('btn-save').dispatchEvent(new window.Event('click'));
+}
+
+describe('recorder GUI: Save-time sensitive-input confirmation (slice #9)', () => {
+  beforeEach(() => {
+    setupDom();
+    app._resetSensitiveState();
+  });
+
+  test('Save with zero sensitive steps sends {type:"save"} immediately', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+
+    clickSave();
+    expect(sent).toEqual([{ type: 'save' }]);
+    expect(document.getElementById('save-sensitive-confirm')).toBeNull();
+  });
+
+  test('Save with one flagged sensitive step shows inline confirmation and suppresses save', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({
+      id: 'type_pw',
+      index: 1,
+      action: 'type',
+      value: 'secret',
+      field_label: 'Password',
+      sensitive: true,
+    });
+
+    clickSave();
+
+    const confirm = document.getElementById('save-sensitive-confirm');
+    expect(confirm).not.toBeNull();
+    expect(confirm.getAttribute('role')).toBe('alert');
+    expect(confirm.textContent).toContain('1 sensitive step captured as literal value. Save anyway?');
+    expect(sent).toEqual([]);
+  });
+
+  test('N=3 flagged sensitive steps produces plural text with the number', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    for (let i = 1; i <= 3; i++) {
+      app.appendStep({
+        id: 'type_pw' + i,
+        index: i,
+        action: 'type',
+        value: 'x',
+        field_label: 'Password',
+        sensitive: true,
+      });
+    }
+
+    clickSave();
+
+    const confirm = document.getElementById('save-sensitive-confirm');
+    expect(confirm).not.toBeNull();
+    expect(confirm.textContent).toContain('3 sensitive steps captured as literal values. Save anyway?');
+    expect(sent).toEqual([]);
+  });
+
+  test('"Save anyway" button sends {type:"save"} and removes the prompt', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'type_pw', index: 1, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
+    clickSave();
+
+    const confirm = document.getElementById('save-sensitive-confirm');
+    const saveAnyway = confirm.querySelector('[data-action="save-anyway"]');
+    expect(saveAnyway).not.toBeNull();
+    saveAnyway.dispatchEvent(new window.Event('click'));
+
+    expect(sent).toEqual([{ type: 'save' }]);
+    expect(document.getElementById('save-sensitive-confirm')).toBeNull();
+  });
+
+  test('"Cancel" button removes the prompt and does NOT send anything', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'type_pw', index: 1, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
+    clickSave();
+
+    const confirm = document.getElementById('save-sensitive-confirm');
+    const cancel = confirm.querySelector('[data-action="cancel"]');
+    expect(cancel).not.toBeNull();
+    cancel.dispatchEvent(new window.Event('click'));
+
+    expect(sent).toEqual([]);
+    expect(document.getElementById('save-sensitive-confirm')).toBeNull();
+  });
+
+  test('--allow-sensitive-input bypasses the prompt even with flagged steps', () => {
+    app._setAllowSensitiveInput(true);
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'type_pw', index: 1, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
+
+    clickSave();
+
+    expect(sent).toEqual([{ type: 'save' }]);
+    expect(document.getElementById('save-sensitive-confirm')).toBeNull();
+  });
+
+  test('A sensitive step edited via applyValueEdited no longer counts at Save time', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'type_pw', index: 1, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
+    app.applyValueEdited(document, { step_id: 'type_pw', new_value: '${env.PASSWORD}' });
+
+    clickSave();
+
+    expect(sent).toEqual([{ type: 'save' }]);
+    expect(document.getElementById('save-sensitive-confirm')).toBeNull();
+  });
+
+  test('Save clicked twice while the prompt is open does not duplicate the prompt', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'type_pw', index: 1, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
+
+    clickSave();
+    clickSave();
+
+    expect(document.querySelectorAll('#save-sensitive-confirm').length).toBe(1);
+    expect(sent).toEqual([]);
+  });
+
+  test('Mixed sensitive + non-sensitive: count reflects only flagged steps', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'type_email', index: 2, action: 'type', value: 'a@b.com', field_label: 'Email', sensitive: false });
+    app.appendStep({ id: 'type_pw', index: 3, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
+
+    clickSave();
+
+    const confirm = document.getElementById('save-sensitive-confirm');
+    expect(confirm).not.toBeNull();
+    expect(confirm.textContent).toContain('1 sensitive step captured as literal value. Save anyway?');
+  });
+
+  test('Deleting the only sensitive step causes Save to be direct', () => {
+    const sent = [];
+    app.wireButtons({ document, sendWs: (m) => sent.push(m) });
+
+    app.appendStep({ id: 'type_pw', index: 1, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
+    app.applyStepDeleted(document, { step_id: 'type_pw', assertion_policy: 'none' });
+
+    clickSave();
+
+    expect(sent).toEqual([{ type: 'save' }]);
+    expect(document.getElementById('save-sensitive-confirm')).toBeNull();
+  });
+});

--- a/tests/unit/recorder/web-sensitive-markers.test.js
+++ b/tests/unit/recorder/web-sensitive-markers.test.js
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+// Mark the environment so app.js does not auto-connect a real WebSocket.
+window.__RECORDER_TEST__ = true;
+
+const path = require('path');
+const appPath = path.resolve(__dirname, '../../../tools/recorder/web/app.js');
+
+// eslint-disable-next-line import/no-dynamic-require
+const app = require(appPath);
+
+const CAUTION_TOOLTIP = 'Sensitive input. Click to edit value before Save.';
+
+describe('recorder GUI: sensitive-input caution markers (slice #9)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<ul id="step-list"></ul>';
+    app._resetSensitiveState();
+  });
+
+  test('renders a .caution span with the spec tooltip for sensitive type steps', () => {
+    const li = app.renderStepRow({
+      id: 'type_password',
+      index: 1,
+      action: 'type',
+      value: 'p4ssw0rd!',
+      field_label: 'Password',
+      sensitive: true,
+    });
+
+    const caution = li.querySelector('.caution');
+    expect(caution).not.toBeNull();
+    expect(caution.textContent).toBe('⚠');
+    expect(caution.getAttribute('title')).toBe(CAUTION_TOOLTIP);
+    expect(caution.getAttribute('aria-label')).toBe(CAUTION_TOOLTIP);
+    expect(caution.getAttribute('role')).toBe('img');
+  });
+
+  test('does NOT render a caution span when sensitive is false', () => {
+    const li = app.renderStepRow({
+      id: 'type_email',
+      index: 2,
+      action: 'type',
+      value: 'a@b.com',
+      field_label: 'Email',
+      sensitive: false,
+    });
+    expect(li.querySelector('.caution')).toBeNull();
+  });
+
+  test('does NOT render a caution span when --allow-sensitive-input is set', () => {
+    app._setAllowSensitiveInput(true);
+    const li = app.renderStepRow({
+      id: 'type_password',
+      index: 3,
+      action: 'type',
+      value: 'p4ssw0rd!',
+      field_label: 'Password',
+      sensitive: true,
+    });
+    expect(li.querySelector('.caution')).toBeNull();
+  });
+
+  test('caution span sits between .step-value and .step-into for visual association', () => {
+    const li = app.renderStepRow({
+      id: 'type_password',
+      index: 4,
+      action: 'type',
+      value: 'p4ss!',
+      field_label: 'Password',
+      sensitive: true,
+    });
+
+    const spans = [...li.children];
+    const valueIdx = spans.findIndex((el) => el.classList && el.classList.contains('step-value'));
+    const cautionIdx = spans.findIndex((el) => el.classList && el.classList.contains('caution'));
+    const intoIdx = spans.findIndex((el) => el.classList && el.classList.contains('step-into'));
+
+    expect(valueIdx).toBeGreaterThanOrEqual(0);
+    expect(cautionIdx).toBe(valueIdx + 1);
+    expect(intoIdx).toBe(cautionIdx + 1);
+  });
+
+  test('applyValueEdited removes the caution span for the edited step', () => {
+    app.appendStep({
+      id: 'type_password',
+      index: 1,
+      action: 'type',
+      value: 'p4ss!',
+      field_label: 'Password',
+      sensitive: true,
+    });
+    const li = document.querySelector('[data-step-id="type_password"]');
+    expect(li.querySelector('.caution')).not.toBeNull();
+
+    app.applyValueEdited(document, { step_id: 'type_password', new_value: '${env.PASSWORD}' });
+
+    expect(li.querySelector('.caution')).toBeNull();
+  });
+
+  test('applyValueEdited does not affect caution on a different (still-flagged) step', () => {
+    app.appendStep({ id: 'type_pw1', index: 1, action: 'type', value: 'a', field_label: 'Password', sensitive: true });
+    app.appendStep({ id: 'type_pw2', index: 2, action: 'type', value: 'b', field_label: 'Password', sensitive: true });
+
+    app.applyValueEdited(document, { step_id: 'type_pw1', new_value: '${env.A}' });
+
+    const pw1 = document.querySelector('[data-step-id="type_pw1"]');
+    const pw2 = document.querySelector('[data-step-id="type_pw2"]');
+    expect(pw1.querySelector('.caution')).toBeNull();
+    expect(pw2.querySelector('.caution')).not.toBeNull();
+  });
+
+  test('applyValueEdited rewrites the value span literally (no bullets after edit)', () => {
+    app.appendStep({
+      id: 'type_password',
+      index: 1,
+      action: 'type',
+      value: 'p4ss!',
+      field_label: 'Password',
+      sensitive: true,
+    });
+    app.applyValueEdited(document, { step_id: 'type_password', new_value: '${env.PASSWORD}' });
+
+    const li = document.querySelector('[data-step-id="type_password"]');
+    const valueSpan = li.querySelector('.step-value');
+    expect(valueSpan.textContent).toBe('"${env.PASSWORD}"');
+    expect(valueSpan.textContent).not.toMatch(/•/);
+  });
+
+  test('edit then re-edit to the original literal still leaves caution cleared (intent-based)', () => {
+    app.appendStep({
+      id: 'type_password',
+      index: 1,
+      action: 'type',
+      value: 'p4ss!',
+      field_label: 'Password',
+      sensitive: true,
+    });
+    app.applyValueEdited(document, { step_id: 'type_password', new_value: '${env.X}' });
+    app.applyValueEdited(document, { step_id: 'type_password', new_value: 'p4ss!' });
+
+    const li = document.querySelector('[data-step-id="type_password"]');
+    expect(li.querySelector('.caution')).toBeNull();
+  });
+
+  test('renderStepRow on a sensitive step is idempotent re-rendering does not duplicate caution spans', () => {
+    // The second render replaces a fresh row (callers control mounting); regression
+    // guard against the future bug of accidentally appending two cautions.
+    const li1 = app.renderStepRow({ id: 'type_pw', index: 1, action: 'type', value: 'x', field_label: 'Password', sensitive: true });
+    const li2 = app.renderStepRow({ id: 'type_pw', index: 1, action: 'type', value: 'x', field_label: 'Password', sensitive: true });
+    expect(li1.querySelectorAll('.caution').length).toBe(1);
+    expect(li2.querySelectorAll('.caution').length).toBe(1);
+  });
+
+  test('applyValueEdited on a non-sensitive step is a no-op for caution UI', () => {
+    app.appendStep({ id: 'type_email', index: 1, action: 'type', value: 'a@b.com', field_label: 'Email', sensitive: false });
+    expect(document.querySelector('[data-step-id="type_email"] .caution')).toBeNull();
+
+    app.applyValueEdited(document, { step_id: 'type_email', new_value: 'c@d.com' });
+
+    expect(document.querySelector('[data-step-id="type_email"] .caution')).toBeNull();
+  });
+});

--- a/tools/recorder/README.md
+++ b/tools/recorder/README.md
@@ -62,8 +62,21 @@ The sidecar coordinates several deep modules under `src/`:
 | `capture/keyboard-region.js` | Identifies whether a tap landed inside the on-screen keyboard subtree. Android-only for now; iOS keyboard region detection is deferred. |
 | `coalesce/gesture-classifier.js` | Coalesces raw down/move/up events into the v1 gesture vocabulary (tap, long-press, double-tap, swipe). |
 | `coalesce/type-buffer.js` | Coalesces sequential keyboard taps into a single `type` event when focus leaves the field, on Enter, on silence-timeout, or at session end. |
-| `server/http-server.js` | Serves the recorder GUI over HTTP. |
+| `server/http-server.js` | Serves the recorder GUI over HTTP. Exposes `GET /api/mode` returning `{ mode, allow_sensitive_input }` (slice #9). |
 | `server/ws-protocol.js` | Streams events to the GUI and receives Save/Cancel commands. |
+
+## Sensitive input handling (slice #9)
+
+When `capture/focus-detector.js` flags a focused field as sensitive, `coalesce/type-buffer.js` carries `sensitive: true` through to the emitted `type` event. The GUI then:
+
+1. **Masks** the value in the step list with bullet characters (`web/app.js` render path, slice #35).
+2. **Tracks** the step in an in-memory `Map<step_id, dirty:boolean>` and renders a ⚠ `.caution` span between the value and `into` spans.
+3. **Gates Save**: on `#btn-save` click, counts entries where `dirty === true`. If non-zero (and `_allowSensitiveInput` is false), renders `#save-sensitive-confirm` inline in `<footer>` instead of sending `{type:'save'}`.
+4. **Clears on edit**: `applyValueEdited` flips the dirty flag to `false` and removes the caution span. This is **intent-based** — the act of opening edit-value is the user's affirmation, independent of whether the new string differs from the captured literal. Edit-then-retype-the-same-literal still clears the caution.
+
+`--allow-sensitive-input` (CLI flag declared in `src/index.js`, forwarded by `commands/mobile-automator/record.toml`) reaches the GUI via the `/api/mode` payload's `allow_sensitive_input` boolean and suppresses both the dirty-tracking AND the inline confirmation. The bullet-masking from slice #35 still applies — that's an orthogonal "never render the literal in the DOM" guarantee.
+
+The `${env.VAR}` syntax users typically substitute is a **runtime convention enforced by the executor**, not a schema construct. The recorder neither validates nor resolves it.
 
 Test fixtures live under `tests/fixtures/recorder/`:
 

--- a/tools/recorder/src/server/http-server.js
+++ b/tools/recorder/src/server/http-server.js
@@ -32,12 +32,12 @@ function serveScreenshot(req, res, screenshotsDir) {
   return true;
 }
 
-function serveApiMode(req, res, mode) {
+function serveApiMode(req, res, mode, allowSensitiveInput) {
   const urlPath = req.url.split('?')[0];
   if (urlPath !== '/api/mode') return false;
   res.statusCode = 200;
   res.setHeader('Content-Type', 'application/json');
-  res.end(JSON.stringify({ mode }));
+  res.end(JSON.stringify({ mode, allow_sensitive_input: !!allowSensitiveInput }));
   return true;
 }
 
@@ -55,11 +55,11 @@ function serveStatic(req, res) {
   fs.createReadStream(filePath).pipe(res);
 }
 
-async function startHttpServer({ projectRoot, scenarioId, requestHandler = null, mode = 'platform-aware' }) {
+async function startHttpServer({ projectRoot, scenarioId, requestHandler = null, mode = 'platform-aware', allowSensitiveInput = false }) {
   const screenshotsDir = path.join(projectRoot, 'mobile-automator', '.recorder', scenarioId, 'screenshots');
   const server = http.createServer((req, res) => {
     if (serveScreenshot(req, res, screenshotsDir)) return;
-    if (serveApiMode(req, res, mode)) return;
+    if (serveApiMode(req, res, mode, allowSensitiveInput)) return;
     if (requestHandler) { try { if (requestHandler(req, res)) return; } catch (e) { /* fall through */ } }
     serveStatic(req, res);
   });

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -241,7 +241,27 @@
         sendWs(message);
       });
     }
-    bindOnce('btn-save', { type: 'save' });
+
+    function bindSaveOnce() {
+      const btn = doc.getElementById('btn-save');
+      if (!btn) return;
+      if (btn.getAttribute('data-recorder-wired') === '1') return;
+      btn.setAttribute('data-recorder-wired', '1');
+      btn.addEventListener('click', function () {
+        // Slice #9: count sensitive steps still holding their captured literal.
+        // _allowSensitiveInput suppresses the gate entirely; an empty map (zero
+        // sensitive steps OR all already edited) means the legacy direct-save
+        // path is taken.
+        if (_allowSensitiveInput) { sendWs({ type: 'save' }); return; }
+        let pending = 0;
+        _sensitiveDirty.forEach(function (v) { if (v === true) pending++; });
+        if (pending === 0) { sendWs({ type: 'save' }); return; }
+        // Idempotent: if the prompt is already open, do nothing.
+        if (doc.getElementById('save-sensitive-confirm')) return;
+        _renderSaveSensitiveConfirm(doc, pending, function () { sendWs({ type: 'save' }); });
+      });
+    }
+    bindSaveOnce();
     bindOnce('btn-cancel', { type: 'cancel' });
 
     function bindAddAssertion() {
@@ -668,6 +688,44 @@
     // Slice #9: drop the dirty entry so a subsequent Save doesn't count the
     // deleted step as still-pending.
     _sensitiveDirty.delete(p.step_id);
+  }
+
+  function _renderSaveSensitiveConfirm(doc, pending, onSaveAnyway) {
+    const footer = doc.querySelector('footer');
+    if (!footer) return null;
+    const panel = doc.createElement('div');
+    panel.id = 'save-sensitive-confirm';
+    panel.setAttribute('role', 'alert');
+
+    const noun = pending === 1 ? 'sensitive step' : 'sensitive steps';
+    const tail = pending === 1 ? 'as literal value.' : 'as literal values.';
+    const message = doc.createElement('span');
+    message.textContent = pending + ' ' + noun + ' captured ' + tail + ' Save anyway?';
+    panel.appendChild(message);
+
+    const saveAnyway = doc.createElement('button');
+    saveAnyway.type = 'button';
+    saveAnyway.setAttribute('data-action', 'save-anyway');
+    saveAnyway.textContent = 'Save anyway';
+    saveAnyway.addEventListener('click', function () {
+      if (panel.parentNode) panel.parentNode.removeChild(panel);
+      onSaveAnyway();
+    });
+
+    const cancel = doc.createElement('button');
+    cancel.type = 'button';
+    cancel.setAttribute('data-action', 'cancel');
+    cancel.textContent = 'Cancel';
+    cancel.addEventListener('click', function () {
+      if (panel.parentNode) panel.parentNode.removeChild(panel);
+    });
+
+    panel.appendChild(saveAnyway);
+    panel.appendChild(cancel);
+    // Prepend so the inline alert sits to the left of the existing buttons.
+    if (footer.firstChild) footer.insertBefore(panel, footer.firstChild);
+    else footer.appendChild(panel);
+    return panel;
   }
 
   function _setMode(m) {

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -13,6 +13,15 @@
   var latestStepId = null;
   var _mode = 'platform-aware';
 
+  // Slice #9: per-step "still holds its captured literal" tracker.
+  // Map<step_id, true> — true means the caution still applies. Cleared on
+  // edit-value (intent-based: the act of editing is the user's affirmation,
+  // independent of whether the new string differs from the captured literal).
+  var _sensitiveDirty = new Map();
+  var _allowSensitiveInput = false;
+
+  var CAUTION_TOOLTIP = 'Sensitive input. Click to edit value before Save.';
+
   var AGNOSTIC_BANNER_TEXT =
     "Recording in agnostic mode. press_back / grant_permission / deny_permission auto-detected; click 'Mark as dismiss_keyboard' on a tap step to mark it manually.";
 
@@ -84,12 +93,11 @@
     }
 
     if (step && step.action === 'type') {
-      // Render: <num>. Type "<value>" into "<field_label>"
-      // Slice #35 review fix: when step.sensitive === true the value is
-      // masked here in the GUI render path with bullet characters of
-      // matching length. The full sensitive-input UX (caution badges,
-      // Save-time confirmation modal, --allow-sensitive-input flag, and
-      // on-disk redaction) still lands in slice #30.
+      // Render: <num>. Type "<value>" [⚠] into "<field_label>"
+      // Slice #35 masks sensitive values with bullets in the rendered DOM.
+      // Slice #9 adds the ⚠ caution span between the value and "into" spans
+      // (suppressed when _allowSensitiveInput is true) and tracks the step in
+      // _sensitiveDirty so the Save handler can prompt before sending.
       li.setAttribute('data-action', 'type');
 
       const action = doc.createElement('span');
@@ -97,8 +105,9 @@
       action.textContent = 'Type';
 
       const rawValue = step.value == null ? '' : String(step.value);
+      const isSensitive = step.sensitive === true;
       let displayValue;
-      if (step.sensitive === true) {
+      if (isSensitive) {
         // Cap the bullet count so a degenerate (very long or zero-length)
         // value renders sensibly. Min 1 bullet so an empty sensitive value
         // doesn't betray its zero length.
@@ -122,6 +131,16 @@
       li.appendChild(num);
       li.appendChild(action);
       li.appendChild(value);
+      if (isSensitive && !_allowSensitiveInput) {
+        _sensitiveDirty.set(step.id, true);
+        const caution = doc.createElement('span');
+        caution.className = 'caution';
+        caution.setAttribute('role', 'img');
+        caution.setAttribute('aria-label', CAUTION_TOOLTIP);
+        caution.setAttribute('title', CAUTION_TOOLTIP);
+        caution.textContent = '⚠';
+        li.appendChild(caution);
+      }
       li.appendChild(into);
       li.appendChild(target);
       li.appendChild(_makeStepMenuButton(doc));
@@ -599,6 +618,14 @@
     if (!li) return;
     const span = li.querySelector('.step-value');
     if (span) span.textContent = '"' + p.new_value + '"';
+    // Slice #9: the act of editing is the user's affirmation that they own
+    // this value (typical replacement is "${env.PASSWORD}"). Drop the caution
+    // marker and the dirty flag so the Save handler stops counting this step.
+    if (_sensitiveDirty.get(p.step_id) === true) {
+      _sensitiveDirty.set(p.step_id, false);
+      const caution = li.querySelector('.caution');
+      if (caution && caution.parentNode) caution.parentNode.removeChild(caution);
+    }
   }
 
   function applyAssertionTextEdited(doc, p) {
@@ -638,10 +665,22 @@
       }
     }
     if (li.parentNode) li.parentNode.removeChild(li);
+    // Slice #9: drop the dirty entry so a subsequent Save doesn't count the
+    // deleted step as still-pending.
+    _sensitiveDirty.delete(p.step_id);
   }
 
   function _setMode(m) {
     _mode = m;
+  }
+
+  function _setAllowSensitiveInput(v) {
+    _allowSensitiveInput = !!v;
+  }
+
+  function _resetSensitiveState() {
+    _sensitiveDirty = new Map();
+    _allowSensitiveInput = false;
   }
 
   // Expose to the browser global.
@@ -659,6 +698,8 @@
   root.applyStepMarkedSemantic = applyStepMarkedSemantic;
   root.applyModeBanner = applyModeBanner;
   root._setMode = _setMode;
+  root._setAllowSensitiveInput = _setAllowSensitiveInput;
+  root._resetSensitiveState = _resetSensitiveState;
 
   // Expose to CommonJS (jest).
   if (typeof module !== 'undefined' && module.exports) {
@@ -677,6 +718,8 @@
       applyStepMarkedSemantic: applyStepMarkedSemantic,
       applyModeBanner: applyModeBanner,
       _setMode: _setMode,
+      _setAllowSensitiveInput: _setAllowSensitiveInput,
+      _resetSensitiveState: _resetSensitiveState,
     };
   }
 
@@ -727,9 +770,10 @@
       // Fetch the session mode and show the banner if agnostic.
       fetch('/api/mode').then(function (res) { return res.json(); }).then(function (data) {
         if (data && data.mode) _setMode(data.mode);
+        if (data) _setAllowSensitiveInput(!!data.allow_sensitive_input);
         applyModeBanner(document);
       }).catch(function () {
-        // Failed fetch — leave _mode as 'platform-aware', banner stays hidden.
+        // Failed fetch — leave defaults (platform-aware, allow_sensitive_input=false).
       });
 
       wireButtons({

--- a/tools/recorder/web/style.css
+++ b/tools/recorder/web/style.css
@@ -5,7 +5,9 @@ header h1 { margin: 0; flex: 1; }
 main { padding: 16px; }
 #step-list { list-style: none; padding: 0; margin: 0; }
 #step-list li { padding: 8px; border-bottom: 1px solid #eee; display: flex; align-items: center; gap: 8px; }
-.step-row .caution { color: #d4a72c; }
+.step-row .caution { color: #d4a72c; cursor: help; font-size: 1.05em; }
+#save-sensitive-confirm { background: #fef3c7; border: 1px solid #d4a72c; border-radius: 6px; padding: 8px 12px; margin-right: auto; display: flex; gap: 8px; align-items: center; font-size: 0.9rem; }
+#save-sensitive-confirm button { padding: 4px 10px; font-size: 0.85rem; }
 footer { padding: 12px 16px; border-top: 1px solid #ddd; display: flex; gap: 8px; }
 button { padding: 8px 16px; }
 .modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; }


### PR DESCRIPTION
## Summary

Implements [PRD #21 / Q13-B](https://github.com/sh3lan93/mobile-automator/issues/21): the recorder captures sensitive input values as-is; the user is the sole authority on replacement. This slice closes the loop with three user-facing affordances and one CLI escape hatch:

- ⚠ caution badge on sensitive `type` step rows (between the masked value and the "into" span).
- Save-time inline confirmation in `<footer>`: *"N sensitive step(s) captured as literal value(s). Save anyway?"* — fires only when one or more flagged steps still hold their captured literal.
- Editing a flagged step via the existing ⋯ → **Edit value** affordance ([Recorder Slice 7](https://github.com/sh3lan93/mobile-automator/issues/28)) clears its caution. **Intent-based** — the act of opening the editor is the user's affirmation, independent of whether the new string differs from the literal.
- `--allow-sensitive-input` (declared at `tools/recorder/src/index.js:20`, forwarded by `commands/mobile-automator/record.toml:34`) reaches the GUI via `/api/mode.allow_sensitive_input` and suppresses both the markers and the prompt. Bullet-masking from [Recorder Slice 2](https://github.com/sh3lan93/mobile-automator/issues/35) is unaffected — that is an orthogonal "never render the literal in the DOM" guarantee.

`gemini-extension.json` bumped to `0.12.0-rc.8` per the experimental-gate convention.

## Commits

1. `test(recorder)` — failing tests pin the contract (TDD red).
2. `feat(recorder)` — server: `/api/mode` payload extended with `allow_sensitive_input` boolean.
3. `feat(recorder)` — GUI: caution markers + dirty-map + edit-clears + CSS.
4. `feat(recorder)` — GUI: inline Save-time confirmation with pluralized count + idempotent against double-click.
5. `docs(recorder)` — `README.md`, `tools/recorder/README.md`, `CHANGELOG.md`.
6. `chore` — `0.12.0-rc.7` → `0.12.0-rc.8`.

## Design decisions worth flagging

- **`Map<step_id, dirty:bool>` over value-comparison.** The bullet-masking already strips the literal from the DOM, so there is no original literal to compare against. More importantly, Q13-B is about user *intent* — edit-then-retype-the-same-literal should still clear the caution. The Map captures intent; a string compare would capture coincidence.
- **Extended `/api/mode` rather than a sibling endpoint.** The GUI already fetches `/api/mode` once on boot — piggybacking avoids a second round trip and a second swallow-the-error block. If a future slice adds a third config flag, a rename to `/api/config` is worth a follow-up.
- **Scope discipline.** The sidecar `main()` bootstrap that calls `startHttpServer({allowSensitiveInput})` is not in this PR — the recorder's spawn site materializes in a later slice. This PR ships the contract (option-passing + payload field + tests) and stops short.

## Test plan

- [x] `npx jest tests/unit/recorder/web-sensitive-markers.test.js` — 10 new tests (caution render, edit-clears, idempotency, `--allow-sensitive-input` suppression, edge cases).
- [x] `npx jest tests/unit/recorder/web-save-sensitive-confirm.test.js` — 10 new tests (Save-flow gate, pluralization, double-click idempotency, mixed sensitive + non-sensitive, delete-clears).
- [x] `npx jest tests/unit/recorder/http-server-mode.test.js` — extended payload assertions + 2 new tests.
- [x] `npm test` — 422/422 (was 400, +22 new).
- [x] Manual smoke: serve `tools/recorder/web/` statically, render two type steps (one sensitive), click Save, verify inline confirmation; click Edit value on the sensitive step, submit `\${env.PASSWORD}`, click Save, verify direct save.

Closes #30
Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)