### PR TITLE
cli slice 3 — config + setup scaffold + guide/schema/bootstrap floor

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -8,6 +8,17 @@ const { DeviceBridge } = require('./device/bridge');
 const { ScenarioValidator } = require('./scenario/validator');
 const { evaluate, MECHANICAL_TYPES } = require('./assertion/evaluator');
 const { ResultStore } = require('./result/store');
+const configManager = require('./config/manager');
+const { scaffold } = require('./setup/scaffold');
+const guideEmitter = require('./guide/emitter');
+
+// Map the user-facing --mode flag onto the stored config mode values.
+const MODE_ALIASES = {
+  aware: 'platform-aware',
+  agnostic: 'platform-agnostic',
+  'platform-aware': 'platform-aware',
+  'platform-agnostic': 'platform-agnostic',
+};
 
 const KNOWN_ASSERTION_TYPES = new Set([
   ...MECHANICAL_TYPES,
@@ -259,6 +270,82 @@ function handleResultFinalize({ resultStoreFactory, projectRoot }, opts) {
   return { envelope: ok(result), exitKind: 'ok' };
 }
 
+// --- Slice 3: workspace + reasoning-delivery floor -----------------------
+//
+// Contract split: the action/result verbs above emit the JSON envelope. The
+// content-emitting verbs `guide`/`schema`/`bootstrap` instead emit RAW content
+// (markdown / JSON schema / text) on stdout, because an agent injects that text
+// directly into its own context. Their handlers return `{ raw, exitKind:'ok' }`
+// on success; only their ERROR paths (unknown topic/name) fall back to the
+// `fail(...)` envelope + exit 3.
+
+function handleSetup({ projectRoot }, opts = {}) {
+  const raw = opts.mode === undefined ? 'aware' : String(opts.mode);
+  const mode = MODE_ALIASES[raw];
+  if (!mode) {
+    return {
+      envelope: fail('invalid_input', `unknown mode "${opts.mode}"`, 'Use --mode aware or --mode agnostic.'),
+      exitKind: 'invalid_input',
+    };
+  }
+  const r = scaffold(projectRoot, { mode });
+  return {
+    envelope: ok({ created: r.created, mode: r.mode, next: 'run `mauto guide setup`' }),
+    exitKind: 'ok',
+  };
+}
+
+function handleConfigGet({ projectRoot }, key) {
+  const value = configManager.get(projectRoot, key);
+  return { envelope: ok({ key, value }), exitKind: 'ok' };
+}
+
+function handleConfigSet({ projectRoot }, key, rawValue) {
+  let value = rawValue;
+  try {
+    value = JSON.parse(rawValue);
+  } catch (_) {
+    // Not JSON — keep the literal string.
+  }
+  configManager.set(projectRoot, key, value);
+  return { envelope: ok({ key, value }), exitKind: 'ok' };
+}
+
+// RAW content on success; fail envelope only when the topic is unknown.
+function handleGuide({ projectRoot, emitter = guideEmitter, config = configManager }, topic) {
+  const cfg = config.load(projectRoot);
+  const mode = config.resolveMode(cfg);
+  let raw;
+  try {
+    raw = emitter.emitGuide(topic, { mode });
+  } catch (err) {
+    return {
+      envelope: fail('invalid_input', `unknown guide topic "${topic}"`, 'Topics: generate, execute, record, setup.'),
+      exitKind: 'invalid_input',
+    };
+  }
+  return { raw, exitKind: 'ok' };
+}
+
+// RAW JSON schema on success; fail envelope only when the name is unknown.
+function handleSchema({ emitter = guideEmitter } = {}, name) {
+  let raw;
+  try {
+    raw = emitter.emitSchema(name);
+  } catch (err) {
+    return {
+      envelope: fail('invalid_input', `unknown schema "${name}"`, 'Names: scenario, result.'),
+      exitKind: 'invalid_input',
+    };
+  }
+  return { raw, exitKind: 'ok' };
+}
+
+// RAW bootstrap text; no error path.
+function handleBootstrap({ emitter = guideEmitter } = {}) {
+  return { raw: emitter.emitBootstrap(), exitKind: 'ok' };
+}
+
 // ---------------------------------------------------------------------------
 // Program wiring
 // ---------------------------------------------------------------------------
@@ -436,11 +523,65 @@ function buildProgram(deps = {}) {
       emit(r, humanFlag());
     });
 
+  // --- Slice 3 verbs --------------------------------------------------------
+
+  // Emit a handler result that may be either an envelope (success/error) OR
+  // raw content. Raw content with exitKind 'ok' prints verbatim (exit 0);
+  // anything else is an envelope error and goes through the normal emit path.
+  const emitMaybeRaw = (r) => {
+    if (r.raw !== undefined && r.exitKind === 'ok') {
+      emitRaw(r.raw, r.exitKind);
+    } else {
+      emit(r, humanFlag());
+    }
+  };
+
+  program
+    .command('setup')
+    .description('Scaffold the workspace (mobile-automator/) and write a config')
+    .option('--mode <mode>', 'aware (platform-aware, default) | agnostic (platform-agnostic)')
+    .action((opts) => {
+      const r = handleSetup({ projectRoot }, { mode: opts.mode });
+      emit(r, humanFlag());
+    });
+
+  const config = program.command('config').description('Read or update the workspace config');
+  config
+    .command('get <key>')
+    .description('Get a dotted-path config value')
+    .action((key) => emit(handleConfigGet({ projectRoot }, key), humanFlag()));
+  config
+    .command('set <key> <value>')
+    .description('Set a dotted-path config value (JSON-parsed when possible)')
+    .action((key, value) => emit(handleConfigSet({ projectRoot }, key, value), humanFlag()));
+
+  program
+    .command('guide <topic>')
+    .description('Print the RAW workflow guide for a topic (generate|execute|record|setup)')
+    .action((topic) => emitMaybeRaw(handleGuide({ projectRoot }, topic)));
+
+  program
+    .command('schema <name>')
+    .description('Print the RAW JSON schema (scenario|result)')
+    .action((name) => emitMaybeRaw(handleSchema({}, name)));
+
+  program
+    .command('bootstrap')
+    .description('Print the RAW bootstrap (verb map + invariants)')
+    .action(() => emitMaybeRaw(handleBootstrap({})));
+
   return program;
 }
 
 function defaultEmit({ envelope, exitKind }, human) {
   process.stdout.write(render(envelope, { human }) + '\n');
+  process.exit(exitCodeFor(exitKind));
+}
+
+// Print raw content (markdown / JSON schema / text) verbatim — no envelope
+// wrapping — then exit. Used by guide/schema/bootstrap success paths.
+function emitRaw(content, exitKind) {
+  process.stdout.write(content.endsWith('\n') ? content : content + '\n');
   process.exit(exitCodeFor(exitKind));
 }
 
