### PR TITLE
cli slice 2 — execute verbs + AssertionEvaluator + ResultStore

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/mohamedshalan/open-source/ma-wt/cli-70/node_modules

--- a/src/assertion/evaluator.js
+++ b/src/assertion/evaluator.js
@@ -1,0 +1,279 @@
+'use strict';
+
+// Pure assertion evaluator.
+//
+// The executor SKILL (templates/mobile-automator-executor/aware/SKILL.md) splits
+// the 27 assertion types into two tiers:
+//
+//   Tier 1 — "Powered by mobile_list_elements_on_screen()". These are purely
+//            MECHANICAL: a deterministic check over the agnostic element list
+//            (+ captured variables / a previous snapshot). The CLI owns them.
+//
+//   Tier 2 — "Powered by mobile_take_screenshot() + AI visual analysis". These
+//            require an agent to judge a screenshot, so the CLI cannot decide
+//            pass/fail. We surface them as needs_agent with pass = null.
+//
+// MECHANICAL_TYPES is the verbatim Tier-1 list from that SKILL section
+// (SKILL.md "Tier 1" bullets), minus `element_state` whose per-attribute state
+// inspection is not represented in the agnostic element model (no enabled/
+// focused/checked fields survive normalization), so it cannot be decided
+// mechanically here and falls through to needs_agent.
+const MECHANICAL_TYPES = new Set([
+  'element_exists',
+  'element_not_exists',
+  'element_visible',
+  'element_text',
+  'text_contains',
+  'text_not_empty',
+  'element_hint',
+  'pattern_match',
+  'element_count',
+  'list_item_count',
+  'list_is_empty',
+  'content_description',
+  'has_accessibility_label',
+  'value_matches_variable',
+  'text_changed',
+]);
+
+function textOf(e) {
+  return (e && typeof e.text === 'string') ? e.text : '';
+}
+
+function labelOf(e) {
+  return (e && typeof e.accessibility_label === 'string') ? e.accessibility_label : '';
+}
+
+// An element "matches" a target string if the target appears (case-insensitive)
+// in its text or its accessibility label. A null/empty target matches all.
+function matches(e, target) {
+  if (target === undefined || target === null || target === '') return true;
+  const needle = String(target).toLowerCase();
+  return (
+    textOf(e).toLowerCase().includes(needle) ||
+    labelOf(e).toLowerCase().includes(needle)
+  );
+}
+
+function findFirst(elements, target) {
+  return elements.find((e) => matches(e, target)) || null;
+}
+
+function countMatching(elements, target) {
+  return elements.filter((e) => matches(e, target)).length;
+}
+
+function compare(actual, operator, expected) {
+  switch (operator) {
+    case '>':
+      return actual > expected;
+    case '>=':
+      return actual >= expected;
+    case '<':
+      return actual < expected;
+    case '<=':
+      return actual <= expected;
+    case '!=':
+      return actual !== expected;
+    case '==':
+    case '=':
+    case undefined:
+    case null:
+    default:
+      return actual === expected;
+  }
+}
+
+function boolFromFlag(v, dflt = true) {
+  if (v === undefined || v === null || v === '') return dflt;
+  if (typeof v === 'boolean') return v;
+  return String(v).toLowerCase() !== 'false';
+}
+
+function result(type, mechanical, pass, message) {
+  return {
+    type,
+    mechanical,
+    pass,
+    needs_agent: !mechanical,
+    message,
+  };
+}
+
+function needsAgent(type) {
+  return result(
+    type,
+    false,
+    null,
+    `Assertion '${type}' is a Tier-2 visual check; the agent must judge it from a screenshot.`
+  );
+}
+
+// Evaluate a single assertion.
+//   assertion: { type, target?, expected?, operator?, count?, pattern?, variable_name? }
+//   ctx:       { elements, variables = {}, previous = null }
+function evaluate(assertion = {}, ctx = {}) {
+  const type = assertion.type;
+  const elements = Array.isArray(ctx.elements) ? ctx.elements : [];
+  const variables = ctx.variables || {};
+  const previous = Array.isArray(ctx.previous) ? ctx.previous : null;
+
+  if (!MECHANICAL_TYPES.has(type)) {
+    return needsAgent(type);
+  }
+
+  const target = assertion.target;
+  let pass = false;
+  let message = '';
+
+  switch (type) {
+    case 'element_exists': {
+      const found = findFirst(elements, target);
+      pass = Boolean(found);
+      message = pass
+        ? `Element matching '${target}' is present.`
+        : `No element matching '${target}' found on screen.`;
+      break;
+    }
+    case 'element_not_exists': {
+      const found = findFirst(elements, target);
+      pass = !found;
+      message = pass
+        ? `Element matching '${target}' is absent, as expected.`
+        : `Element matching '${target}' is present but expected to be absent.`;
+      break;
+    }
+    case 'element_visible': {
+      const wantVisible = boolFromFlag(assertion.expected, true);
+      const found = Boolean(findFirst(elements, target));
+      pass = found === wantVisible;
+      message = pass
+        ? `Element '${target}' visibility=${found} matches expected=${wantVisible}.`
+        : `Element '${target}' visibility=${found} but expected=${wantVisible}.`;
+      break;
+    }
+    case 'element_text': {
+      const found = findFirst(elements, target);
+      const actual = found ? textOf(found) : null;
+      pass = actual !== null && actual === assertion.expected;
+      message = pass
+        ? `Element '${target}' text equals '${assertion.expected}'.`
+        : `Element '${target}' text is '${actual}', expected '${assertion.expected}'.`;
+      break;
+    }
+    case 'text_contains': {
+      const needle = String(assertion.expected == null ? '' : assertion.expected);
+      const scope = assertion.target ? elements.filter((e) => matches(e, assertion.target)) : elements;
+      const hit = scope.find((e) => textOf(e).includes(needle));
+      pass = Boolean(hit);
+      message = pass
+        ? `Found text containing '${needle}'.`
+        : `No element text contains '${needle}'.`;
+      break;
+    }
+    case 'text_not_empty': {
+      const found = findFirst(elements, target);
+      pass = Boolean(found) && textOf(found).length > 0;
+      message = pass
+        ? `Element '${target}' has non-empty text.`
+        : `Element '${target}' has empty or missing text.`;
+      break;
+    }
+    case 'element_hint': {
+      const found = findFirst(elements, target);
+      // The agnostic model has no dedicated hint field; treat text/label as the
+      // best available surface for a hint/placeholder match.
+      const surface = found ? `${textOf(found)} ${labelOf(found)}` : '';
+      const expected = String(assertion.expected == null ? '' : assertion.expected);
+      pass = Boolean(found) && surface.includes(expected);
+      message = pass
+        ? `Element '${target}' hint matches '${expected}'.`
+        : `Element '${target}' hint does not match '${expected}'.`;
+      break;
+    }
+    case 'pattern_match': {
+      let re;
+      try {
+        re = new RegExp(assertion.pattern);
+      } catch (err) {
+        return result(type, true, false, `Invalid regex pattern: ${err.message}`);
+      }
+      const scope = assertion.target ? elements.filter((e) => matches(e, assertion.target)) : elements;
+      pass = scope.some((e) => re.test(textOf(e)));
+      message = pass
+        ? `At least one element text matches /${assertion.pattern}/.`
+        : `No element text matches /${assertion.pattern}/.`;
+      break;
+    }
+    case 'element_count':
+    case 'list_item_count': {
+      const actual = countMatching(elements, target);
+      const expected = Number(assertion.count);
+      const operator = assertion.operator || '==';
+      pass = compare(actual, operator, expected);
+      message = pass
+        ? `Count ${actual} ${operator} ${expected} for '${target}'.`
+        : `Count ${actual} does not satisfy ${operator} ${expected} for '${target}'.`;
+      break;
+    }
+    case 'list_is_empty': {
+      const actual = countMatching(elements, target);
+      pass = actual === 0;
+      message = pass
+        ? `No items matching '${target}' (list empty).`
+        : `${actual} item(s) matching '${target}' present (list not empty).`;
+      break;
+    }
+    case 'content_description': {
+      const found = findFirst(elements, target);
+      const label = found ? labelOf(found) : '';
+      const expected = String(assertion.expected == null ? '' : assertion.expected);
+      pass = Boolean(found) && (expected === '' ? label.length > 0 : label === expected);
+      message = pass
+        ? `Element '${target}' content-description matches.`
+        : `Element '${target}' content-description '${label}' did not match '${expected}'.`;
+      break;
+    }
+    case 'has_accessibility_label': {
+      const found = findFirst(elements, target);
+      const label = found ? labelOf(found) : '';
+      pass = Boolean(found) && label.length > 0;
+      message = pass
+        ? `Element '${target}' has a non-empty accessibility label.`
+        : `Element '${target}' is missing an accessibility label.`;
+      break;
+    }
+    case 'value_matches_variable': {
+      const varName = assertion.variable_name;
+      const expected = variables[varName];
+      const found = findFirst(elements, target);
+      const actual = found ? textOf(found) : null;
+      pass = expected !== undefined && actual !== null && actual.includes(String(expected));
+      message = pass
+        ? `Element '${target}' contains variable '${varName}'=${expected}.`
+        : `Element '${target}' text '${actual}' does not match variable '${varName}'=${expected}.`;
+      break;
+    }
+    case 'text_changed': {
+      if (!previous) {
+        return result(type, true, false, `No previous snapshot to compare '${target}' against.`);
+      }
+      const curr = findFirst(elements, target);
+      const prev = findFirst(previous, target);
+      const currText = curr ? textOf(curr) : null;
+      const prevText = prev ? textOf(prev) : null;
+      pass = currText !== prevText;
+      message = pass
+        ? `Element '${target}' text changed from '${prevText}' to '${currText}'.`
+        : `Element '${target}' text unchanged ('${currText}').`;
+      break;
+    }
+    default:
+      // Should be unreachable given the MECHANICAL_TYPES guard above.
+      return needsAgent(type);
+  }
+
+  return result(type, true, pass, message);
+}
+
+module.exports = { MECHANICAL_TYPES, evaluate };

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,27 @@ const { Command } = require('commander');
 const { ok, fail, render, exitCodeFor } = require('./output/envelope');
 const { DeviceBridge } = require('./device/bridge');
 const { ScenarioValidator } = require('./scenario/validator');
