### PR TITLE
cli slice 1 — CLI spine: envelope, DeviceBridge, validator, verbs

### DIFF
--- a/bin/mauto.js
+++ b/bin/mauto.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+require('../src/cli').run(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "mobile-automator",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobile-automator",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ajv": "^8.20.0",
         "commander": "^12.1.0",
         "pngjs": "^7.0.0",
         "ws": "^8.18.0"
@@ -517,6 +519,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -886,6 +900,46 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1066,6 +1120,44 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1114,6 +1206,39 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -1325,6 +1450,46 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -1400,11 +1565,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1412,6 +1585,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1587,12 +1776,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -1620,7 +1866,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1677,7 +1922,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1733,6 +1977,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -1771,7 +2024,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -1781,6 +2033,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
@@ -1809,6 +2067,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -1836,7 +2103,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1846,7 +2112,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1856,7 +2121,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1890,6 +2154,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
@@ -1957,6 +2227,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2007,12 +2307,120 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2035,6 +2443,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2068,6 +2497,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2094,7 +2541,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2124,7 +2570,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2159,7 +2604,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2208,7 +2652,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2238,7 +2681,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2267,13 +2709,21 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -2295,6 +2745,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -2394,8 +2864,25 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2457,6 +2944,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2474,7 +2967,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3185,6 +3677,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3271,6 +3772,18 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3378,10 +3891,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -3455,7 +3988,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -3464,6 +3996,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -3509,11 +4050,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3622,6 +4195,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3646,7 +4228,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3658,6 +4239,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3687,6 +4278,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -3753,6 +4353,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -3793,12 +4406,67 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",
@@ -3812,6 +4480,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3878,11 +4555,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -3908,11 +4600,86 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3925,10 +4692,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -3994,6 +4832,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-length": {
@@ -4139,6 +4986,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/toml": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
@@ -4198,6 +5054,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -4213,6 +5125,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4270,6 +5191,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -4347,7 +5277,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4381,7 +5310,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -4493,6 +5421,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "mobile-automator",
   "version": "0.12.0",
   "private": true,
+  "bin": {
+    "mauto": "bin/mauto.js"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
@@ -21,6 +24,8 @@
     "test:all": "jest"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ajv": "^8.20.0",
     "commander": "^12.1.0",
     "pngjs": "^7.0.0",
     "ws": "^8.18.0"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,175 @@
+'use strict';
+
+const fs = require('fs');
+const { Command } = require('commander');
+
+const { ok, fail, render, exitCodeFor } = require('./output/envelope');
+const { DeviceBridge } = require('./device/bridge');
+const { ScenarioValidator } = require('./scenario/validator');
+
+// ---------------------------------------------------------------------------
+// Handlers — pure-ish: accept injected deps, return { envelope, exitKind }.
+// No process.exit / printing here so they are trivially unit-testable.
+// ---------------------------------------------------------------------------
+
+async function handleElements({ deviceBridge }) {
+  try {
+    const elements = await deviceBridge.listElements();
+    return { envelope: ok(elements), exitKind: 'ok' };
+  } catch (err) {
+    return {
+      envelope: fail(
+        'device',
+        err.message || String(err),
+        'Ensure a device or simulator is connected and the app is running.'
+      ),
+      exitKind: 'device',
+    };
+  }
+}
+
+async function handleScreenshot({ deviceBridge }, destPath) {
+  try {
+    const savedPath = await deviceBridge.screenshot(destPath);
+    return { envelope: ok({ path: savedPath }), exitKind: 'ok' };
+  } catch (err) {
+    return {
+      envelope: fail(
+        'device',
+        err.message || String(err),
+        'Ensure a device or simulator is connected.'
+      ),
+      exitKind: 'device',
+    };
+  }
+}
+
+function handleValidate({ validator }, file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    return {
+      envelope: fail(
+        'invalid_input',
+        `cannot read file: ${err.message}`,
+        'Check that the path exists and is readable.'
+      ),
+      exitKind: 'invalid_input',
+    };
+  }
+
+  let scenario;
+  try {
+    scenario = JSON.parse(raw);
+  } catch (err) {
+    return {
+      envelope: fail(
+        'invalid_input',
+        `file is not valid JSON: ${err.message}`,
+        'Fix the JSON syntax and try again.'
+      ),
+      exitKind: 'invalid_input',
+    };
+  }
+
+  const result = validator.validate(scenario);
+  if (result.valid) {
+    return { envelope: ok({ valid: true }), exitKind: 'ok' };
+  }
+
+  const env = fail(
+    'invalid_input',
+    'scenario failed schema validation',
+    'See data.errors for the specific schema violations.'
+  );
+  env.data = { valid: false, errors: result.errors };
+  return { envelope: env, exitKind: 'invalid_input' };
+}
+
+// ---------------------------------------------------------------------------
+// Program wiring
+// ---------------------------------------------------------------------------
+
+// Lazily build a DeviceBridge backed by a real mobile-mcp connection. Returns
+// the bridge plus a close() to tear the transport down. Imported lazily so the
+// MCP SDK is only loaded when an on-device command actually runs.
+async function realDeviceBridge({ device } = {}) {
+  const { createCall } = require('./device/mobile-mcp-client');
+  const { call, close } = await createCall({ device });
+  return { bridge: new DeviceBridge({ call }), close };
+}
+
+function buildProgram(deps = {}) {
+  const {
+    // Factory returning { bridge, close }. Overridable in tests.
+    deviceBridgeFactory = realDeviceBridge,
+    validator = new ScenarioValidator(),
+    // Sink used to emit the rendered envelope + drive the exit code.
+    emit = defaultEmit,
+  } = deps;
+
+  const program = new Command();
+  program
+    .name('mauto')
+    .description('Platform-agnostic mobile automation CLI')
+    .option('--human', 'render human-readable output instead of JSON', false);
+
+  const humanFlag = () => Boolean(program.opts().human);
+
+  program
+    .command('elements')
+    .description('List the agnostic UI elements currently on screen')
+    .option('--device <id>', 'target device id')
+    .action(async (opts) => {
+      const { bridge, close } = await deviceBridgeFactory({ device: opts.device });
+      try {
+        const r = await handleElements({ deviceBridge: bridge });
+        emit(r, humanFlag());
+      } finally {
+        if (typeof close === 'function') await close();
+      }
+    });
+
+  program
+    .command('screenshot <path>')
+    .description('Save a screenshot to the given path')
+    .option('--device <id>', 'target device id')
+    .action(async (destPath, opts) => {
+      const { bridge, close } = await deviceBridgeFactory({ device: opts.device });
+      try {
+        const r = await handleScreenshot({ deviceBridge: bridge }, destPath);
+        emit(r, humanFlag());
+      } finally {
+        if (typeof close === 'function') await close();
+      }
+    });
+
+  program
+    .command('validate <file>')
+    .description('Validate a scenario JSON file against the scenario schema')
+    .action((file) => {
+      const r = handleValidate({ validator }, file);
+      emit(r, humanFlag());
+    });
+
+  return program;
+}
+
+function defaultEmit({ envelope, exitKind }, human) {
+  process.stdout.write(render(envelope, { human }) + '\n');
+  process.exit(exitCodeFor(exitKind));
+}
+
+async function run(argv) {
+  const program = buildProgram();
+  await program.parseAsync(argv);
+}
+
+module.exports = {
+  run,
+  buildProgram,
+  handleElements,
+  handleScreenshot,
+  handleValidate,
+};

--- a/src/device/bridge.js
+++ b/src/device/bridge.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { normalize } = require('./element-model');
+
+// Thin wrapper over an injected mobile-mcp `call(toolName, args)` function.
+// Mirrors tools/recorder/src/capture/mobile-mcp-bridge.js but returns the
+// agnostic element model and exposes only the primitives Slice 1 needs.
+class DeviceBridge {
+  constructor({ call }) {
+    if (typeof call !== 'function') {
+      throw new TypeError('DeviceBridge requires a `call` function (toolName, args) => Promise');
+    }
+    this._call = call;
+  }
+
+  async listElements() {
+    const result = await this._call('mobile_list_elements_on_screen', {});
+    const raw = Array.isArray(result) ? result : (result && result.elements) || [];
+    return normalize(raw);
+  }
+
+  async screenshot(destPath) {
+    const result = await this._call('mobile_save_screenshot', { path: destPath });
+    return (result && result.path) || destPath;
+  }
+}
+
+module.exports = { DeviceBridge };

--- a/src/device/element-model.js
+++ b/src/device/element-model.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Agnostic element shape. We deliberately drop every OS-specific identifier
+// (resource_id / identifier) so downstream consumers can only target elements
+// by visible/semantic attributes (text, accessibility_label, geometry).
+
+function resolveBounds(raw) {
+  if (Array.isArray(raw.bounds) && raw.bounds.length === 4) {
+    return raw.bounds.map(Number);
+  }
+  if (Array.isArray(raw.coordinates) && raw.coordinates.length === 4) {
+    return raw.coordinates.map(Number);
+  }
+  if (raw.rect && typeof raw.rect === 'object') {
+    const { x, y, width, height } = raw.rect;
+    if ([x, y, width, height].every((v) => typeof v === 'number')) {
+      return [x, y, x + width, y + height];
+    }
+  }
+  return null;
+}
+
+function centerOf([x1, y1, x2, y2]) {
+  return [Math.round((x1 + x2) / 2), Math.round((y1 + y2) / 2)];
+}
+
+function nullable(v) {
+  return v === undefined || v === null || v === '' ? null : v;
+}
+
+function normalize(rawElements) {
+  if (!Array.isArray(rawElements)) return [];
+
+  const out = [];
+  for (const raw of rawElements) {
+    if (!raw || typeof raw !== 'object') continue;
+    const bounds = resolveBounds(raw);
+    if (!bounds) continue; // can't position it -> not useful, skip
+
+    out.push({
+      text: nullable(raw.text),
+      accessibility_label: nullable(
+        raw.accessibility_label !== undefined ? raw.accessibility_label : raw.label
+      ),
+      bounds,
+      center: centerOf(bounds),
+      type: nullable(raw.type),
+    });
+  }
+  return out;
+}
+
+module.exports = { normalize };

--- a/src/device/mobile-mcp-client.js
+++ b/src/device/mobile-mcp-client.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const { StdioClientTransport } = require('@modelcontextprotocol/sdk/client/stdio.js');
+
+// Integration glue: spawns mobile-mcp over stdio and returns a `call`
+// function shaped exactly like the one DeviceBridge expects.
+// NOT unit-tested (would require spawning mobile-mcp); see the smoke test.
+async function createCall({ device } = {}) {
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: ['-y', '@mobilenext/mobile-mcp@latest'],
+    // mobile-mcp reads the target device from the environment / its own
+    // selection; we pass it through when provided so callers can pin a device.
+    env: device ? { ...process.env, MOBILE_MCP_DEVICE: device } : process.env,
+  });
+
+  const client = new Client(
+    { name: 'mauto', version: '0.1.0' },
+    { capabilities: {} }
+  );
+
+  await client.connect(transport);
+
+  async function call(toolName, args = {}) {
+    const res = await client.callTool({ name: toolName, arguments: args });
+    return parseToolResult(res);
+  }
+
+  async function close() {
+    try {
+      await client.close();
+    } catch (_e) {
+      // best-effort teardown
+    }
+  }
+
+  return { call, close };
+}
+
+// mobile-mcp returns its payload as text content that is itself JSON.
+// Parse defensively: prefer JSON text content, fall back to raw text/struct.
+function parseToolResult(res) {
+  if (!res) return null;
+  if (res.structuredContent !== undefined) return res.structuredContent;
+
+  const content = res.content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter((c) => c && c.type === 'text' && typeof c.text === 'string')
+      .map((c) => c.text);
+    for (const t of texts) {
+      try {
+        return JSON.parse(t);
+      } catch (_e) {
+        // not JSON; keep looking, fall through to raw join
+      }
+    }
+    if (texts.length) return texts.join('\n');
+  }
+  return res;
+}
+
+module.exports = { createCall };