@@ -462,4 +603,10 @@ module.exports = {
   handleAssert,
   handleResultAddStep,
   handleResultFinalize,
+  handleSetup,
+  handleConfigGet,
+  handleConfigSet,
+  handleGuide,
+  handleSchema,
+  handleBootstrap,
 };

--- a/src/config/manager.js
+++ b/src/config/manager.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// Workspace config manager for the `mauto` CLI.
+//
+// Reads/writes mobile-automator/config.json under a project root. Mode
+// resolution mirrors the recorder's prior art (tools/recorder/src/config.js):
+// a config without an explicit `mode` is treated as `platform-aware`.
+
+const fs = require('fs');
+const path = require('path');
+
+function configDir(projectRoot) {
+  return path.join(projectRoot, 'mobile-automator');
+}
+
+function configPath(projectRoot) {
+  return path.join(configDir(projectRoot), 'config.json');
+}
+
+// Parsed config object, or null when the file is absent.
+function load(projectRoot) {
+  const p = configPath(projectRoot);
+  if (!fs.existsSync(p)) return null;
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+// Default to platform-aware for null/empty/legacy configs.
+function resolveMode(cfg) {
+  return cfg && cfg.mode ? cfg.mode : 'platform-aware';
+}
+
+// Dotted-path lookup. Missing path -> undefined.
+function get(projectRoot, key) {
+  const cfg = load(projectRoot);
+  if (cfg == null) return undefined;
+  return getPath(cfg, key);
+}
+
+// Load-or-{}, set the dotted path, write back preserving every other field as
+// pretty 2-space JSON. Creates mobile-automator/ if needed.
+function set(projectRoot, key, value) {
+  const cfg = load(projectRoot) || {};
+  setPath(cfg, key, value);
+  fs.mkdirSync(configDir(projectRoot), { recursive: true });
+  fs.writeFileSync(configPath(projectRoot), JSON.stringify(cfg, null, 2) + '\n');
+  return cfg;
+}
+
+function getPath(obj, key) {
+  const parts = String(key).split('.');
+  let cur = obj;
+  for (const part of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}
+
+function setPath(obj, key, value) {
+  const parts = String(key).split('.');
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (cur[part] == null || typeof cur[part] !== 'object') {
+      cur[part] = {};
+    }
+    cur = cur[part];
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+module.exports = { load, resolveMode, get, set, configPath, configDir };

--- a/src/guide/emitter.js
+++ b/src/guide/emitter.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// Reasoning-delivery floor for the `mauto` CLI.
+//
+// emitGuide / emitSchema / emitBootstrap produce RAW content an agent injects
+// directly into its own context (markdown / JSON schema / text). They do NOT
+// wrap their output in the JSON envelope — only the CLI's ERROR paths (unknown
+// topic/name) do that. See src/cli.js for the raw-vs-envelope wiring.
+//
+// These are structured STUBS in slice 3; the full prose ports land in later
+// slices. The stubs are deliberately minimal but already honour every contract
+// the lint guards enforce: no `{{placeholder}}` tokens, no leaked `mobile_*`
+// tool names (the agent drives the device only through `mauto` verbs), and in
+// platform-agnostic mode no OS / OS-specific tooling words — per-OS facts are
+// reached through the four semantic actions, never named here.
+
+const fs = require('fs');
+const path = require('path');
+
+const SCENARIO_SCHEMA = path.resolve(
+  __dirname,
+  '../../templates/mobile-automator-generator/references/scenario_schema.json'
+);
+const RESULT_SCHEMA = path.resolve(
+  __dirname,
+  '../../templates/mobile-automator-executor/references/result_schema.json'
+);
+
+const TOPICS = {
+  generate:
+    'Author a test scenario. The agent drives `mauto elements`/`tap`/`type`/`swipe`/`press` to explore the app, then assembles a scenario JSON validated with `mauto validate` against `mauto schema scenario`.',
+  execute:
+    'Run a scenario. The agent replays each step through `mauto` action verbs, evaluates checks with `mauto assert`, and records progress with `mauto result add-step` / `mauto result finalize`.',
+  record:
+    'Capture a scenario from live interaction. The agent observes the session and emits scenario JSON through `mauto` verbs.',
+  setup:
+    'Initialise the workspace. `mauto setup` scaffolds the mobile-automator tree and a config; `mauto config get/set` reads and updates it.',
+};
+
+const SEMANTIC_ACTIONS = ['press_back', 'dismiss_keyboard', 'grant_permission', 'deny_permission'];
+
+function emitGuide(topic, { mode = 'platform-aware' } = {}) {
+  const summary = TOPICS[topic];
+  if (!summary) {
+    throw new Error(`unknown guide topic: ${topic}`);
+  }
+
+  const lines = [];
+  lines.push(`# Guide: ${topic} (${mode})`);
+  lines.push('');
+  lines.push(summary);
+  lines.push('');
+  lines.push(`This guide directs the agent through \`mauto\` verbs for the \`${topic}\` workflow.`);
+
+  if (mode === 'platform-agnostic') {
+    lines.push('');
+    lines.push(
+      'Platform-agnostic: never rely on a specific platform. Map every OS-level gesture to one of the four semantic actions, executed through `mauto press`:'
+    );
+    lines.push('');
+    for (const act of SEMANTIC_ACTIONS) {
+      lines.push(`- \`${act}\``);
+    }
+  }
+
+  lines.push('');
+  lines.push('_(full guide content lands in a later slice)_');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function emitSchema(name) {
+  const file = name === 'scenario' ? SCENARIO_SCHEMA : name === 'result' ? RESULT_SCHEMA : null;
+  if (!file) {
+    throw new Error(`unknown schema name: ${name}`);
+  }
+  return fs.readFileSync(file, 'utf8');
+}
+
+function emitBootstrap() {
+  const verbs = [
+    ['elements', 'list the UI elements currently on screen'],
+    ['tap', 'tap at absolute screen coordinates'],
+    ['type', 'type text into the focused element'],
+    ['swipe', 'swipe in a cardinal direction'],
+    ['press', 'press a system/hardware button or semantic action'],
+    ['screenshot', 'save a screenshot to a path'],
+    ['assert', 'evaluate an assertion against the current screen'],
+    ['validate', 'validate a scenario file against the scenario schema'],
+    ['result', 'record step results and finalize a run'],
+    ['setup', 'scaffold the workspace and write a config'],
+    ['config', 'get/set values in the workspace config'],
+    ['guide', 'print the guide for a workflow topic'],
+    ['schema', 'print the scenario or result JSON schema'],
+    ['record', 'capture a scenario from live interaction'],
+  ];
+
+  const lines = [];
+  lines.push('# mauto bootstrap');
+  lines.push('');
+  lines.push('Verb map:');
+  for (const [verb, desc] of verbs) {
+    lines.push(`- \`mauto ${verb}\` — ${desc}`);
+  }
+  lines.push('');
+  lines.push('Invariants:');
+  lines.push('- Run `mauto guide <topic>` before first using a workflow.');
+  lines.push('- Drive the device ONLY through `mauto` verbs.');
+  lines.push('- Platform-agnostic: never rely on a stable element id from the view hierarchy.');
+  lines.push('- Every action verb returns a JSON envelope ({ ok, data } or { ok:false, error }).');
+  lines.push('');
+  return lines.join('\n');
+}
+
+module.exports = { emitGuide, emitSchema, emitBootstrap, TOPICS, SEMANTIC_ACTIONS };

--- a/src/setup/scaffold.js
+++ b/src/setup/scaffold.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Workspace scaffolding for `mauto setup`.
+//
+// Creates the mobile-automator/{scenarios,screenshots,results} tree and a
+// skeleton config.json. Idempotent: re-running never clobbers an existing
+// config's other fields — it only ensures the requested `mode` is set.
+
+const fs = require('fs');
+const path = require('path');
+
+const manager = require('../config/manager');
+
+const SUBDIRS = ['scenarios', 'screenshots', 'results'];
+
+function scaffold(projectRoot, { mode } = {}) {
+  const created = [];
+
+  const baseDir = path.join(projectRoot, 'mobile-automator');
+  ensureDir(baseDir, created);
+  for (const sub of SUBDIRS) {
+    ensureDir(path.join(baseDir, sub), created);
+  }
+
+  const cfgPath = manager.configPath(projectRoot);
+  let configWritten = false;
+  if (!fs.existsSync(cfgPath)) {
+    // Fresh skeleton — single source of truth for the day-one config shape.
+    const skeleton = {
+      mode,
+      project_name: null,
+      environments: [],
+      default_environment: null,
+    };
+    fs.writeFileSync(cfgPath, JSON.stringify(skeleton, null, 2) + '\n');
+    created.push(cfgPath);
+    configWritten = true;
+  } else {
+    // Pre-existing config: only set the mode, preserving every other field.
+    manager.set(projectRoot, 'mode', mode);
+  }
+
+  return { created, mode, configWritten };
+}
+
+function ensureDir(dir, created) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    created.push(dir);
+  }
+}
+
+module.exports = { scaffold };

--- a/tests/lint/guide-agnostic-no-os.test.js
+++ b/tests/lint/guide-agnostic-no-os.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { emitGuide } = require('../../src/guide/emitter');
+
+const TOPICS = ['generate', 'execute', 'record', 'setup'];
+
+// Banned-word style mirrors tests/lint/agnostic-no-platform-words.test.js:
+// case-insensitive, word-boundary anchored. In platform-agnostic mode the
+// guide stubs must name no OS / OS-specific tooling — per-OS facts resolve at
+// runtime via the four semantic actions, not in the guide prose.
+const FORBIDDEN = [
+  /\bAndroid\b/i,
+  /\biOS\b/i,
+  /\badb\b/i,
+  /\bxcrun\b/i,
+  /\bresource[ -]?id\b/i,
+  /\bFlutter\b/i,
+  /\bReact[ -]?Native\b/i,
+  /\bKotlin\b/i,
+  /\bCompose\b/i,
+  /\bxcode\b/i,
+  /\bsimulator\b/i,
+  /\bemulator\b/i,
+];
+
+describe('guide emitter — agnostic mode names no OS', () => {
+  for (const topic of TOPICS) {
+    it(`${topic} (platform-agnostic) contains no OS/platform words`, () => {
+      const out = emitGuide(topic, { mode: 'platform-agnostic' });
+      const violations = FORBIDDEN.filter((p) => p.test(out)).map((p) => p.toString());
+      expect(violations).toEqual([]);
+    });
+  }
+});

--- a/tests/lint/guide-no-mcp-tool-leak.test.js
+++ b/tests/lint/guide-no-mcp-tool-leak.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { emitGuide, emitBootstrap } = require('../../src/guide/emitter');
+
+const TOPICS = ['generate', 'execute', 'record', 'setup'];
+const MODES = ['platform-aware', 'platform-agnostic'];
+
+// The CLI is the only interface the agent should see. Any leaked raw
+// mobile-mcp tool name (mobile_list_elements_on_screen, mobile_tap, ...) is a
+// contract break — the agent must drive the device through `mauto` verbs.
+const MCP_TOOL = /\bmobile_[a-z_]+/;
+
+describe('guide emitter — no leaked mobile-mcp tool names', () => {
+  for (const topic of TOPICS) {
+    for (const mode of MODES) {
+      it(`${topic} (${mode}) names no mobile_* tool`, () => {
+        expect(emitGuide(topic, { mode })).not.toMatch(MCP_TOOL);
+      });
+    }
+  }
+
+  it('bootstrap names no mobile_* tool', () => {
+    expect(emitBootstrap()).not.toMatch(MCP_TOOL);
+  });
+});

--- a/tests/lint/guide-no-placeholder-leak.test.js
+++ b/tests/lint/guide-no-placeholder-leak.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { emitGuide } = require('../../src/guide/emitter');
+
+const TOPICS = ['generate', 'execute', 'record', 'setup'];
+const MODES = ['platform-aware', 'platform-agnostic'];
+
+describe('guide emitter — no placeholder leak', () => {
+  for (const topic of TOPICS) {
+    for (const mode of MODES) {
+      it(`${topic} (${mode}) contains no {{ tokens`, () => {
+        expect(emitGuide(topic, { mode })).not.toContain('{{');
+      });
+    }
+  }
+});

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -15,6 +15,12 @@ const {
   handleAssert,
   handleResultAddStep,
   handleResultFinalize,
+  handleSetup,
+  handleConfigGet,
+  handleConfigSet,
+  handleGuide,
+  handleSchema,
+  handleBootstrap,
 } = require('../../src/cli');
 const Ajv = require('ajv');
 
@@ -274,6 +280,115 @@ describe('cli handlers', () => {
       const schema = JSON.parse(fs.readFileSync(RESULT_SCHEMA_PATH, 'utf8'));
       const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
       expect(validate(f.envelope.data)).toBe(true);
+    });
+  });
+
+  // --- Slice 3: workspace + reasoning-delivery floor ----------------------
+
+  describe('handleSetup', () => {
+    test('scaffolds into an injected projectRoot and maps aware->platform-aware', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-setup-'));
+      const { envelope, exitKind } = handleSetup({ projectRoot }, { mode: 'aware' });
+      expect(exitKind).toBe('ok');
+      expect(envelope.ok).toBe(true);
+      expect(envelope.data.mode).toBe('platform-aware');
+      expect(envelope.data.next).toContain('mauto guide setup');
+      expect(fs.existsSync(path.join(projectRoot, 'mobile-automator', 'scenarios'))).toBe(true);
+    });
+
+    test('maps agnostic->platform-agnostic and writes config mode', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-setup-'));
+      const { envelope } = handleSetup({ projectRoot }, { mode: 'agnostic' });
+      expect(envelope.data.mode).toBe('platform-agnostic');
+      const cfg = JSON.parse(fs.readFileSync(path.join(projectRoot, 'mobile-automator', 'config.json'), 'utf8'));
+      expect(cfg.mode).toBe('platform-agnostic');
+    });
+
+    test('defaults to platform-aware when no --mode given', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-setup-'));
+      const { envelope } = handleSetup({ projectRoot }, {});
+      expect(envelope.data.mode).toBe('platform-aware');
+    });
+
+    test('rejects an unknown mode', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-setup-'));
+      const { exitKind } = handleSetup({ projectRoot }, { mode: 'windows' });
+      expect(exitKind).toBe('invalid_input');
+    });
+  });
+
+  describe('config get/set', () => {
+    test('set then get round-trips with JSON-parsed values', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const setR = handleConfigSet({ projectRoot }, 'app_package', 'com.example.app');
+      expect(setR.exitKind).toBe('ok');
+      const getR = handleConfigGet({ projectRoot }, 'app_package');
+      expect(getR.envelope.data).toEqual({ key: 'app_package', value: 'com.example.app' });
+    });
+
+    test('set parses JSON arrays/numbers when possible', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      handleConfigSet({ projectRoot }, 'business_critical_paths', '["checkout","login"]');
+      const getR = handleConfigGet({ projectRoot }, 'business_critical_paths');
+      expect(getR.envelope.data.value).toEqual(['checkout', 'login']);
+    });
+
+    test('get of a missing key returns undefined value', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const getR = handleConfigGet({ projectRoot }, 'nope');
+      expect(getR.exitKind).toBe('ok');
+      expect(getR.envelope.data.value).toBeUndefined();
+    });
+  });
+
+  describe('handleGuide (raw content / fail on unknown)', () => {
+    test('returns raw markdown for a known topic resolving mode from config', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-guide-'));
+      handleConfigSet({ projectRoot }, 'mode', 'platform-agnostic');
+      const r = handleGuide({ projectRoot }, 'execute');
+      expect(r.exitKind).toBe('ok');
+      expect(r.raw).toContain('mauto');
+      expect(r.raw).toContain('press_back');
+      expect(r.envelope).toBeUndefined();
+    });
+
+    test('defaults to platform-aware when no config present', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-guide-'));
+      const r = handleGuide({ projectRoot }, 'setup');
+      expect(r.exitKind).toBe('ok');
+      expect(typeof r.raw).toBe('string');
+    });
+
+    test('unknown topic -> fail envelope + invalid_input exit 3', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-guide-'));
+      const r = handleGuide({ projectRoot }, 'bogus');
+      expect(r.exitKind).toBe('invalid_input');
+      expect(r.envelope.error.kind).toBe('invalid_input');
+      expect(r.raw).toBeUndefined();
+    });
+  });
+
+  describe('handleSchema (raw JSON / fail on unknown)', () => {
+    test('returns raw JSON for scenario', () => {
+      const r = handleSchema({}, 'scenario');
+      expect(r.exitKind).toBe('ok');
+      expect(() => JSON.parse(r.raw)).not.toThrow();
+    });
+
+    test('unknown name -> fail envelope exit 3', () => {
+      const r = handleSchema({}, 'bogus');
+      expect(r.exitKind).toBe('invalid_input');
+      expect(r.envelope.error.kind).toBe('invalid_input');
+    });
+  });
+
+  describe('handleBootstrap (raw text)', () => {
+    test('returns the verb map as raw text', () => {
+      const r = handleBootstrap({});
+      expect(r.exitKind).toBe('ok');
+      expect(r.raw).toContain('elements');
+      expect(r.raw).toContain('schema');
+      expect(r.raw).not.toMatch(/\bmobile_[a-z_]+/);
     });
   });
 });