+const { evaluate, MECHANICAL_TYPES } = require('./assertion/evaluator');
+const { ResultStore } = require('./result/store');
+
+const KNOWN_ASSERTION_TYPES = new Set([
+  ...MECHANICAL_TYPES,
+  // Tier-2 visual types the agent must judge.
+  'screenshot_match',
+  'visual_state',
+  'element_fully_visible',
+  'color_style',
+  'screen_title',
+  'alert_present',
+  'alert_text',
+  'toast_visible',
+  'keyboard_visible',
+  'dark_mode_active',
+  'permission_dialog_shown',
+  'element_state',
+]);
+
+const SWIPE_DIRECTIONS = new Set(['up', 'down', 'left', 'right']);
 
 // ---------------------------------------------------------------------------
 // Handlers — pure-ish: accept injected deps, return { envelope, exitKind }.
@@ -87,6 +108,157 @@ function handleValidate({ validator }, file) {
   return { envelope: env, exitKind: 'invalid_input' };
 }
 
+function deviceFail(err) {
+  return {
+    envelope: fail(
+      'device',
+      err.message || String(err),
+      'Ensure a device or simulator is connected and the app is running.'
+    ),
+    exitKind: 'device',
+  };
+}
+
+async function handleTap({ deviceBridge }, raw) {
+  const parts = String(raw == null ? '' : raw).split(',');
+  if (parts.length !== 2) {
+    return {
+      envelope: fail('invalid_input', `expected coordinates as "x,y", got "${raw}"`, 'Pass --at <x,y>, e.g. --at 100,250.'),
+      exitKind: 'invalid_input',
+    };
+  }
+  const x = Number(parts[0]);
+  const y = Number(parts[1]);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return {
+      envelope: fail('invalid_input', `coordinates must be numbers, got "${raw}"`, 'Pass --at <x,y>, e.g. --at 100,250.'),
+      exitKind: 'invalid_input',
+    };
+  }
+  const ix = Math.round(x);
+  const iy = Math.round(y);
+  try {
+    await deviceBridge.tap({ x: ix, y: iy });
+    return { envelope: ok({ tapped: [ix, iy] }), exitKind: 'ok' };
+  } catch (err) {
+    return deviceFail(err);
+  }
+}
+
+async function handleType({ deviceBridge }, text) {
+  const str = text == null ? '' : String(text);
+  try {
+    await deviceBridge.type(str);
+    return { envelope: ok({ typed: str.length }), exitKind: 'ok' };
+  } catch (err) {
+    return deviceFail(err);
+  }
+}
+
+async function handleSwipe({ deviceBridge }, direction) {
+  const dir = String(direction || '').toLowerCase();
+  if (!SWIPE_DIRECTIONS.has(dir)) {
+    return {
+      envelope: fail('invalid_input', `invalid swipe direction "${direction}"`, 'Use one of: up, down, left, right.'),
+      exitKind: 'invalid_input',
+    };
+  }
+  try {
+    await deviceBridge.swipe({ direction: dir });
+    return { envelope: ok({ swiped: dir }), exitKind: 'ok' };
+  } catch (err) {
+    return deviceFail(err);
+  }
+}
+
+async function handlePress({ deviceBridge }, button) {
+  const b = String(button || '');
+  if (!b) {
+    return {
+      envelope: fail('invalid_input', 'a button name is required', 'e.g. mauto press BACK'),
+      exitKind: 'invalid_input',
+    };
+  }
+  try {
+    await deviceBridge.pressButton(b);
+    return { envelope: ok({ pressed: b }), exitKind: 'ok' };
+  } catch (err) {
+    return deviceFail(err);
+  }
+}
+
+// Build an assertion object from CLI flags, fetch the current element list,
+// and run the pure evaluator. A failed assertion is a valid RESULT (exit 0);
+// only an unknown assertion type is a structural (invalid_input) error.
+async function handleAssert({ deviceBridge }, type, flags = {}) {
+  if (!KNOWN_ASSERTION_TYPES.has(type)) {
+    return {
+      envelope: fail('invalid_input', `unknown assertion type "${type}"`, 'See the executor SKILL for the supported assertion types.'),
+      exitKind: 'invalid_input',
+    };
+  }
+
+  let elements;
+  try {
+    elements = await deviceBridge.listElements();
+  } catch (err) {
+    return deviceFail(err);
+  }
+
+  const assertion = { type };
+  if (flags.target !== undefined) assertion.target = flags.target;
+  if (flags.expected !== undefined) assertion.expected = flags.expected;
+  if (flags.operator !== undefined) assertion.operator = flags.operator;
+  if (flags.count !== undefined) assertion.count = Number(flags.count);
+  if (flags.pattern !== undefined) assertion.pattern = flags.pattern;
+  if (flags.variable !== undefined) assertion.variable_name = flags.variable;
+
+  const r = evaluate(assertion, { elements });
+  return {
+    envelope: ok({
+      type: r.type,
+      mechanical: r.mechanical,
+      pass: r.pass,
+      needs_agent: r.needs_agent,
+      message: r.message,
+    }),
+    exitKind: 'ok',
+  };
+}
+
+function handleResultAddStep({ resultStoreFactory, projectRoot }, opts) {
+  const { runId, scenarioId, stepId, status, attempts } = opts;
+  if (!runId || !stepId || !status) {
+    return {
+      envelope: fail('invalid_input', '--run-id, --step-id and --status are required', null),
+      exitKind: 'invalid_input',
+    };
+  }
+  const store = resultStoreFactory({ runId, scenarioId, projectRoot });
+  const step = store.addStep({
+    step_id: stepId,
+    status,
+    attempts: attempts === undefined ? 1 : Number(attempts),
+  });
+  return { envelope: ok({ run_id: runId, step }), exitKind: 'ok' };
+}
+
+function handleResultFinalize({ resultStoreFactory, projectRoot }, opts) {
+  const { runId, scenarioId, status, duration } = opts;
+  if (!runId) {
+    return {
+      envelope: fail('invalid_input', '--run-id is required', null),
+      exitKind: 'invalid_input',
+    };
+  }
+  const store = resultStoreFactory({ runId, scenarioId, projectRoot });
+  const result = store.finalize({
+    status,
+    durationSeconds: duration === undefined ? 0 : Number(duration),
+  });
+  return { envelope: ok(result), exitKind: 'ok' };
+}
+
 // ---------------------------------------------------------------------------
 // Program wiring
 // ---------------------------------------------------------------------------