--- a/src/output/envelope.js
+++ b/src/output/envelope.js
@@ -1,0 +1,78 @@
+'use strict';
+
+// Stable contract between the `mauto` CLI and any calling agent.
+// Every command prints exactly one envelope on stdout.
+
+const SCHEMA_VERSION = '2.1';
+
+const EXIT = {
+  OK: 0,
+  DEVICE: 2,
+  INVALID_INPUT: 3,
+  TARGET_NOT_FOUND: 4,
+  CANCEL: 130,
+};
+
+// error.kind -> process exit code. `internal` (and anything unknown) -> 1.
+const KIND_TO_CODE = {
+  ok: EXIT.OK,
+  device: EXIT.DEVICE,
+  invalid_input: EXIT.INVALID_INPUT,
+  target_not_found: EXIT.TARGET_NOT_FOUND,
+  cancel: EXIT.CANCEL,
+  internal: 1,
+};
+
+function ok(data) {
+  return { ok: true, data, schema_version: SCHEMA_VERSION };
+}
+
+function fail(kind, message, hint = null) {
+  return {
+    ok: false,
+    error: { kind, message },
+    hint,
+    schema_version: SCHEMA_VERSION,
+  };
+}
+
+function exitCodeFor(kind) {
+  if (Object.prototype.hasOwnProperty.call(KIND_TO_CODE, kind)) {
+    return KIND_TO_CODE[kind];
+  }
+  return 1;
+}
+
+function render(envelope, { human = false } = {}) {
+  if (!human) {
+    return JSON.stringify(envelope);
+  }
+
+  if (envelope.ok) {
+    const data = envelope.data;
+    if (Array.isArray(data)) {
+      return `ok: ${data.length} item(s)`;
+    }
+    if (data && typeof data === 'object') {
+      const keys = Object.keys(data);
+      return `ok: ${keys.length ? keys.join(', ') : '(no data)'}`;
+    }
+    return `ok: ${String(data)}`;
+  }
+
+  const { kind, message } = envelope.error || {};
+  let out = `error [${kind}]: ${message}`;
+  if (envelope.hint) {
+    out += `\nhint: ${envelope.hint}`;
+  }
+  return out;
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  EXIT,
+  ok,
+  fail,
+  exitCodeFor,
+  render,
+};