--- a/tests/unit/config/manager.test.js
+++ b/tests/unit/config/manager.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const { load, resolveMode, get, set } = require('../../../src/config/manager');
+
+function tmpRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+}
+
+function configPath(root) {
+  return path.join(root, 'mobile-automator', 'config.json');
+}
+
+describe('config/manager', () => {
+  describe('load', () => {
+    it('returns null when no config file exists', () => {
+      const root = tmpRoot();
+      expect(load(root)).toBeNull();
+    });
+
+    it('returns the parsed config object when present', () => {
+      const root = tmpRoot();
+      fs.mkdirSync(path.join(root, 'mobile-automator'), { recursive: true });
+      fs.writeFileSync(configPath(root), JSON.stringify({ mode: 'platform-agnostic', app_package: 'com.x' }));
+      expect(load(root)).toEqual({ mode: 'platform-agnostic', app_package: 'com.x' });
+    });
+  });
+
+  describe('resolveMode', () => {
+    it('defaults to platform-aware for null/empty config', () => {
+      expect(resolveMode(null)).toBe('platform-aware');
+      expect(resolveMode({})).toBe('platform-aware');
+      expect(resolveMode(undefined)).toBe('platform-aware');
+    });
+
+    it('returns the explicit mode when set', () => {
+      expect(resolveMode({ mode: 'platform-agnostic' })).toBe('platform-agnostic');
+      expect(resolveMode({ mode: 'platform-aware' })).toBe('platform-aware');
+    });
+  });
+
+  describe('get', () => {
+    it('returns undefined when config is absent', () => {
+      const root = tmpRoot();
+      expect(get(root, 'app_package')).toBeUndefined();
+    });
+
+    it('returns a top-level value', () => {
+      const root = tmpRoot();
+      set(root, 'app_package', 'com.example');
+      expect(get(root, 'app_package')).toBe('com.example');
+    });
+
+    it('returns a dotted-path nested value', () => {
+      const root = tmpRoot();
+      set(root, 'project.business_critical_paths', ['checkout']);
+      expect(get(root, 'project.business_critical_paths')).toEqual(['checkout']);
+    });
+
+    it('returns undefined for a missing dotted path', () => {
+      const root = tmpRoot();
+      set(root, 'a.b', 1);
+      expect(get(root, 'a.c')).toBeUndefined();
+      expect(get(root, 'x.y.z')).toBeUndefined();
+    });
+  });
+
+  describe('set', () => {
+    it('round-trips set then get', () => {
+      const root = tmpRoot();
+      set(root, 'mode', 'platform-agnostic');
+      expect(get(root, 'mode')).toBe('platform-agnostic');
+    });
+
+    it('creates the mobile-automator directory when missing', () => {
+      const root = tmpRoot();
+      set(root, 'mode', 'platform-aware');
+      expect(fs.existsSync(configPath(root))).toBe(true);
+    });
+
+    it('preserves sibling fields when setting another key', () => {
+      const root = tmpRoot();
+      set(root, 'mode', 'platform-agnostic');
+      set(root, 'app_package', 'com.example.app');
+      const cfg = load(root);
+      expect(cfg.mode).toBe('platform-agnostic');
+      expect(cfg.app_package).toBe('com.example.app');
+    });
+
+    it('preserves siblings when setting a nested dotted path', () => {
+      const root = tmpRoot();
+      set(root, 'project.name', 'Demo');
+      set(root, 'project.domain', 'fintech');
+      const cfg = load(root);
+      expect(cfg.project).toEqual({ name: 'Demo', domain: 'fintech' });
+    });
+
+    it('writes pretty 2-space JSON', () => {
+      const root = tmpRoot();
+      set(root, 'mode', 'platform-aware');
+      const raw = fs.readFileSync(configPath(root), 'utf8');
+      expect(raw).toContain('\n  "mode"');
+    });
+  });
+});