@@ -105,6 +277,10 @@ function buildProgram(deps = {}) {
     // Factory returning { bridge, close }. Overridable in tests.
     deviceBridgeFactory = realDeviceBridge,
     validator = new ScenarioValidator(),
+    // Factory for the incremental result store. Overridable in tests.
+    resultStoreFactory = (args) => new ResultStore(args),
+    // Project root used to resolve mobile-automator/results/.
+    projectRoot = process.cwd(),
     // Sink used to emit the rendered envelope + drive the exit code.
     emit = defaultEmit,
   } = deps;
@@ -153,6 +329,113 @@ function buildProgram(deps = {}) {
       emit(r, humanFlag());
     });
 
+  // --- Action verbs (one-shot; CLI owns the mechanical work) ---------------
+
+  const withBridge = async (device, fn) => {
+    const { bridge, close } = await deviceBridgeFactory({ device });
+    try {
+      const r = await fn(bridge);
+      emit(r, humanFlag());
+    } finally {
+      if (typeof close === 'function') await close();
+    }
+  };
+
+  program
+    .command('tap')
+    .description('Tap at absolute screen coordinates')
+    .requiredOption('--at <x,y>', 'coordinates as "x,y"')
+    .option('--device <id>', 'target device id')
+    .action((opts) => withBridge(opts.device, (bridge) => handleTap({ deviceBridge: bridge }, opts.at)));
+
+  program
+    .command('type <text>')
+    .description('Type text into the focused element')
+    .option('--device <id>', 'target device id')
+    .action((text, opts) => withBridge(opts.device, (bridge) => handleType({ deviceBridge: bridge }, text)));
+
+  program
+    .command('swipe')
+    .description('Swipe in a cardinal direction')
+    .requiredOption('--direction <dir>', 'up | down | left | right')
+    .option('--device <id>', 'target device id')
+    .action((opts) => withBridge(opts.device, (bridge) => handleSwipe({ deviceBridge: bridge }, opts.direction)));
+
+  program
+    .command('press <button>')
+    .description('Press a system/hardware button (BACK, HOME, ENTER, ...)')
+    .option('--device <id>', 'target device id')
+    .action((button, opts) => withBridge(opts.device, (bridge) => handlePress({ deviceBridge: bridge }, button)));
+
+  program
+    .command('assert <type>')
+    .description('Evaluate an assertion against the current screen (mechanical types decided by the CLI; visual types deferred to the agent)')
+    .option('--target <s>', 'element/target description')
+    .option('--expected <s>', 'expected value')
+    .option('--operator <op>', 'comparison operator for count assertions')
+    .option('--count <n>', 'expected count')
+    .option('--pattern <re>', 'regex pattern')
+    .option('--variable <name>', 'captured variable name')
+    .option('--device <id>', 'target device id')
+    .action((type, opts) =>
+      withBridge(opts.device, (bridge) =>
+        handleAssert({ deviceBridge: bridge }, type, {
+          target: opts.target,
+          expected: opts.expected,
+          operator: opts.operator,
+          count: opts.count,
+          pattern: opts.pattern,
+          variable: opts.variable,
+        })
+      )
+    );
+
+  // --- Result persistence verbs --------------------------------------------
+
+  const result = program.command('result').description('Incremental result file operations');
+
+  result
+    .command('add-step')
+    .description('Append a step result to the run file')
+    .requiredOption('--run-id <id>', 'run identifier (run_YYYYMMDD_HHMMSS)')
+    .option('--scenario-id <id>', 'scenario identifier')
+    .requiredOption('--step-id <id>', 'step identifier')
+    .requiredOption('--status <s>', 'pass | fail | skipped | error')
+    .option('--attempts <n>', 'number of attempts (>1 records flakiness on pass)')
+    .action((opts) => {
+      const r = handleResultAddStep(
+        { resultStoreFactory, projectRoot },
+        {
+          runId: opts.runId,
+          scenarioId: opts.scenarioId,
+          stepId: opts.stepId,
+          status: opts.status,
+          attempts: opts.attempts,
+        }
+      );
+      emit(r, humanFlag());
+    });
+
+  result
+    .command('finalize')
+    .description('Assemble and write the final result file')
+    .requiredOption('--run-id <id>', 'run identifier')
+    .option('--scenario-id <id>', 'scenario identifier')
+    .option('--status <s>', 'passed | failed | error')
+    .option('--duration <secs>', 'total duration in seconds')
+    .action((opts) => {
+      const r = handleResultFinalize(
+        { resultStoreFactory, projectRoot },
+        {
+          runId: opts.runId,
+          scenarioId: opts.scenarioId,
+          status: opts.status,
+          duration: opts.duration,
+        }
+      );
+      emit(r, humanFlag());
+    });
+
   return program;
 }
 