--- a/src/scenario/validator.js
+++ b/src/scenario/validator.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+
+// Repo-root-relative default path to the canonical scenario schema.
+// src/scenario/validator.js -> repo root is two directories up.
+const DEFAULT_SCHEMA_PATH = path.resolve(
+  __dirname,
+  '../../templates/mobile-automator-generator/references/scenario_schema.json'
+);
+
+function formatError(err) {
+  const where = err.instancePath || '(root)';
+  let msg = `${where} ${err.message}`;
+  if (err.keyword === 'required' && err.params && err.params.missingProperty) {
+    msg = `${where} is missing required property '${err.params.missingProperty}'`;
+  } else if (err.keyword === 'enum' && err.params && Array.isArray(err.params.allowedValues)) {
+    msg = `${where} ${err.message}: ${err.params.allowedValues.join(', ')}`;
+  } else if (err.keyword === 'additionalProperties' && err.params) {
+    msg = `${where} has unexpected property '${err.params.additionalProperty}'`;
+  }
+  return msg;
+}
+
+class ScenarioValidator {
+  constructor({ schemaPath = DEFAULT_SCHEMA_PATH } = {}) {
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    this._validateFn = ajv.compile(schema);
+  }
+
+  validate(scenarioObject) {
+    const valid = this._validateFn(scenarioObject);
+    if (valid) {
+      return { valid: true, errors: [] };
+    }
+    const errors = (this._validateFn.errors || []).map(formatError);
+    return { valid: false, errors };
+  }
+}
+
+module.exports = { ScenarioValidator, DEFAULT_SCHEMA_PATH };

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const {
+  handleElements,
+  handleScreenshot,
+  handleValidate,
+} = require('../../src/cli');
+const { ScenarioValidator } = require('../../src/scenario/validator');
+
+const SCHEMA_PATH = path.resolve(
+  __dirname,
+  '../../templates/mobile-automator-generator/references/scenario_schema.json'
+);
+
+function validScenario() {
+  return {
+    $schema_version: '2.1',
+    scenario_id: 'login_smoke',
+    name: 'Login smoke',
+    description: 'Verifies the user can reach the login screen.',
+    platform: 'cross-platform',
+    app_package: 'com.example.app',
+    metadata: { app_version: 'staging-latest', environment: 'staging' },
+    steps: [{ id: 'launch', action: 'launch_app', description: 'Launch the app' }],
+    assertions: [
+      {
+        id: 'login_visible',
+        after_step: 'launch',
+        type: 'element_exists',
+        description: 'Login button is present',
+      },
+    ],
+  };
+}
+
+function writeTmp(name, contents) {
+  const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-')), name);
+  fs.writeFileSync(p, contents);
+  return p;
+}
+
+describe('cli handlers', () => {
+  describe('handleElements', () => {
+    test('returns ok envelope with the agnostic elements from the bridge', async () => {
+      const fakeBridge = {
+        listElements: async () => [
+          { text: 'A', accessibility_label: null, bounds: [0, 0, 2, 2], center: [1, 1], type: 'B' },
+        ],
+      };
+      const { envelope, exitKind } = await handleElements({ deviceBridge: fakeBridge });
+      expect(exitKind).toBe('ok');
+      expect(envelope.ok).toBe(true);
+      expect(envelope.data).toHaveLength(1);
+      expect(JSON.stringify(envelope)).not.toMatch(/resource_id/);
+    });
+
+    test('returns a device-fail envelope when the bridge throws', async () => {
+      const fakeBridge = {
+        listElements: async () => {
+          throw new Error('no device connected');
+        },
+      };
+      const { envelope, exitKind } = await handleElements({ deviceBridge: fakeBridge });
+      expect(exitKind).toBe('device');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('device');
+      expect(envelope.error.message).toMatch(/no device connected/);
+    });
+  });
+
+  describe('handleScreenshot', () => {
+    test('returns ok envelope with the saved path', async () => {
+      const fakeBridge = { screenshot: async (p) => p };
+      const { envelope, exitKind } = await handleScreenshot(
+        { deviceBridge: fakeBridge },
+        '/tmp/shot.png'
+      );
+      expect(exitKind).toBe('ok');
+      expect(envelope.data).toEqual({ path: '/tmp/shot.png' });
+    });
+  });
+
+  describe('handleValidate', () => {
+    test('valid scenario -> ok envelope, exitKind ok', () => {
+      const file = writeTmp('s.json', JSON.stringify(validScenario()));
+      const validator = new ScenarioValidator({ schemaPath: SCHEMA_PATH });
+      const { envelope, exitKind } = handleValidate({ validator }, file);
+      expect(exitKind).toBe('ok');
+      expect(envelope.ok).toBe(true);
+      expect(envelope.data).toEqual({ valid: true });
+    });
+
+    test('invalid scenario -> invalid_input fail, exitKind invalid_input, errors in data', () => {
+      const bad = validScenario();
+      delete bad.app_package;
+      const file = writeTmp('bad.json', JSON.stringify(bad));
+      const validator = new ScenarioValidator({ schemaPath: SCHEMA_PATH });
+      const { envelope, exitKind } = handleValidate({ validator }, file);
+      expect(exitKind).toBe('invalid_input');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('invalid_input');
+      expect(Array.isArray(envelope.data.errors)).toBe(true);
+      expect(envelope.data.errors.length).toBeGreaterThan(0);
+    });
+
+    test('unreadable / unparseable file -> invalid_input fail', () => {
+      const file = writeTmp('broken.json', '{ not valid json');
+      const validator = new ScenarioValidator({ schemaPath: SCHEMA_PATH });
+      const { envelope, exitKind } = handleValidate({ validator }, file);
+      expect(exitKind).toBe('invalid_input');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('invalid_input');
+    });
+
+    test('missing file -> invalid_input fail', () => {
+      const validator = new ScenarioValidator({ schemaPath: SCHEMA_PATH });
+      const { envelope, exitKind } = handleValidate(
+        { validator },
+        '/no/such/file/here.json'
+      );
+      expect(exitKind).toBe('invalid_input');
+      expect(envelope.ok).toBe(false);
+    });
+  });
+});