--- a/tests/unit/guide/emitter.test.js
+++ b/tests/unit/guide/emitter.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { emitGuide, emitSchema, emitBootstrap } = require('../../../src/guide/emitter');
+
+const TOPICS = ['generate', 'execute', 'record', 'setup'];
+const MODES = ['platform-aware', 'platform-agnostic'];
+
+describe('guide/emitter', () => {
+  describe('emitGuide', () => {
+    for (const topic of TOPICS) {
+      for (const mode of MODES) {
+        it(`returns non-empty markdown for ${topic} (${mode})`, () => {
+          const out = emitGuide(topic, { mode });
+          expect(typeof out).toBe('string');
+          expect(out.trim().length).toBeGreaterThan(0);
+          expect(out).toContain('mauto');
+          expect(out).toContain(topic);
+        });
+      }
+    }
+
+    it('defaults mode to platform-aware', () => {
+      expect(emitGuide('setup')).toContain('mauto');
+    });
+
+    it('contains no placeholder tokens', () => {
+      for (const topic of TOPICS) {
+        for (const mode of MODES) {
+          expect(emitGuide(topic, { mode })).not.toContain('{{');
+        }
+      }
+    });
+
+    it('notes that full content lands later', () => {
+      expect(emitGuide('generate', { mode: 'platform-aware' }).toLowerCase()).toContain('later slice');
+    });
+
+    it('agnostic stubs mention the four semantic actions', () => {
+      for (const topic of TOPICS) {
+        const out = emitGuide(topic, { mode: 'platform-agnostic' });
+        for (const act of ['press_back', 'dismiss_keyboard', 'grant_permission', 'deny_permission']) {
+          expect(out).toContain(act);
+        }
+      }
+    });
+
+    it('throws on an unknown topic', () => {
+      expect(() => emitGuide('nope', { mode: 'platform-aware' })).toThrow();
+    });
+  });
+
+  describe('emitSchema', () => {
+    it('emitSchema(scenario) parses as JSON', () => {
+      const s = emitSchema('scenario');
+      expect(() => JSON.parse(s)).not.toThrow();
+    });
+
+    it('emitSchema(result) parses as JSON', () => {
+      const s = emitSchema('result');
+      expect(() => JSON.parse(s)).not.toThrow();
+    });
+
+    it('throws on an unknown schema name', () => {
+      expect(() => emitSchema('bogus')).toThrow();
+    });
+  });
+
+  describe('emitBootstrap', () => {
+    it('contains the verb list', () => {
+      const out = emitBootstrap();
+      for (const verb of [
+        'elements', 'tap', 'type', 'swipe', 'press', 'screenshot',
+        'assert', 'validate', 'result', 'setup', 'config', 'guide', 'schema', 'record',
+      ]) {
+        expect(out).toContain(verb);
+      }
+    });
+
+    it('states the invariants', () => {
+      const out = emitBootstrap().toLowerCase();
+      expect(out).toContain('mauto guide');
+      expect(out).toContain('envelope');
+    });
+
+    it('contains no placeholder tokens or leaked mcp tool names', () => {
+      const out = emitBootstrap();
+      expect(out).not.toContain('{{');
+      expect(out).not.toMatch(/\bmobile_[a-z_]+/);
+    });
+  });
+});