@@ -172,4 +455,11 @@ module.exports = {
   handleElements,
   handleScreenshot,
   handleValidate,
+  handleTap,
+  handleType,
+  handleSwipe,
+  handlePress,
+  handleAssert,
+  handleResultAddStep,
+  handleResultFinalize,
 };

--- a/src/device/bridge.js
+++ b/src/device/bridge.js
@@ -23,6 +23,28 @@ class DeviceBridge {
     const result = await this._call('mobile_save_screenshot', { path: destPath });
     return (result && result.path) || destPath;
   }
+
+  // Tap at absolute screen coordinates. The agent derives x,y from listElements
+  // centers, so the bridge stays free of any element targeting logic.
+  async tap({ x, y } = {}) {
+    return this._call('mobile_click_on_screen_at_coordinates', { x, y });
+  }
+
+  // Type into the focused element. We never auto-submit; pressing ENTER is a
+  // distinct, explicit action via pressButton.
+  async type(text) {
+    return this._call('mobile_type_keys', { text, submit: false });
+  }
+
+  // Swipe in a cardinal direction (up/down/left/right) from screen center.
+  async swipe({ direction } = {}) {
+    return this._call('mobile_swipe_on_screen', { direction });
+  }
+
+  // Press a hardware/system button (BACK, HOME, ENTER, ...).
+  async pressButton(button) {
+    return this._call('mobile_press_button', { button });
+  }
 }
 
 module.exports = { DeviceBridge };