--- a/tests/unit/device/bridge.test.js
+++ b/tests/unit/device/bridge.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { DeviceBridge } = require('../../../src/device/bridge');
+
+describe('DeviceBridge', () => {
+  test('throws TypeError when call is not a function', () => {
+    expect(() => new DeviceBridge({})).toThrow(TypeError);
+    expect(() => new DeviceBridge({ call: 'nope' })).toThrow(TypeError);
+  });
+
+  describe('listElements', () => {
+    test('invokes mobile_list_elements_on_screen and returns normalized agnostic elements', async () => {
+      const calls = [];
+      const call = async (tool, args) => {
+        calls.push([tool, args]);
+        return {
+          elements: [
+            {
+              text: 'Login',
+              bounds: [0, 0, 100, 50],
+              resource_id: 'com.app:id/login',
+              type: 'Button',
+            },
+          ],
+        };
+      };
+      const bridge = new DeviceBridge({ call });
+      const els = await bridge.listElements();
+
+      expect(calls).toEqual([['mobile_list_elements_on_screen', {}]]);
+      expect(els).toHaveLength(1);
+      expect(els[0]).toEqual({
+        text: 'Login',
+        accessibility_label: null,
+        bounds: [0, 0, 100, 50],
+        center: [50, 25],
+        type: 'Button',
+      });
+      expect(Object.keys(els[0])).not.toContain('resource_id');
+    });
+
+    test('tolerates the result being a bare array', async () => {
+      const call = async () => [{ text: 'A', bounds: [0, 0, 2, 2] }];
+      const bridge = new DeviceBridge({ call });
+      const els = await bridge.listElements();
+      expect(els).toHaveLength(1);
+      expect(els[0].center).toEqual([1, 1]);
+    });
+  });
+
+  describe('screenshot', () => {
+    test('invokes mobile_save_screenshot with the dest path and returns result.path', async () => {
+      const calls = [];
+      const call = async (tool, args) => {
+        calls.push([tool, args]);
+        return { path: '/tmp/actual.png' };
+      };
+      const bridge = new DeviceBridge({ call });
+      const p = await bridge.screenshot('/tmp/req.png');
+      expect(calls).toEqual([['mobile_save_screenshot', { path: '/tmp/req.png' }]]);
+      expect(p).toBe('/tmp/actual.png');
+    });
+
+    test('falls back to the requested path when result has none', async () => {
+      const call = async () => ({});
+      const bridge = new DeviceBridge({ call });
+      const p = await bridge.screenshot('/tmp/req.png');
+      expect(p).toBe('/tmp/req.png');
+    });
+  });
+});