--- a/tests/unit/setup/scaffold.test.js
+++ b/tests/unit/setup/scaffold.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const { scaffold } = require('../../../src/setup/scaffold');
+const { load } = require('../../../src/config/manager');
+
+function tmpRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-scaffold-'));
+}
+
+describe('setup/scaffold', () => {
+  it('creates scenarios, screenshots and results directories', () => {
+    const root = tmpRoot();
+    scaffold(root, { mode: 'platform-aware' });
+    for (const d of ['scenarios', 'screenshots', 'results']) {
+      expect(fs.existsSync(path.join(root, 'mobile-automator', d))).toBe(true);
+    }
+  });
+
+  it('writes a skeleton config with the requested mode when absent', () => {
+    const root = tmpRoot();
+    const r = scaffold(root, { mode: 'platform-agnostic' });
+    expect(r.configWritten).toBe(true);
+    const cfg = load(root);
+    expect(cfg).toEqual({
+      mode: 'platform-agnostic',
+      project_name: null,
+      environments: [],
+      default_environment: null,
+    });
+  });
+
+  it('returns created paths and mode', () => {
+    const root = tmpRoot();
+    const r = scaffold(root, { mode: 'platform-aware' });
+    expect(r.mode).toBe('platform-aware');
+    expect(Array.isArray(r.created)).toBe(true);
+    expect(r.created.length).toBeGreaterThan(0);
+  });
+
+  it('does not clobber an existing config but sets the mode', () => {
+    const root = tmpRoot();
+    fs.mkdirSync(path.join(root, 'mobile-automator'), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, 'mobile-automator', 'config.json'),
+      JSON.stringify({ mode: 'platform-aware', project_name: 'Existing', app_package: 'com.x' })
+    );
+    const r = scaffold(root, { mode: 'platform-agnostic' });
+    expect(r.configWritten).toBe(false);
+    const cfg = load(root);
+    expect(cfg.project_name).toBe('Existing');
+    expect(cfg.app_package).toBe('com.x');
+    expect(cfg.mode).toBe('platform-agnostic');
+  });
+
+  it('is idempotent (re-run is safe and preserves config)', () => {
+    const root = tmpRoot();
+    scaffold(root, { mode: 'platform-agnostic' });
+    set_app_package(root);
+    const r2 = scaffold(root, { mode: 'platform-agnostic' });
+    expect(r2.configWritten).toBe(false);
+    const cfg = load(root);
+    expect(cfg.app_package).toBe('com.example');
+    expect(cfg.mode).toBe('platform-agnostic');
+  });
+});
+
+function set_app_package(root) {
+  const { set } = require('../../../src/config/manager');
+  set(root, 'app_package', 'com.example');
+}