--- a/src/result/store.js
+++ b/src/result/store.js
@@ -1,0 +1,162 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Incremental result accumulator that persists to
+//   <projectRoot>/mobile-automator/results/<runId>.json
+//
+// The CLI runs one-shot: each `result add-step` / `result finalize` invocation
+// is a fresh process. To support that, the store loads any existing in-progress
+// file for the run on construction and appends to it, so state survives across
+// invocations until finalize writes the schema-conformant result.
+
+const SCHEMA_VERSION = '2.0';
+
+function defaultMetadata(overrides = {}) {
+  return {
+    app_version: overrides.app_version || 'unknown',
+    device_model: overrides.device_model || 'unknown',
+    api_level: overrides.api_level || 'unknown',
+    environment: overrides.environment || 'unknown',
+    timestamp: overrides.timestamp || new Date().toISOString(),
+  };
+}
+
+// Normalize the caller-friendly status ('pass'/'fail') to the schema enums.
+function stepStatus(status) {
+  if (status === 'pass' || status === 'passed') return 'passed';
+  if (status === 'fail' || status === 'failed') return 'failed';
+  if (status === 'skipped' || status === 'skip') return 'skipped';
+  return 'error';
+}
+
+function assertionStatus(pass) {
+  return pass ? 'passed' : 'failed';
+}
+
+class ResultStore {
+  constructor({ runId, scenarioId, projectRoot, metadata } = {}) {
+    if (!runId) throw new Error('ResultStore requires a runId');
+    if (!projectRoot) throw new Error('ResultStore requires a projectRoot');
+
+    this.runId = runId;
+    this.scenarioId = scenarioId || null;
+    this.projectRoot = projectRoot;
+    this._metadataOverrides = metadata || {};
+
+    this._dir = path.join(projectRoot, 'mobile-automator', 'results');
+    this._file = path.join(this._dir, `${runId}.json`);
+
+    const loaded = this._load();
+    this._steps = loaded.steps_executed || [];
+    this._assertions = loaded.assertion_results || [];
+    this._observations = loaded.observations || [];
+    this._capturedVariables = loaded.captured_variables || {};
+    if (!this.scenarioId && loaded.scenario_id) this.scenarioId = loaded.scenario_id;
+  }
+
+  // Load an existing in-progress (or finalized) file if present; else empty.
+  _load() {
+    try {
+      const raw = fs.readFileSync(this._file, 'utf8');
+      return JSON.parse(raw);
+    } catch (_e) {
+      return {};
+    }
+  }
+
+  _persistInProgress() {
+    fs.mkdirSync(this._dir, { recursive: true });
+    const snapshot = {
+      run_id: this.runId,
+      scenario_id: this.scenarioId,
+      schema_version: SCHEMA_VERSION,
+      steps_executed: this._steps,
+      assertion_results: this._assertions,
+      observations: this._observations,
+      captured_variables: this._capturedVariables,
+      _in_progress: true,
+    };
+    fs.writeFileSync(this._file, JSON.stringify(snapshot, null, 2));
+  }
+
+  addStep({ step_id, status, attempts = 1, screenshot = null, error_message = null, observations = null } = {}) {
+    const normalized = stepStatus(status);
+    const retryCount = Math.max(0, Number(attempts) - 1);
+    const step = {
+      step_id,
+      status: normalized,
+      screenshot,
+      error_message,
+      retried: retryCount > 0,
+      retry_count: retryCount,
+      observations,
+    };
+    this._steps.push(step);
+
+    // Flakiness bookkeeping: a step that ultimately PASSED but needed more than
+    // one attempt is flaky.
+    if (retryCount > 0 && normalized === 'passed') {
+      this._observations.push({
+        type: 'flakiness',
+        step_id,
+        message: `Step '${step_id}' passed only after ${attempts} attempts; possible flakiness.`,
+      });
+    }
+
+    this._persistInProgress();
+    return step;
+  }
+
+  addAssertion({ step_id, assertion_id, type, pass, message, expected = null, actual = null } = {}) {
+    const entry = {
+      assertion_id: assertion_id || `${step_id || 'assert'}_${type || 'unknown'}_${this._assertions.length + 1}`,
+      status: assertionStatus(pass),
+      expected: expected == null ? null : String(expected),
+      actual: actual == null ? null : String(actual),
+      message: message || '',
+    };
+    this._assertions.push(entry);
+    this._persistInProgress();
+    return entry;
+  }
+
+  captureVariable(name, value) {
+    this._capturedVariables[name] = value;
+    this._persistInProgress();
+  }
+
+  finalize({ status, durationSeconds = 0, summary, metadata } = {}) {
+    const passed = this._assertions.filter((a) => a.status === 'passed').length;
+    const failed = this._assertions.filter((a) => a.status === 'failed').length;
+    const total = this._assertions.length;
+
+    const resolvedStatus = status || (failed > 0 ? 'failed' : 'passed');
+
+    const result = {
+      run_id: this.runId,
+      scenario_id: this.scenarioId,
+      schema_version: SCHEMA_VERSION,
+      status: resolvedStatus,
+      metadata: defaultMetadata({ ...this._metadataOverrides, ...(metadata || {}) }),
+      total_assertions: total,
+      passed_assertions: passed,
+      failed_assertions: failed,
+      duration_seconds: Number(durationSeconds) || 0,
+      steps_executed: this._steps,
+      assertion_results: this._assertions,
+      observations: this._observations,
+      captured_variables: this._capturedVariables,
+      summary:
+        summary ||
+        `${resolvedStatus}: ${passed}/${total} assertion(s) passed across ${this._steps.length} step(s).`,
+    };
+
+    fs.mkdirSync(this._dir, { recursive: true });
+    fs.writeFileSync(this._file, JSON.stringify(result, null, 2));
+    return result;
+  }
+}
+
+module.exports = { ResultStore };

