### PR TITLE
Recorder sidecar: auto-open the GUI in the default browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Recorder sidecar — auto-open GUI in default browser** ([#65](https://github.com/sh3lan93/mobile-automator/issues/65)). The README has long claimed `/mobile-automator:record` *"opens your default browser to a localhost recorder GUI"*, but the sidecar never actually launched one — it started its HTTP server and waited for a WebSocket connection that would never arrive unless the user found the port file by hand. The sidecar now spawns the platform-native launcher (`open` on darwin, `xdg-open` on linux, `cmd /c start "" <url>` on win32) detached/unrefed after the HTTP server starts, and prints `🌐 Recorder GUI: http://127.0.0.1:<port>/` to stdout unconditionally so the URL stays recoverable if auto-open fails silently or the tab gets closed. `--no-gui` short-circuits the launch so CI / headless mode is unaffected. Unsupported platforms and `ENOENT` from the launcher are logged once and swallowed — the printed URL is the fallback.
+
 ## [0.12.1] — 2026-05-23
 
 ### 🐛 Fixed

--- a/tests/unit/recorder/browser-opener.test.js
+++ b/tests/unit/recorder/browser-opener.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const { EventEmitter } = require('events');
+const { openInBrowser } = require('../../../tools/recorder/src/server/browser-opener');
+
+function makeFakeSpawn() {
+  const calls = [];
+  const procs = [];
+  const fn = jest.fn((cmd, args, opts) => {
+    const proc = new EventEmitter();
+    proc.unref = jest.fn();
+    calls.push({ cmd, args, opts });
+    procs.push(proc);
+    return proc;
+  });
+  fn._calls = calls;
+  fn._procs = procs;
+  return fn;
+}
+
+describe('openInBrowser', () => {
+  const url = 'http://127.0.0.1:54321/';
+
+  test('darwin: spawns `open` with the URL, detached, stdio ignored', () => {
+    const spawn = makeFakeSpawn();
+    openInBrowser({ url, platform: 'darwin', spawn });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const call = spawn._calls[0];
+    expect(call.cmd).toBe('open');
+    expect(call.args).toEqual([url]);
+    expect(call.opts).toEqual(expect.objectContaining({ detached: true, stdio: 'ignore' }));
+  });
+
+  test('linux: spawns `xdg-open` with the URL', () => {
+    const spawn = makeFakeSpawn();
+    openInBrowser({ url, platform: 'linux', spawn });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const call = spawn._calls[0];
+    expect(call.cmd).toBe('xdg-open');
+    expect(call.args).toEqual([url]);
+    expect(call.opts).toEqual(expect.objectContaining({ detached: true, stdio: 'ignore' }));
+  });
+
+  test('win32: spawns `cmd /c start "" <url>`', () => {
+    const spawn = makeFakeSpawn();
+    openInBrowser({ url, platform: 'win32', spawn });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const call = spawn._calls[0];
+    expect(call.cmd).toBe('cmd');
+    expect(call.args).toEqual(['/c', 'start', '', url]);
+    expect(call.opts).toEqual(expect.objectContaining({ detached: true, stdio: 'ignore' }));
+  });
+
+  test('unknown platform: does not throw, does not spawn, logs a warning', () => {
+    const spawn = makeFakeSpawn();
+    const warn = jest.fn();
+    expect(() => openInBrowser({ url, platform: 'sunos', spawn, warn })).not.toThrow();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test('noGui=true: does not spawn regardless of platform', () => {
+    const spawn = makeFakeSpawn();
+    openInBrowser({ url, platform: 'darwin', spawn, noGui: true });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('returned child proc is unref-ed', () => {
+    const spawn = makeFakeSpawn();
+    openInBrowser({ url, platform: 'darwin', spawn });
+    expect(spawn._procs[0].unref).toHaveBeenCalledTimes(1);
+  });
+
+  test('missing url: does not spawn, does not throw', () => {
+    const spawn = makeFakeSpawn();
+    expect(() => openInBrowser({ url: undefined, platform: 'darwin', spawn })).not.toThrow();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  test('spawn throwing synchronously is swallowed (best-effort launch)', () => {
+    const spawn = jest.fn(() => { throw new Error('ENOENT'); });
+    const warn = jest.fn();
+    expect(() => openInBrowser({ url, platform: 'darwin', spawn, warn })).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/recorder/lifecycle-live.test.js
+++ b/tests/unit/recorder/lifecycle-live.test.js
@@ -30,8 +30,8 @@ function makeFakeWsCtx() {
   };
 }
 
-function makeFakeHttpSrv() {
-  return { port: 0, server: {}, close: jest.fn().mockResolvedValue(undefined) };
+function makeFakeHttpSrv(port = 0) {
+  return { port, server: {}, close: jest.fn().mockResolvedValue(undefined) };
 }
 
 describe('startLiveCapture (lifecycle/live)', () => {
@@ -164,6 +164,82 @@ describe('startLiveCapture (lifecycle/live)', () => {
       },
     });
     expect(wsCtx._broadcasts).toContainEqual({ type: 'mode', mode: 'platform-aware' });
+  });
+
+  test('opens the GUI in the default browser after HTTP server starts (#65)', async () => {
+    const openInBrowser = jest.fn();
+    const httpSrv = makeFakeHttpSrv(54321);
+    const startModeB = jest.fn().mockImplementation(() => {
+      // assert auto-open happened BEFORE the mode handler runs
+      expect(openInBrowser).toHaveBeenCalledTimes(1);
+      return Promise.resolve(0);
+    });
+    await startLiveCapture({
+      projectRoot,
+      scenarioId: 'scn',
+      platform: 'android',
+      mode: 'b',
+      opts: { noGui: false },
+      deps: {
+        startHttpServer: jest.fn().mockResolvedValue(httpSrv),
+        attachWsServer: jest.fn().mockReturnValue(makeFakeWsCtx()),
+        startC3: jest.fn().mockResolvedValue(0),
+        startModeB,
+        openInBrowser,
+      },
+    });
+    expect(openInBrowser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://127.0.0.1:54321/',
+        noGui: false,
+      }),
+    );
+  });
+
+  test('passes noGui=true through to openInBrowser when --no-gui is set', async () => {
+    const openInBrowser = jest.fn();
+    await startLiveCapture({
+      projectRoot,
+      scenarioId: 'scn',
+      platform: 'android',
+      mode: 'b',
+      opts: { noGui: true },
+      deps: {
+        startHttpServer: jest.fn().mockResolvedValue(makeFakeHttpSrv(54321)),
+        attachWsServer: jest.fn().mockReturnValue(makeFakeWsCtx()),
+        startC3: jest.fn().mockResolvedValue(0),
+        startModeB: jest.fn().mockResolvedValue(0),
+        openInBrowser,
+      },
+    });
+    expect(openInBrowser).toHaveBeenCalledTimes(1);
+    expect(openInBrowser).toHaveBeenCalledWith(
+      expect.objectContaining({ noGui: true }),
+    );
+  });
+
+  test('always prints the recorder GUI URL to stdout (#65 AC bullet 3)', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await startLiveCapture({
+        projectRoot,
+        scenarioId: 'scn',
+        platform: 'android',
+        mode: 'b',
+        opts: { noGui: true },
+        deps: {
+          startHttpServer: jest.fn().mockResolvedValue(makeFakeHttpSrv(54321)),
+          attachWsServer: jest.fn().mockReturnValue(makeFakeWsCtx()),
+          startC3: jest.fn().mockResolvedValue(0),
+          startModeB: jest.fn().mockResolvedValue(0),
+          openInBrowser: jest.fn(),
+        },
+      });
+      const printed = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(printed).toContain('http://127.0.0.1:54321/');
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   test('closes WS + HTTP server on completion', async () => {

--- a/tools/recorder/src/lifecycle/live.js
+++ b/tools/recorder/src/lifecycle/live.js
@@ -3,6 +3,7 @@
 const { ArtifactsStore } = require('../artifacts');
 const { startHttpServer } = require('../server/http-server');
 const { attachWsServer } = require('../server/ws-protocol');
+const { openInBrowser } = require('../server/browser-opener');
 const { loadProjectConfig, resolveModeAndDefaults } = require('../config');
 
 /**
@@ -28,6 +29,7 @@ async function startLiveCapture({
   const StoreCtor = deps.ArtifactsStore || ArtifactsStore;
   const _startHttp = deps.startHttpServer || startHttpServer;
   const _attachWs = deps.attachWsServer || attachWsServer;
+  const _openBrowser = deps.openInBrowser || openInBrowser;
   const _startC3 = deps.startC3 || require('./c3').startC3;
   const _startModeB = deps.startModeB || require('./mode-b').startModeB;
 
@@ -53,6 +55,15 @@ async function startLiveCapture({
     allowSensitiveInput: !!opts.allowSensitiveInput,
   });
   const wsCtx = _attachWs({ httpServer: httpSrv.server });
+
+  // Print the recorder GUI URL and auto-launch the default browser (#65).
+  // The URL is logged unconditionally so the user always has a fallback if
+  // auto-open fails silently (unsupported platform, ENOENT, etc.) or if the
+  // tab is closed mid-recording. `--no-gui` (threaded as opts.noGui) skips
+  // the launch so CI / headless / test mode stays browser-free.
+  const guiUrl = `http://127.0.0.1:${httpSrv.port}/`;
+  console.log(`🌐 Recorder GUI: ${guiUrl}`);
+  _openBrowser({ url: guiUrl, noGui: !!opts.noGui });
 
   // Broadcast the initial mode message so any client that connects sees the
   // emit mode without an extra round-trip.

--- a/tools/recorder/src/server/browser-opener.js
+++ b/tools/recorder/src/server/browser-opener.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { spawn: defaultSpawn } = require('child_process');
+
+/**
+ * Open the given URL in the host OS's default browser.
+ *
+ * Best-effort: failures (unsupported platform, missing launcher binary, spawn
+ * throwing synchronously) are reported via the injected `warn` and swallowed
+ * so they cannot crash the recorder sidecar. The caller always prints the URL
+ * to stdout regardless, so a silent failure here is still recoverable.
+ *
+ * - `noGui: true` short-circuits without spawning (used by `--no-gui` so CI
+ *   and headless tests don't pop a browser).
+ * - `spawn` is injectable so the unit tests can drive each platform branch
+ *   without actually launching a browser. Mirrors the pattern in
+ *   `tools/recorder/src/capture/adb-getevent.js`.
+ *
+ * @param {object} args
+ * @param {string} args.url - URL to open. If falsy, no-ops silently.
+ * @param {string} [args.platform=process.platform] - OS branch selector.
+ * @param {boolean} [args.noGui=false] - When true, do not spawn anything.
+ * @param {Function} [args.spawn=child_process.spawn] - Spawn injector.
+ * @param {Function} [args.warn=console.warn] - Warning channel.
+ */
+function openInBrowser({
+  url,
+  platform = process.platform,
+  noGui = false,
+  spawn = defaultSpawn,
+  warn = console.warn,
+} = {}) {
+  if (noGui) return;
+  if (!url) return;
+
+  let cmd;
+  let args;
+  switch (platform) {
+    case 'darwin':
+      cmd = 'open';
+      args = [url];
+      break;
+    case 'linux':
+      cmd = 'xdg-open';
+      args = [url];
+      break;
+    case 'win32':
+      cmd = 'cmd';
+      args = ['/c', 'start', '', url];
+      break;
+    default:
+      warn(`[recorder] auto-open: unsupported platform ${platform}; open ${url} manually`);
+      return;
+  }
+
+  try {
+    const proc = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+    if (proc && typeof proc.unref === 'function') {
+      proc.unref();
+    }
+  } catch (err) {
+    warn(`[recorder] auto-open failed (${err && err.message ? err.message : err}); open ${url} manually`);
+  }
+}
+
+module.exports = { openInBrowser };


### PR DESCRIPTION
## Summary

- The README promised that `/mobile-automator:record` *"opens your default browser to a localhost recorder GUI"*, but the sidecar only started its HTTP server and waited — no browser ever launched and no URL was printed, leaving users staring at a hung terminal.
- New helper `tools/recorder/src/server/browser-opener.js` spawns the platform-native launcher (`open` / `xdg-open` / `cmd /c start "" <url>`) detached and unref-ed; `spawn` and `platform` are injectable, mirroring the pattern in `tools/recorder/src/capture/adb-getevent.js`.
- `lifecycle/live.js` calls the helper right after the HTTP server starts and **always** prints `🌐 Recorder GUI: http://127.0.0.1:<port>/` to stdout so the URL stays recoverable when auto-open fails silently or the tab is closed. `--no-gui` short-circuits the launch so CI / test runs remain browser-free.

## Test plan

- [x] When `--no-gui` is NOT set, the sidecar spawns the platform-native browser launcher.
- [x] When `--no-gui` IS set, no browser is launched.
- [x] The URL is always printed to stdout regardless of auto-open success.
- [x] `child_process.spawn` is dependency-injectable for tests.
- [x] Unit tests cover: darwin / linux / win32 / unknown-platform / `--no-gui` / unref / missing-url / spawn-throws-ENOENT.
- [x] Integration test asserts `startLiveCapture` calls `openInBrowser` after the HTTP server starts and before the mode handler runs.
- [x] Full suite: `npm test` → 83 suites / 571 tests passing (baseline was 82 / 560).

Closes #65
Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)