### PR DESCRIPTION
Stacked on #81 (slice 2). The reasoning-delivery floor + workspace plumbing.

## What
- **ConfigManager** — `config get|set` on `mobile-automator/config.json` (dotted-path, sibling-preserving), mode resolution (default `platform-aware`).
- **Setup/Scaffold** — `mauto setup [--mode aware|agnostic]` creates `scenarios/screenshots/results` + config skeleton; idempotent, no clobber.
- **GuideEmitter** — `mauto guide <topic>` (per-mode **structured stubs**; full prose ports land in slices 4–6), `mauto schema <name>`, `mauto bootstrap`.
- **Contract refinement** — content verbs (`guide`/`schema`/`bootstrap`) emit **raw** content for agent injection; action verbs keep the JSON envelope; error paths use the envelope.
- **Lint guards** (reusable for the ports): guides leak no `{{`, no `mobile_*` tool names; agnostic guides name no OS.

## Test plan
- `npm test`: **96 suites / 709 tests green** (+71, incl. 3 lint guards)
- Manual: `setup --mode agnostic` scaffolds + writes `mode:"platform-agnostic"`; `schema scenario` prints valid JSON; `bootstrap` prints the verb map; `guide execute` (agnostic) prints a clean stub; unknown topic/name → `invalid_input` exit 3

Closes #72 · Refs #69