--- a/tests/unit/assertion/evaluator.test.js
+++ b/tests/unit/assertion/evaluator.test.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const {
+  MECHANICAL_TYPES,
+  evaluate,
+} = require('../../../src/assertion/evaluator');
+
+// Agnostic element fixtures (shape produced by ElementModel.normalize).
+function el(text, extra = {}) {
+  return {
+    text,
+    accessibility_label: null,
+    bounds: [0, 0, 10, 10],
+    center: [5, 5],
+    type: null,
+    ...extra,
+  };
+}
+
+describe('MECHANICAL_TYPES', () => {
+  test('is the Tier-1 set from the executor SKILL', () => {
+    expect(MECHANICAL_TYPES.has('element_exists')).toBe(true);
+    expect(MECHANICAL_TYPES.has('element_not_exists')).toBe(true);
+    expect(MECHANICAL_TYPES.has('element_visible')).toBe(true);
+    expect(MECHANICAL_TYPES.has('element_text')).toBe(true);
+    expect(MECHANICAL_TYPES.has('text_contains')).toBe(true);
+    expect(MECHANICAL_TYPES.has('text_not_empty')).toBe(true);
+    expect(MECHANICAL_TYPES.has('element_hint')).toBe(true);
+    expect(MECHANICAL_TYPES.has('pattern_match')).toBe(true);
+    expect(MECHANICAL_TYPES.has('element_count')).toBe(true);
+    expect(MECHANICAL_TYPES.has('list_item_count')).toBe(true);
+    expect(MECHANICAL_TYPES.has('list_is_empty')).toBe(true);
+    expect(MECHANICAL_TYPES.has('content_description')).toBe(true);
+    expect(MECHANICAL_TYPES.has('has_accessibility_label')).toBe(true);
+    expect(MECHANICAL_TYPES.has('value_matches_variable')).toBe(true);
+    expect(MECHANICAL_TYPES.has('text_changed')).toBe(true);
+    // Tier 2 must NOT be mechanical.
+    expect(MECHANICAL_TYPES.has('screenshot_match')).toBe(false);
+    expect(MECHANICAL_TYPES.has('element_fully_visible')).toBe(false);
+    expect(MECHANICAL_TYPES.has('color_style')).toBe(false);
+  });
+});
+
+describe('evaluate — mechanical types', () => {
+  test('element_exists passes when a matching element is present', () => {
+    const r = evaluate(
+      { type: 'element_exists', target: 'Login' },
+      { elements: [el('Login'), el('Cancel')] }
+    );
+    expect(r.type).toBe('element_exists');
+    expect(r.mechanical).toBe(true);
+    expect(r.needs_agent).toBe(false);
+    expect(r.pass).toBe(true);
+  });
+
+  test('element_exists fails when no element matches', () => {
+    const r = evaluate(
+      { type: 'element_exists', target: 'Login' },
+      { elements: [el('Cancel')] }
+    );
+    expect(r.pass).toBe(false);
+    expect(r.mechanical).toBe(true);
+  });
+
+  test('element_not_exists passes when absent, fails when present', () => {
+    expect(
+      evaluate({ type: 'element_not_exists', target: 'Login' }, { elements: [el('Cancel')] }).pass
+    ).toBe(true);
+    expect(
+      evaluate({ type: 'element_not_exists', target: 'Login' }, { elements: [el('Login')] }).pass
+    ).toBe(false);
+  });
+
+  test('element_visible honors expected flag', () => {
+    expect(
+      evaluate(
+        { type: 'element_visible', target: 'Login', expected: 'false' },
+        { elements: [el('Cancel')] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'element_visible', target: 'Login' },
+        { elements: [el('Login')] }
+      ).pass
+    ).toBe(true);
+  });
+
+  test('element_text exact match pass/fail (element located by accessibility label)', () => {
+    expect(
+      evaluate(
+        { type: 'element_text', target: 'greeting', expected: 'Hello' },
+        { elements: [el('Hello', { accessibility_label: 'greeting' })] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'element_text', target: 'greeting', expected: 'Hello' },
+        { elements: [el('Hello World', { accessibility_label: 'greeting' })] }
+      ).pass
+    ).toBe(false);
+  });
+
+  test('text_contains substring pass/fail', () => {
+    expect(
+      evaluate(
+        { type: 'text_contains', expected: 'ello' },
+        { elements: [el('Hello World')] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'text_contains', expected: 'zzz' },
+        { elements: [el('Hello World')] }
+      ).pass
+    ).toBe(false);
+  });
+
+  test('text_not_empty', () => {
+    expect(
+      evaluate({ type: 'text_not_empty', target: 'Hello' }, { elements: [el('Hello')] }).pass
+    ).toBe(true);
+    expect(
+      evaluate({ type: 'text_not_empty', target: 'X' }, { elements: [el('', { accessibility_label: 'X' })] }).pass
+    ).toBe(false);
+  });
+
+  test('pattern_match against element text', () => {
+    expect(
+      evaluate(
+        { type: 'pattern_match', pattern: '^\\d{3}-\\d{4}$' },
+        { elements: [el('123-4567')] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'pattern_match', pattern: '^\\d{3}-\\d{4}$' },
+        { elements: [el('nope')] }
+      ).pass
+    ).toBe(false);
+  });
+
+  test('element_count with operator', () => {
+    expect(
+      evaluate(
+        { type: 'element_count', target: 'Item', operator: '>=', count: 2 },
+        { elements: [el('Item A'), el('Item B'), el('Other')] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'element_count', target: 'Item', operator: '==', count: 5 },
+        { elements: [el('Item A')] }
+      ).pass
+    ).toBe(false);
+  });
+
+  test('list_is_empty', () => {
+    expect(
+      evaluate({ type: 'list_is_empty', target: 'Row' }, { elements: [el('Header')] }).pass
+    ).toBe(true);
+    expect(
+      evaluate({ type: 'list_is_empty', target: 'Row' }, { elements: [el('Row 1')] }).pass
+    ).toBe(false);
+  });
+
+  test('has_accessibility_label', () => {
+    expect(
+      evaluate(
+        { type: 'has_accessibility_label', target: 'icon' },
+        { elements: [el('icon', { accessibility_label: 'Settings' })] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'has_accessibility_label', target: 'icon' },
+        { elements: [el('icon', { accessibility_label: null })] }
+      ).pass
+    ).toBe(false);
+  });
+
+  test('value_matches_variable compares captured variable to element text', () => {
+    expect(
+      evaluate(
+        { type: 'value_matches_variable', target: 'order', variable_name: 'order_id' },
+        { elements: [el('ORD-99', { accessibility_label: 'order' })], variables: { order_id: 'ORD-99' } }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'value_matches_variable', target: 'order', variable_name: 'order_id' },
+        { elements: [el('ORD-00', { accessibility_label: 'order' })], variables: { order_id: 'ORD-99' } }
+      ).pass
+    ).toBe(false);
+  });
+
+  test('text_changed compares against previous snapshot', () => {
+    expect(
+      evaluate(
+        { type: 'text_changed', target: 'counter' },
+        { elements: [el('2', { accessibility_label: 'counter' })], previous: [el('1', { accessibility_label: 'counter' })] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'text_changed', target: 'counter' },
+        { elements: [el('1', { accessibility_label: 'counter' })], previous: [el('1', { accessibility_label: 'counter' })] }
+      ).pass
+    ).toBe(false);
+  });
+});
+
+describe('evaluate — non-mechanical (needs agent)', () => {
+  test('screenshot_match returns needs_agent with null pass', () => {
+    const r = evaluate({ type: 'screenshot_match' }, { elements: [] });
+    expect(r.mechanical).toBe(false);
+    expect(r.needs_agent).toBe(true);
+    expect(r.pass).toBeNull();
+    expect(r.message).toMatch(/agent/i);
+  });
+
+  test('element_fully_visible needs agent', () => {
+    const r = evaluate({ type: 'element_fully_visible', target: 'x' }, { elements: [el('x')] });
+    expect(r.needs_agent).toBe(true);
+    expect(r.pass).toBeNull();
+  });
+
+  test('an unknown/visual type is treated as needs_agent rather than crashing', () => {
+    const r = evaluate({ type: 'color_style', target: 'x' }, { elements: [el('x')] });
+    expect(r.needs_agent).toBe(true);
+    expect(r.mechanical).toBe(false);
+  });
+});

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -8,7 +8,20 @@ const {
   handleElements,
   handleScreenshot,
   handleValidate,
+  handleTap,
+  handleType,
+  handleSwipe,
+  handlePress,
+  handleAssert,
+  handleResultAddStep,
+  handleResultFinalize,
 } = require('../../src/cli');
