### PR TITLE
fix(recorder): unify tap target quote-wrap contract across render + rename (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] — 2026-05-23
+
+### 🐛 Fixed
+
+- **Recorder GUI — unified tap target quote-wrap contract** ([#40](https://github.com/sh3lan93/mobile-automator/issues/40)). The legacy generic branch in `renderStepRow` and its sibling `applyStepRenamed` now wrap `step.target` in literal `"` characters at render time, matching the `long_press` / `double_tap` branches (slice [#24](https://github.com/sh3lan93/mobile-automator/issues/24)) and the `type` branch (slice [#35](https://github.com/sh3lan93/mobile-automator/issues/35)). Aligns the user-visible rendering with what the live lifecycle producer at `tools/recorder/src/lifecycle.js` actually sends (unquoted `display_name`). Pre-baked-quote test fixtures across the recorder unit suite were corrected accordingly. Bug was latent — the live `step-added` broadcast producer is not yet wired in production.
+
 ## [0.12.0] — 2026-05-23
 
 > **Soft-launch graduation of `/mobile-automator:record`** — the cross-platform interactive scenario recorder designed in [PRD #21](https://github.com/sh3lan93/mobile-automator/issues/21) and built across 13 slices. The recorder is feature-complete and stays gated behind `MOBILE_AUTOMATOR_RECORDER=1` so it can collect real-world mileage before the env-var gate is removed in a future release. With the gate off, behaviour is identical to v0.11.0.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Mobile QA automation with test generation and execution using mobile-mcp",
   "author": "Mohamed Shalan",
   "repository": "https://github.com/sh3lan93/mobile-automator",

--- a/tests/unit/recorder/web-add-assertion-button.test.js
+++ b/tests/unit/recorder/web-add-assertion-button.test.js
@@ -32,14 +32,14 @@ describe('Add Assertion button', () => {
     const btn = document.getElementById('btn-add-assertion');
     expect(btn.disabled).toBe(true);
 
-    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: 'Login' });
 
     expect(btn.disabled).toBe(false);
   });
 
   test('clicking the button sends {type: "request-assertion-screenshot"} over the stub WS', () => {
     // First add a step so the button is enabled and latestStepId is set.
-    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: 'Login' });
 
     const sent = [];
     const sendWs = (msg) => sent.push(msg);

--- a/tests/unit/recorder/web-assertion-row.test.js
+++ b/tests/unit/recorder/web-assertion-row.test.js
@@ -21,8 +21,8 @@ describe('appendAssertionRow', () => {
   test('inserts <li class="assertion-row"> after the anchor step row', () => {
     // Add an anchor step row manually.
     const list = document.getElementById('step-list');
-    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: '"Login"' });
-    app.appendStep({ id: 'tap_submit', index: 2, action: 'Tap', target: '"Submit"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: 'Login' });
+    app.appendStep({ id: 'tap_submit', index: 2, action: 'Tap', target: 'Submit' });
 
     app.appendAssertionRow({
       id: 'a1',
@@ -39,7 +39,7 @@ describe('appendAssertionRow', () => {
   });
 
   test('renders "Verifies:" label and nl_text', () => {
-    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: 'Login' });
 
     const li = app.appendAssertionRow({
       id: 'a1',
@@ -57,7 +57,7 @@ describe('appendAssertionRow', () => {
   });
 
   test('falls back to append-at-end when anchor step not found', () => {
-    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'Tap', target: 'Login' });
 
     const list = document.getElementById('step-list');
     const beforeCount = list.children.length;

--- a/tests/unit/recorder/web-device-disconnected.test.js
+++ b/tests/unit/recorder/web-device-disconnected.test.js
@@ -87,7 +87,7 @@ describe('recorder GUI: device-disconnected error banner (slice #10)', () => {
     app.attachWsClient({ url: 'ws://x', WebSocketCtor: FakeWS });
 
     // Pre-existing steps must visually disappear when the device drops.
-    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: 'Login' });
 
     fire({ type: 'device-disconnected', device_label: 'Pixel_7', reason: null });
 

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -202,11 +202,11 @@ describe('confirmation display-effect', () => {
     document.body.innerHTML = '<div id="modal-root"></div><ul id="step-list"></ul>';
   });
 
-  test('applyStepRenamed relabels the row target, keeps data-step-id', () => {
+  test('applyStepRenamed relabels the row target with the same quote-wrap contract as renderStepRow (#40)', () => {
     app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.applyStepRenamed(document, { step_id: 'tap_login', new_display_name: 'Tap the Login button' });
     const li = document.querySelector('[data-step-id="tap_login"]');
-    expect(li.querySelector('.step-target').textContent).toBe('Tap the Login button');
+    expect(li.querySelector('.step-target').textContent).toBe('"Tap the Login button"');
     expect(li.getAttribute('data-step-id')).toBe('tap_login');
   });
 

--- a/tests/unit/recorder/web-edit-affordances.test.js
+++ b/tests/unit/recorder/web-edit-affordances.test.js
@@ -13,19 +13,19 @@ describe('"⋯" menu rendering & per-row-type filtering', () => {
   });
 
   test('every step row gets an always-visible .step-menu button', () => {
-    const li = app.renderStepRow({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    const li = app.renderStepRow({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     const btn = li.querySelector('button.step-menu');
     expect(btn).not.toBeNull();
     expect(btn.getAttribute('aria-label')).toBe('Edit step');
   });
 
   test('generic step row carries data-action for filtering', () => {
-    const li = app.renderStepRow({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    const li = app.renderStepRow({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     expect(li.getAttribute('data-action')).toBe('tap');
   });
 
   test('opening the menu on a generic step shows Rename + Delete only', () => {
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.attachEditAffordances({ document, sendWs: jest.fn() });
     document.querySelector('[data-step-id="tap_login"] button.step-menu').click();
     const items = [...document.querySelectorAll('.step-menu-popover .menu-item')].map((b) => b.getAttribute('data-edit-action'));
@@ -49,7 +49,7 @@ describe('"⋯" menu rendering & per-row-type filtering', () => {
   });
 
   test('assertion row menu shows Edit text only (no reorder/insert/type-change anywhere)', () => {
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'Shown', anchor_step_id: 'tap_login' });
     app.attachEditAffordances({ document, sendWs: jest.fn() });
     document.querySelector('[data-assertion-id="a1"] button.step-menu').click();
@@ -59,7 +59,7 @@ describe('"⋯" menu rendering & per-row-type filtering', () => {
   });
 
   test('assertion row carries data-anchor-step-id', () => {
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     const li = app.appendAssertionRow({ id: 'a1', nl_text: 'Shown', anchor_step_id: 'tap_login' });
     expect(li.getAttribute('data-anchor-step-id')).toBe('tap_login');
   });
@@ -78,7 +78,7 @@ describe('inline editors send the correct WS message', () => {
 
   test('rename: commit with Enter sends rename-step', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.attachEditAffordances({ document, sendWs });
     openMenuAndClick('[data-step-id="tap_login"]', 'rename');
     const input = document.querySelector('[data-step-id="tap_login"] input.inline-edit');
@@ -90,7 +90,7 @@ describe('inline editors send the correct WS message', () => {
 
   test('rename: Escape cancels — no WS, input removed', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.attachEditAffordances({ document, sendWs });
     openMenuAndClick('[data-step-id="tap_login"]', 'rename');
     const input = document.querySelector('[data-step-id="tap_login"] input.inline-edit');
@@ -113,7 +113,7 @@ describe('inline editors send the correct WS message', () => {
 
   test('edit-assertion-text sends edit-assertion-text', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'old text', anchor_step_id: 'tap_login' });
     app.attachEditAffordances({ document, sendWs });
     openMenuAndClick('[data-assertion-id="a1"]', 'edit-assertion-text');
@@ -126,7 +126,7 @@ describe('inline editors send the correct WS message', () => {
 
   test('blank commit is ignored (no WS)', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.attachEditAffordances({ document, sendWs });
     openMenuAndClick('[data-step-id="tap_login"]', 'rename');
     const input = document.querySelector('[data-step-id="tap_login"] input.inline-edit');
@@ -148,7 +148,7 @@ describe('delete prompt', () => {
 
   test('no anchored assertions → plain confirm → delete-step policy none', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_skip', index: 1, action: 'tap', target: '"Skip"' });
+    app.appendStep({ id: 'tap_skip', index: 1, action: 'tap', target: 'Skip' });
     app.attachEditAffordances({ document, sendWs });
     openDelete('[data-step-id="tap_skip"]');
     const prompt = document.querySelector('.delete-prompt');
@@ -160,7 +160,7 @@ describe('delete prompt', () => {
 
   test('anchored assertions → 3-option prompt, reanchor is the default', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: '"Submit"' });
+    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: 'Submit' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'Dashboard', anchor_step_id: 'tap_submit' });
     app.appendAssertionRow({ id: 'a2', nl_text: 'Toast', anchor_step_id: 'tap_submit' });
     app.attachEditAffordances({ document, sendWs });
@@ -175,7 +175,7 @@ describe('delete prompt', () => {
 
   test('choosing cascade sends cascade', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: '"Submit"' });
+    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: 'Submit' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'Dashboard', anchor_step_id: 'tap_submit' });
     app.attachEditAffordances({ document, sendWs });
     openDelete('[data-step-id="tap_submit"]');
@@ -187,7 +187,7 @@ describe('delete prompt', () => {
 
   test('cancel sends nothing and removes the prompt', () => {
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: '"Submit"' });
+    app.appendStep({ id: 'tap_submit', index: 1, action: 'tap', target: 'Submit' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'Dashboard', anchor_step_id: 'tap_submit' });
     app.attachEditAffordances({ document, sendWs });
     openDelete('[data-step-id="tap_submit"]');
@@ -203,7 +203,7 @@ describe('confirmation display-effect', () => {
   });
 
   test('applyStepRenamed relabels the row target, keeps data-step-id', () => {
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.applyStepRenamed(document, { step_id: 'tap_login', new_display_name: 'Tap the Login button' });
     const li = document.querySelector('[data-step-id="tap_login"]');
     expect(li.querySelector('.step-target').textContent).toBe('Tap the Login button');
@@ -217,15 +217,15 @@ describe('confirmation display-effect', () => {
   });
 
   test('applyAssertionTextEdited updates the assertion text span', () => {
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'old', anchor_step_id: 'tap_login' });
     app.applyAssertionTextEdited(document, { assertion_id: 'a1', new_nl_text: 'new text' });
     expect(document.querySelector('[data-assertion-id="a1"] .assertion-text').textContent).toBe('new text');
   });
 
   test('applyStepDeleted cascade removes the step and its anchored assertions', () => {
-    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: '"A"' });
-    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: '"B"' });
+    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: 'A' });
+    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: 'B' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'x', anchor_step_id: 'tap_b' });
     app.applyStepDeleted(document, { step_id: 'tap_b', assertion_policy: 'cascade' });
     expect(document.querySelector('[data-step-id="tap_b"]')).toBeNull();
@@ -233,9 +233,9 @@ describe('confirmation display-effect', () => {
   });
 
   test('applyStepDeleted reanchor moves assertions to the previous surviving step', () => {
-    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: '"A"' });
-    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: '"B"' });
-    app.appendStep({ id: 'tap_c', index: 3, action: 'tap', target: '"C"' });
+    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: 'A' });
+    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: 'B' });
+    app.appendStep({ id: 'tap_c', index: 3, action: 'tap', target: 'C' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'x', anchor_step_id: 'tap_b' });
     app.applyStepDeleted(document, { step_id: 'tap_b', assertion_policy: 'reanchor' });
     const a = document.querySelector('[data-assertion-id="a1"]');
@@ -245,8 +245,8 @@ describe('confirmation display-effect', () => {
   });
 
   test('applyStepDeleted reanchor preserves relative order of multiple assertions', () => {
-    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: '"A"' });
-    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: '"B"' });
+    app.appendStep({ id: 'tap_a', index: 1, action: 'tap', target: 'A' });
+    app.appendStep({ id: 'tap_b', index: 2, action: 'tap', target: 'B' });
     app.appendAssertionRow({ id: 'a1', nl_text: 'first', anchor_step_id: 'tap_b' });
     app.appendAssertionRow({ id: 'a2', nl_text: 'second', anchor_step_id: 'tap_b' });
     const before = [...document.querySelectorAll('.assertion-row')].map((r) => r.getAttribute('data-assertion-id'));

--- a/tests/unit/recorder/web-mark-semantic.test.js
+++ b/tests/unit/recorder/web-mark-semantic.test.js
@@ -33,7 +33,7 @@ describe('Mark as dismiss_keyboard — agnostic mode', () => {
 
   test('agnostic mode: tap row menu contains mark-as-semantic item with correct text', () => {
     app._setMode('platform-agnostic');
-    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: '"Button"' });
+    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: 'Button' });
     app.attachEditAffordances({ document, sendWs: jest.fn() });
 
     // Open the menu and inspect the items in one operation.
@@ -50,7 +50,7 @@ describe('Mark as dismiss_keyboard — agnostic mode', () => {
 
   test('aware mode: tap row menu has Rename + Delete only (no mark-as-semantic)', () => {
     app._setMode('platform-aware');
-    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: '"Button"' });
+    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: 'Button' });
     app.attachEditAffordances({ document, sendWs: jest.fn() });
 
     const actions = openMenuActions('[data-step-id="tap_x"]');
@@ -77,9 +77,9 @@ describe('Mark as dismiss_keyboard — agnostic mode', () => {
 
   test('agnostic mode: long_press, double_tap, press_button rows do NOT expose mark-as-semantic', () => {
     app._setMode('platform-agnostic');
-    app.appendStep({ id: 'lp_1', index: 1, action: 'long_press', target: '"Icon"' });
-    app.appendStep({ id: 'dt_1', index: 2, action: 'double_tap', target: '"Logo"' });
-    app.appendStep({ id: 'pb_1', index: 3, action: 'press_button', target: '"OK"' });
+    app.appendStep({ id: 'lp_1', index: 1, action: 'long_press', target: 'Icon' });
+    app.appendStep({ id: 'dt_1', index: 2, action: 'double_tap', target: 'Logo' });
+    app.appendStep({ id: 'pb_1', index: 3, action: 'press_button', target: 'OK' });
     app.attachEditAffordances({ document, sendWs: jest.fn() });
 
     const lpActions = openMenuActions('[data-step-id="lp_1"]');
@@ -104,7 +104,7 @@ describe('Mark as dismiss_keyboard — agnostic mode', () => {
   test('agnostic mode: clicking mark-as-semantic sends correct WS message', () => {
     app._setMode('platform-agnostic');
     const sendWs = jest.fn();
-    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: '"Button"' });
+    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: 'Button' });
     app.attachEditAffordances({ document, sendWs });
 
     openMenuAndClick('[data-step-id="tap_x"]', 'mark-as-semantic');
@@ -118,7 +118,7 @@ describe('Mark as dismiss_keyboard — agnostic mode', () => {
 
   test('step-marked-semantic WS message updates row data-action and .step-action text', () => {
     app._setMode('platform-agnostic');
-    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: '"Button"' });
+    app.appendStep({ id: 'tap_x', index: 1, action: 'tap', target: 'Button' });
 
     // Simulate receiving step-marked-semantic from the server.
     app.applyStepMarkedSemantic(document, {

--- a/tests/unit/recorder/web-save-sensitive-confirm.test.js
+++ b/tests/unit/recorder/web-save-sensitive-confirm.test.js
@@ -37,7 +37,7 @@ describe('recorder GUI: Save-time sensitive-input confirmation (slice #9)', () =
     const sent = [];
     app.wireButtons({ document, sendWs: (m) => sent.push(m) });
 
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
 
     clickSave();
     expect(sent).toEqual([{ type: 'save' }]);
@@ -164,7 +164,7 @@ describe('recorder GUI: Save-time sensitive-input confirmation (slice #9)', () =
     const sent = [];
     app.wireButtons({ document, sendWs: (m) => sent.push(m) });
 
-    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: '"Login"' });
+    app.appendStep({ id: 'tap_login', index: 1, action: 'tap', target: 'Login' });
     app.appendStep({ id: 'type_email', index: 2, action: 'type', value: 'a@b.com', field_label: 'Email', sensitive: false });
     app.appendStep({ id: 'type_pw', index: 3, action: 'type', value: 'secret', field_label: 'Password', sensitive: true });
 

--- a/tests/unit/recorder/web-step-list.test.js
+++ b/tests/unit/recorder/web-step-list.test.js
@@ -184,6 +184,24 @@ describe('recorder GUI: step-list rendering', () => {
       expect(target.textContent).toBe('"Like Button"');
     });
 
+    // Issue #40: pin the contract that the generic/legacy branch wraps
+    // target in literal `"` chars at render time (matching slice #24's
+    // long_press/double_tap branch and slice #35's type branch). The live
+    // lifecycle producer at lifecycle.js passes `display_name` unquoted —
+    // pre-quoted fixtures were the only reason this branch ever "worked".
+    test('renders a generic tap row by wrapping unquoted target in quotes (#40)', () => {
+      const li = app.renderStepRow({
+        id: 'tap_login_40',
+        index: 10,
+        action: 'tap',
+        target: 'Login',
+      });
+
+      const target = li.querySelector('.step-target');
+      expect(target).not.toBeNull();
+      expect(target.textContent).toBe('"Login"');
+    });
+
     test('renders a swipe step as `Swipe <direction>` with no target span', () => {
       const li = app.renderStepRow({
         id: 'swipe_feed',

--- a/tests/unit/recorder/web-step-list.test.js
+++ b/tests/unit/recorder/web-step-list.test.js
@@ -24,7 +24,7 @@ describe('recorder GUI: step-list rendering', () => {
         id: 'tap_login',
         index: 3,
         action: 'Tap',
-        target: '"Login"',
+        target: 'Login',
       });
 
       expect(li).toBeInstanceOf(window.HTMLLIElement);
@@ -233,7 +233,7 @@ describe('recorder GUI: step-list rendering', () => {
         id: 'tap_login',
         index: 1,
         action: 'Tap',
-        target: '"Login"',
+        target: 'Login',
       });
 
       expect(list.children.length).toBe(1);
@@ -282,7 +282,7 @@ describe('recorder GUI: step-list rendering', () => {
       handlers.message({
         data: JSON.stringify({
           type: 'step-added',
-          step: { id: 'tap_login', index: 1, action: 'Tap', target: '"Login"' },
+          step: { id: 'tap_login', index: 1, action: 'Tap', target: 'Login' },
         }),
       });
 
@@ -291,7 +291,7 @@ describe('recorder GUI: step-list rendering', () => {
         id: 'tap_login',
         index: 1,
         action: 'Tap',
-        target: '"Login"',
+        target: 'Login',
       });
     });
 

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -153,9 +153,12 @@
     action.className = 'step-action';
     action.textContent = String(step.action);
 
+    // Issue #40: wrap target in literal `"` at render time so the generic
+    // branch matches the long_press/double_tap (slice #24) and type
+    // (slice #35) branches. Callers pass `display_name` unquoted.
     const target = doc.createElement('span');
     target.className = 'step-target';
-    target.textContent = step.target == null ? '' : String(step.target);
+    target.textContent = '"' + (step.target == null ? '' : String(step.target)) + '"';
 
     li.appendChild(num);
     li.appendChild(action);

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -649,8 +649,14 @@
   function applyStepRenamed(doc, p) {
     const li = doc.querySelector('[data-step-id="' + p.step_id + '"]');
     if (!li) return;
-    const span = li.querySelector('.step-target') || li.querySelector('.step-action');
-    if (span) span.textContent = p.new_display_name;
+    const targetSpan = li.querySelector('.step-target');
+    if (targetSpan) {
+      // Issue #40: same wrap contract as renderStepRow's target spans.
+      targetSpan.textContent = '"' + p.new_display_name + '"';
+      return;
+    }
+    const actionSpan = li.querySelector('.step-action');
+    if (actionSpan) actionSpan.textContent = p.new_display_name;
   }
 
   function applyValueEdited(doc, p) {


### PR DESCRIPTION
## Summary

Closes the rendering-inconsistency gap reported in [#40](https://github.com/sh3lan93/mobile-automator/issues/40). PR #39 (slice [#24](https://github.com/sh3lan93/mobile-automator/issues/24)) and the earlier slice [#35](https://github.com/sh3lan93/mobile-automator/issues/35) established a *renderer-wraps* contract for `.step-target` text — `long_press`, `double_tap`, and `type` rows accept `target` unquoted and wrap it in literal `"..."` at render time. The legacy generic branch in `renderStepRow` (and its sibling re-render path `applyStepRenamed`) were the only two places that violated the contract: they rendered `step.target` as-is, relying on callers to pre-quote the string.

That relied on test fixtures pre-baking quotes (`target: '"Login"'`). The live lifecycle producer at `tools/recorder/src/lifecycle.js:73` (`target: resolved?.display_name`) emits **unquoted** strings. The bug was latent today because the live `step-added` broadcast producer isn't wired in production yet — it would have surfaced the moment that producer landed, with `tap` rows rendering `Tap Login` while sibling gestures rendered `Long press \"Settings Icon\"`.

This PR aligns both paths with the established contract:

- `tools/recorder/web/app.js` — `renderStepRow` generic fall-through branch wraps target in `\"...\"`, matching the long_press/double_tap branch and the type branch.
- `tools/recorder/web/app.js` — `applyStepRenamed` applies the same wrap when the row has a `.step-target` span. The `.step-action` fallback (used only by swipe rows, which have no quote contract on the verb) stays unwrapped.
- ~30 pre-baked-quote test fixtures across 7 recorder unit test files are corrected to pass unquoted `target` values, matching what the live producer actually sends.
- One new regression test in `web-step-list.test.js` permanently pins the generic-branch contract.

## Out of scope

This PR is the planned cleanup of the *generic branch* inconsistency that PR #39 deliberately deferred to keep slice #24's scope tight. It does not change scenario JSON, lifecycle producers, or the schema.

## Test plan

- [x] `npx jest tests/unit/recorder/web-step-list.test.js` — 15/15 green (1 new + 14 existing).
- [x] `npx jest tests/unit/recorder/web-edit-affordances.test.js` — 23/23 green (includes the updated `applyStepRenamed` expectation).
- [x] `npx jest tests/unit/recorder/` — 374/374 green across 49 recorder unit suites.
- [x] `npx jest` (full suite) — 560/560 green across 82 suites. No regressions.
- [x] TDD ordering verified: red commit (new test fails) → green-fix commit (production patch makes new test pass, exposes pre-quoted fixtures as `""Login""`) → fixture sweep → rename consistency patch.

## Commit breakdown

| Commit | Purpose |
|---|---|
| `8cf10ca` | TDD red: new generic-tap render test, currently failing |
| `2d2f930` | Fix: wrap target in `renderStepRow` generic branch |
| `46a990b` | Sweep: drop pre-baked target quotes from 7 recorder test files |
| `94091bf` | Fix: apply the same wrap in `applyStepRenamed` + update its test expectation |

Closes #40
Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)