--- a/tests/unit/device/element-model.test.js
+++ b/tests/unit/device/element-model.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { normalize } = require('../../../src/device/element-model');
+
+describe('element-model.normalize', () => {
+  test('normalizes a bounds-based element and computes center midpoint', () => {
+    const out = normalize([
+      {
+        text: 'Login',
+        accessibility_label: 'login-button',
+        bounds: [0, 0, 100, 50],
+        type: 'android.widget.Button',
+      },
+    ]);
+    expect(out).toEqual([
+      {
+        text: 'Login',
+        accessibility_label: 'login-button',
+        bounds: [0, 0, 100, 50],
+        center: [50, 25],
+        type: 'android.widget.Button',
+      },
+    ]);
+  });
+
+  test('accepts rect:{x,y,width,height} and derives bounds + center', () => {
+    const out = normalize([
+      { label: 'Box', rect: { x: 10, y: 20, width: 40, height: 60 }, type: 'View' },
+    ]);
+    expect(out[0].bounds).toEqual([10, 20, 50, 80]);
+    expect(out[0].center).toEqual([30, 50]);
+    // `label` is mapped onto accessibility_label
+    expect(out[0].accessibility_label).toBe('Box');
+  });
+
+  test('accepts a coordinates array as bounds', () => {
+    const out = normalize([{ coordinates: [5, 5, 15, 25], text: 'C' }]);
+    expect(out[0].bounds).toEqual([5, 5, 15, 25]);
+    expect(out[0].center).toEqual([10, 15]);
+  });
+
+  test('defaults missing text and label to null', () => {
+    const out = normalize([{ bounds: [0, 0, 10, 10], type: 'View' }]);
+    expect(out[0].text).toBeNull();
+    expect(out[0].accessibility_label).toBeNull();
+  });
+
+  test('STRIPS resource_id and identifier (platform-agnostic invariant)', () => {
+    const out = normalize([
+      {
+        text: 'X',
+        bounds: [0, 0, 2, 2],
+        resource_id: 'com.app:id/login',
+        identifier: 'loginBtn',
+        type: 'Button',
+      },
+    ]);
+    const keys = Object.keys(out[0]);
+    expect(keys).not.toContain('resource_id');
+    expect(keys).not.toContain('identifier');
+    // exact key set is the agnostic shape
+    expect(keys.sort()).toEqual(
+      ['accessibility_label', 'bounds', 'center', 'text', 'type'].sort()
+    );
+  });
+
+  test('tolerates empty / non-array input', () => {
+    expect(normalize([])).toEqual([]);
+    expect(normalize(undefined)).toEqual([]);
+    expect(normalize(null)).toEqual([]);
+  });
+
+  test('skips entries with no resolvable bounds', () => {
+    const out = normalize([{ text: 'no-bounds' }, { bounds: [0, 0, 4, 4] }]);
+    expect(out).toHaveLength(1);
+    expect(out[0].bounds).toEqual([0, 0, 4, 4]);
+  });
+});