+const Ajv = require('ajv');
+
+const RESULT_SCHEMA_PATH = path.resolve(
+  __dirname,
+  '../../templates/mobile-automator-executor/references/result_schema.json'
+);
 const { ScenarioValidator } = require('../../src/scenario/validator');
 
 const SCHEMA_PATH = path.resolve(
@@ -124,6 +137,143 @@ describe('cli handlers', () => {
       );
       expect(exitKind).toBe('invalid_input');
       expect(envelope.ok).toBe(false);
+    });
+  });
+
+  describe('handleTap', () => {
+    test('parses "x,y" and taps via the bridge', async () => {
+      const calls = [];
+      const bridge = { tap: async (c) => { calls.push(c); } };
+      const { envelope, exitKind } = await handleTap({ deviceBridge: bridge }, '12,34');
+      expect(exitKind).toBe('ok');
+      expect(envelope.data).toEqual({ tapped: [12, 34] });
+      expect(calls).toEqual([{ x: 12, y: 34 }]);
+    });
+
+    test('rejects bad coordinate format with invalid_input exit 3', async () => {
+      const bridge = { tap: async () => { throw new Error('should not be called'); } };
+      const { envelope, exitKind } = await handleTap({ deviceBridge: bridge }, 'nope');
+      expect(exitKind).toBe('invalid_input');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('invalid_input');
+    });
+  });
+
+  describe('handleType', () => {
+    test('types text and reports the length', async () => {
+      const calls = [];
+      const bridge = { type: async (t) => { calls.push(t); } };
+      const { envelope, exitKind } = await handleType({ deviceBridge: bridge }, 'hello');
+      expect(exitKind).toBe('ok');
+      expect(calls).toEqual(['hello']);
+      expect(envelope.data.typed).toBe(5);
+    });
+  });
+
+  describe('handleSwipe', () => {
+    test('swipes a valid direction', async () => {
+      const calls = [];
+      const bridge = { swipe: async (c) => { calls.push(c); } };
+      const { envelope, exitKind } = await handleSwipe({ deviceBridge: bridge }, 'up');
+      expect(exitKind).toBe('ok');
+      expect(envelope.data).toEqual({ swiped: 'up' });
+      expect(calls).toEqual([{ direction: 'up' }]);
+    });
+
+    test('rejects an invalid direction with invalid_input', async () => {
+      const bridge = { swipe: async () => { throw new Error('nope'); } };
+      const { envelope, exitKind } = await handleSwipe({ deviceBridge: bridge }, 'sideways');
+      expect(exitKind).toBe('invalid_input');
+      expect(envelope.error.kind).toBe('invalid_input');
+    });
+  });
+
+  describe('handlePress', () => {
+    test('presses a button', async () => {
+      const calls = [];
+      const bridge = { pressButton: async (b) => { calls.push(b); } };
+      const { envelope, exitKind } = await handlePress({ deviceBridge: bridge }, 'BACK');
+      expect(exitKind).toBe('ok');
+      expect(envelope.data).toEqual({ pressed: 'BACK' });
+      expect(calls).toEqual(['BACK']);
+    });
+  });
+
+  describe('handleAssert', () => {
+    const fakeBridge = (els) => ({ listElements: async () => els });
+
+    test('mechanical pass: lists elements, evaluates, exit 0', async () => {
+      const els = [
+        { text: 'Login', accessibility_label: null, bounds: [0, 0, 2, 2], center: [1, 1], type: null },
+      ];
+      const { envelope, exitKind } = await handleAssert(
+        { deviceBridge: fakeBridge(els) },
+        'element_exists',
+        { target: 'Login' }
+      );
+      expect(exitKind).toBe('ok'); // failed assertion is still exit 0
+      expect(envelope.ok).toBe(true);
+      expect(envelope.data.mechanical).toBe(true);
+      expect(envelope.data.pass).toBe(true);
+      expect(envelope.data.needs_agent).toBe(false);
+    });
+
+    test('mechanical fail still returns ok envelope, exit 0', async () => {
+      const { envelope, exitKind } = await handleAssert(
+        { deviceBridge: fakeBridge([]) },
+        'element_exists',
+        { target: 'Login' }
+      );
+      expect(exitKind).toBe('ok');
+      expect(envelope.data.pass).toBe(false);
+    });
+
+    test('non-mechanical passes through as needs_agent', async () => {
+      const { envelope, exitKind } = await handleAssert(
+        { deviceBridge: fakeBridge([]) },
+        'screenshot_match',
+        {}
+      );
+      expect(exitKind).toBe('ok');
+      expect(envelope.data.needs_agent).toBe(true);
+      expect(envelope.data.pass).toBeNull();
+    });
+
+    test('unknown type is a structural error -> invalid_input exit 3', async () => {
+      const { envelope, exitKind } = await handleAssert(
+        { deviceBridge: fakeBridge([]) },
+        'totally_made_up',
+        {}
+      );
+      expect(exitKind).toBe('invalid_input');
+      expect(envelope.error.kind).toBe('invalid_input');
+    });
+  });
+
+  describe('handleResultAddStep -> handleResultFinalize round-trip', () => {
+    test('writes a schema-conformant result to a tmp projectRoot', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cli-'));
+      const runId = 'run_20260614_120000';
+      const factory = ({ runId: rid, scenarioId, projectRoot: pr }) =>
+        new (require('../../src/result/store').ResultStore)({ runId: rid, scenarioId, projectRoot: pr });
+
+      const deps = { resultStoreFactory: factory, projectRoot };
+
+      const a = handleResultAddStep(deps, {
+        runId,
+        scenarioId: 'login_smoke',
+        stepId: 'launch',
+        status: 'pass',
+      });
+      expect(a.exitKind).toBe('ok');
+
+      const f = handleResultFinalize(deps, { runId, status: 'passed', duration: 5 });
+      expect(f.exitKind).toBe('ok');
+      expect(f.envelope.data.run_id).toBe(runId);
+
+      const schema = JSON.parse(fs.readFileSync(RESULT_SCHEMA_PATH, 'utf8'));
+      const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
+      expect(validate(f.envelope.data)).toBe(true);
     });
   });
 });

--- a/tests/unit/device/bridge.test.js
+++ b/tests/unit/device/bridge.test.js
@@ -68,4 +68,44 @@ describe('DeviceBridge', () => {
       expect(p).toBe('/tmp/req.png');
     });
   });
+
+  describe('tap', () => {
+    test('invokes mobile_click_on_screen_at_coordinates with x,y', async () => {
+      const calls = [];
+      const call = async (tool, args) => { calls.push([tool, args]); return {}; };
+      const bridge = new DeviceBridge({ call });
+      await bridge.tap({ x: 12, y: 34 });
+      expect(calls).toEqual([['mobile_click_on_screen_at_coordinates', { x: 12, y: 34 }]]);
+    });
+  });
+
+  describe('type', () => {
+    test('invokes mobile_type_keys with text and submit=false', async () => {
+      const calls = [];
+      const call = async (tool, args) => { calls.push([tool, args]); return {}; };
+      const bridge = new DeviceBridge({ call });
+      await bridge.type('hello');
+      expect(calls).toEqual([['mobile_type_keys', { text: 'hello', submit: false }]]);
+    });
+  });
+
+  describe('swipe', () => {
+    test('invokes mobile_swipe_on_screen with the direction', async () => {
+      const calls = [];
+      const call = async (tool, args) => { calls.push([tool, args]); return {}; };
+      const bridge = new DeviceBridge({ call });
+      await bridge.swipe({ direction: 'up' });
+      expect(calls).toEqual([['mobile_swipe_on_screen', { direction: 'up' }]]);
+    });
+  });
+
+  describe('pressButton', () => {
+    test('invokes mobile_press_button with the button name', async () => {
+      const calls = [];
+      const call = async (tool, args) => { calls.push([tool, args]); return {}; };
+      const bridge = new DeviceBridge({ call });
+      await bridge.pressButton('BACK');
+      expect(calls).toEqual([['mobile_press_button', { button: 'BACK' }]]);
+    });
+  });
 });

--- a/tests/unit/result/store.test.js
+++ b/tests/unit/result/store.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+
+const { ResultStore } = require('../../../src/result/store');
+
+const RESULT_SCHEMA_PATH = path.resolve(
+  __dirname,
+  '../../../templates/mobile-automator-executor/references/result_schema.json'
+);
+
+function ajvValidator() {
+  const schema = JSON.parse(fs.readFileSync(RESULT_SCHEMA_PATH, 'utf8'));
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  return ajv.compile(schema);
+}
+
+function tmpRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-store-'));
+}
+
+const RUN_ID = 'run_20260614_101500';
+
+describe('ResultStore', () => {
+  test('finalize assembles a result that conforms to result_schema.json', () => {
+    const projectRoot = tmpRoot();
+    const store = new ResultStore({ runId: RUN_ID, scenarioId: 'login_smoke', projectRoot });
+
+    store.addStep({ step_id: 'launch', status: 'pass' });
+    store.addStep({ step_id: 'tap_login', status: 'pass' });
+    store.addAssertion({ step_id: 'launch', type: 'element_exists', pass: true, message: 'Login present' });
+    store.addAssertion({ step_id: 'tap_login', type: 'element_text', pass: false, message: 'wrong text' });
+
+    const result = store.finalize({ status: 'failed', durationSeconds: 12.5 });
+
+    const validate = ajvValidator();
+    const valid = validate(result);
+    if (!valid) {
+      // surface schema errors for debugging
+      // eslint-disable-next-line no-console
+      console.error(validate.errors);
+    }
+    expect(valid).toBe(true);
+
+    expect(result.run_id).toBe(RUN_ID);
+    expect(result.scenario_id).toBe('login_smoke');
+    expect(result.status).toBe('failed');
+    expect(result.duration_seconds).toBe(12.5);
+    expect(result.steps_executed).toHaveLength(2);
+  });
+
+  test('maintains passed/failed/total assertion counts', () => {
+    const store = new ResultStore({ runId: RUN_ID, scenarioId: 's', projectRoot: tmpRoot() });
+    store.addAssertion({ step_id: 'a', type: 'element_exists', pass: true, message: 'ok' });
+    store.addAssertion({ step_id: 'b', type: 'element_exists', pass: true, message: 'ok' });
+    store.addAssertion({ step_id: 'c', type: 'element_exists', pass: false, message: 'no' });
+
+    const result = store.finalize();
+    expect(result.total_assertions).toBe(3);
+    expect(result.passed_assertions).toBe(2);
+    expect(result.failed_assertions).toBe(1);
+  });
+
+  test('records a flakiness observation when a passing step took more than one attempt', () => {
+    const store = new ResultStore({ runId: RUN_ID, scenarioId: 's', projectRoot: tmpRoot() });
+    store.addStep({ step_id: 'flaky_tap', status: 'pass', attempts: 3 });
+    store.addStep({ step_id: 'steady', status: 'pass', attempts: 1 });
+
+    const result = store.finalize();
+    const flaky = result.observations.filter((o) => o.type === 'flakiness');
+    expect(flaky).toHaveLength(1);
+    expect(flaky[0].step_id).toBe('flaky_tap');
+    expect(flaky[0].message).toMatch(/3/);
+  });
+
+  test('does not record flakiness for a step that ultimately failed even with retries', () => {
+    const store = new ResultStore({ runId: RUN_ID, scenarioId: 's', projectRoot: tmpRoot() });
+    store.addStep({ step_id: 'bad', status: 'fail', attempts: 4 });
+    const result = store.finalize();
+    expect(result.observations.filter((o) => o.type === 'flakiness')).toHaveLength(0);
+  });
+
+  test('writes the finalized result to <projectRoot>/mobile-automator/results/<runId>.json', () => {
+    const projectRoot = tmpRoot();
+    const store = new ResultStore({ runId: RUN_ID, scenarioId: 's', projectRoot });
+    store.addStep({ step_id: 'launch', status: 'pass' });
+    store.finalize({ status: 'passed' });
+
+    const file = path.join(projectRoot, 'mobile-automator', 'results', `${RUN_ID}.json`);
+    expect(fs.existsSync(file)).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(onDisk.run_id).toBe(RUN_ID);
+  });
+
+  test('reloads an in-progress file across separate instances (incremental updates)', () => {
+    const projectRoot = tmpRoot();
+
+    const a = new ResultStore({ runId: RUN_ID, scenarioId: 's', projectRoot });
+    a.addStep({ step_id: 'launch', status: 'pass' });
+
+    // A fresh process / instance picks up where the first left off.
+    const b = new ResultStore({ runId: RUN_ID, scenarioId: 's', projectRoot });
+    b.addStep({ step_id: 'tap', status: 'pass' });
+
+    const result = b.finalize({ status: 'passed' });
+    expect(result.steps_executed.map((s) => s.step_id)).toEqual(['launch', 'tap']);
+  });
+});


### PR DESCRIPTION
Stacked on #80 (slice 1). Lets an agent own the execute loop with one-shot verbs while the CLI owns all mechanical work.

## What
- **AssertionEvaluator** — Tier-1 mechanical assertion subset evaluated by the CLI; Tier-2 visual/semantic types pass through with `needs_agent:true, pass:null`. `element_state` classed needs-agent (agnostic model carries no state attributes).
- **ResultStore** — incremental, `result_schema` (2.0)-conformant assembly + retry/flake bookkeeping (`attempts>1` & pass → `flakiness` observation).
- **DeviceBridge** — `tap`/`type`/`swipe`/`pressButton` over the owned mobile-mcp `call`.
- **CLI verbs** — `tap --at`, `type`, `swipe --direction`, `press`, `assert <type>`, `result add-step|finalize`.

## Test plan
- `npm test`: **90 suites / 638 tests green** (+38, no regressions)
- Manual (no device): `result add-step ×2 → finalize` writes a **schema-valid** result; a 3-attempt passing step yields a `flakiness` observation; `assert` returns mechanical pass/fail and `needs_agent` passthrough; unknown type → `invalid_input`
- Real-device actuation smoke-only (no device in CI)

Closes #71 · Refs #69