--- a/tests/unit/device/mobile-mcp-client.smoke.test.js
+++ b/tests/unit/device/mobile-mcp-client.smoke.test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// Smoke test only — must NOT spawn mobile-mcp.
+const mod = require('../../../src/device/mobile-mcp-client');
+
+describe('mobile-mcp-client (smoke)', () => {
+  test('module loads and exports createCall', () => {
+    expect(typeof mod.createCall).toBe('function');
+  });
+});

--- a/tests/unit/output/envelope.test.js
+++ b/tests/unit/output/envelope.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const {
+  SCHEMA_VERSION,
+  EXIT,
+  ok,
+  fail,
+  exitCodeFor,
+  render,
+} = require('../../../src/output/envelope');
+
+describe('envelope', () => {
+  test('SCHEMA_VERSION is 2.1', () => {
+    expect(SCHEMA_VERSION).toBe('2.1');
+  });
+
+  test('EXIT map has the documented codes', () => {
+    expect(EXIT).toEqual({
+      OK: 0,
+      DEVICE: 2,
+      INVALID_INPUT: 3,
+      TARGET_NOT_FOUND: 4,
+      CANCEL: 130,
+    });
+  });
+
+  describe('ok()', () => {
+    test('wraps data with ok:true and schema_version', () => {
+      const env = ok({ a: 1 });
+      expect(env).toEqual({
+        ok: true,
+        data: { a: 1 },
+        schema_version: '2.1',
+      });
+    });
+
+    test('handles array data', () => {
+      const env = ok([{ text: 'x' }]);
+      expect(env.ok).toBe(true);
+      expect(env.data).toEqual([{ text: 'x' }]);
+    });
+  });
+
+  describe('fail()', () => {
+    test('builds error envelope with default null hint', () => {
+      const env = fail('device', 'no device');
+      expect(env).toEqual({
+        ok: false,
+        error: { kind: 'device', message: 'no device' },
+        hint: null,
+        schema_version: '2.1',
+      });
+    });
+
+    test('carries a hint when provided', () => {
+      const env = fail('invalid_input', 'bad json', 'check the file');
+      expect(env.hint).toBe('check the file');
+      expect(env.error).toEqual({ kind: 'invalid_input', message: 'bad json' });
+    });
+  });
+
+  describe('exitCodeFor()', () => {
+    test.each([
+      ['ok', 0],
+      ['device', 2],
+      ['invalid_input', 3],
+      ['target_not_found', 4],
+      ['cancel', 130],
+      ['internal', 1],
+    ])('maps %s -> %i', (kind, code) => {
+      expect(exitCodeFor(kind)).toBe(code);
+    });
+
+    test('unknown kind falls back to internal (1)', () => {
+      expect(exitCodeFor('something_else')).toBe(1);
+    });
+  });
+
+  describe('render()', () => {
+    test('default renders JSON string of the envelope', () => {
+      const env = ok({ a: 1 });
+      expect(render(env)).toBe(JSON.stringify(env));
+    });
+
+    test('human mode renders readable text for ok', () => {
+      const out = render(ok({ a: 1 }), { human: true });
+      expect(out).toMatch(/ok/i);
+      expect(out).not.toBe(JSON.stringify(ok({ a: 1 })));
+    });
+
+    test('human mode renders readable text for fail including message', () => {
+      const out = render(fail('device', 'no device connected'), { human: true });
+      expect(out).toMatch(/no device connected/);
+    });
+  });
+});

--- a/tests/unit/scenario/validator.test.js
+++ b/tests/unit/scenario/validator.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const path = require('path');
+const { ScenarioValidator } = require('../../../src/scenario/validator');
+
+const SCHEMA_PATH = path.resolve(
+  __dirname,
+  '../../../templates/mobile-automator-generator/references/scenario_schema.json'
+);
+
+// Minimal schema-conformant scenario built from the schema `required` fields.
+function validScenario() {
+  return {
+    $schema_version: '2.1',
+    scenario_id: 'login_smoke',
+    name: 'Login smoke',
+    description: 'Verifies the user can reach the login screen.',
+    platform: 'cross-platform',
+    app_package: 'com.example.app',
+    metadata: {
+      app_version: 'staging-latest',
+      environment: 'staging',
+    },
+    steps: [
+      {
+        id: 'launch',
+        action: 'launch_app',
+        description: 'Launch the app',
+      },
+    ],
+    assertions: [
+      {
+        id: 'login_visible',
+        after_step: 'launch',
+        type: 'element_exists',
+        description: 'Login button is present',
+      },
+    ],
+  };
+}
+
+describe('ScenarioValidator', () => {
+  test('a minimal schema-conformant scenario is valid', () => {
+    const v = new ScenarioValidator({ schemaPath: SCHEMA_PATH });
+    const res = v.validate(validScenario());
+    expect(res.valid).toBe(true);
+    expect(res.errors).toEqual([]);
+  });
+
+  test('a scenario missing a required top-level field is invalid with readable errors', () => {
+    const v = new ScenarioValidator({ schemaPath: SCHEMA_PATH });
+    const bad = validScenario();
+    delete bad.app_package;
+    const res = v.validate(bad);
+    expect(res.valid).toBe(false);
+    expect(res.errors.length).toBeGreaterThan(0);
+    expect(res.errors.every((e) => typeof e === 'string')).toBe(true);
+    expect(res.errors.join(' ')).toMatch(/app_package/);
+  });
+
+  test('reports all errors (allErrors), not just the first', () => {
+    const v = new ScenarioValidator({ schemaPath: SCHEMA_PATH });
+    const bad = validScenario();
+    delete bad.app_package;
+    delete bad.name;
+    const res = v.validate(bad);
+    expect(res.valid).toBe(false);
+    expect(res.errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('defaults to the repo schema path when none is provided', () => {
+    const v = new ScenarioValidator();
+    const res = v.validate(validScenario());
+    expect(res.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
First tracer-bullet slice of the `mauto` CLI migration — a thin end-to-end vertical that proves the agent↔CLI contract.

## What
- **OutputEnvelope** — uniform `{ok,data,error,hint,schema_version}` + exit-code map (0/2/3/4/130)
- **ElementModel** — agnostic element shape `{text,accessibility_label,bounds,center,type}`; **strips `resource_id`** (asserted by test); tolerant of bounds/rect inputs
- **DeviceBridge** — owns mobile-mcp via injected `call`; `listElements`/`screenshot`
- **mobile-mcp-client** — spawns/owns mobile-mcp over MCP stdio (integration glue; smoke-only)
- **ScenarioValidator** — ajv against scenario schema 2.1
- **CLI** — commander router, JSON-by-default + `--human`; verbs `elements`, `screenshot`, `validate`
- `bin/mauto.js` entry; deps `ajv` + `@modelcontextprotocol/sdk`

## Invariants honored
Agnostic / no `resource_id` in element output · JSON envelope on every verb · one-shot verbs · device only via the bridge.

## Test plan
- `npm test`: **88 suites / 600 tests green** (+40, no regressions)
- `mauto validate <valid>` → `{ok:true,...}` exit 0; `<invalid>` → `invalid_input` exit 3; missing file → exit 3; `--human` renders text
- Real-device `elements`/`screenshot` covered by fake-`call` unit tests + client smoke test (no device in CI)

Stacked PR base of the `cli` milestone. Closes #70 · Refs #69