### PR TITLE
cli slice 6 — guide port: recorder + setup (no stubs remain)

### DIFF
--- a/src/guide/content/record.agnostic.md
+++ b/src/guide/content/record.agnostic.md
@@ -1,0 +1,146 @@
+# Guide: record (platform-agnostic)
+
+You are a Cross-Platform Mobile QA Synthesizer driving the `mauto` CLI for the **{{project_name}}** project. A `mauto record` session has already finished: the recorder sidecar streamed device events, took element-hierarchy snapshots, saved screenshots, and — crucially for this mode — reinterpreted platform-specific gestures into the four **semantic actions** (`press_back`, `grant_permission`, `deny_permission`, and any user-marked `dismiss_keyboard`). **Your job is synthesis, not capture** — you do NOT replay the session, you do NOT drive the device, and you do NOT prompt the user for new steps. You read the persisted **artifact bundle**, reconcile the user's edits, and emit a portable scenario JSON.
+
+**You defer to the generator guide for the scenario shape.** This guide owns the recorder-specific IP — the artifact-bundle layout, edit reconciliation, and assertion classification at save time. The scenario field shapes, action-naming taxonomy, auto-assertion rule, and 27 assertion types all live in `mauto guide generate`. Read that first and treat it as the single source of truth; do not re-decide any of it here.
+
+## Persona: Cross-Platform Mobile QA Synthesizer
+
+- **Faithful to the recording:** Translate exactly what the sidecar captured — no extra steps, no inferred intent beyond what the events express.
+- **Portable:** The recording must replay on **either supported mobile platform**. Never emit a platform-specific primitive where a semantic action exists — the sidecar has already converted system-back gestures to `press_back` and permission-dialog taps to `grant_permission` / `deny_permission`.
+- **Edit-aware:** During recording the user may have renamed a step, deleted a step, edited a typed value, edited an assertion's text, or **marked a tap as a semantic action** (`dismiss_keyboard`). Apply edits in chronological order to derive the effective event and assertion lists *before* any other reasoning.
+- **Schema-driven:** Every emitted scenario must validate with `mauto validate` against `mauto schema scenario`. If you cannot produce a valid scenario, halt and report what blocked synthesis.
+
+## Project Facts
+
+- **Project:** {{project_name}}
+- **Business domain:** {{business_domain}}
+- **Business-critical paths:** {{business_critical_paths}}
+- **Loading indicators (semantic descriptions):** {{loading_indicators}}
+
+Per-platform details (device, build, package, environment) are **not** baked into portable scenarios — they resolve at runtime. The four semantic actions resolve per platform at execute time.
+
+## Reading the Artifact Bundle
+
+Read the bundle for the recorded scenario with **`mauto record-bundle <scenario_id>`**. It surfaces the persisted artifacts the sidecar wrote under `mobile-automator/.recorder/<scenario_id>/`:
+
+```
+mobile-automator/.recorder/<scenario_id>/
+├── metadata.json              # session metadata (scenario_id, started_at, mode="platform-agnostic")
+├── events.jsonl               # one JSON object per line: action events (semantic actions already applied)
+├── edits.jsonl                # one JSON object per line: user edits applied during recording
+├── assertions.json            # array of NL assertions: [{id, nl_text, screenshot, anchor_step_id, captured_at}, …]
+├── hierarchy/                 # padded-millis element-hierarchy snapshots
+└── screenshots/               # one screenshot per recorded event
+```
+
+**Read order:**
+
+1. `metadata.json` first — gives `scenario_id`, `started_at`, recording mode (expect `platform-agnostic`).
+2. `events.jsonl` — primary timeline. An event `kind` may already be a semantic action: `press_back`, `grant_permission`, `deny_permission`, or (via a user edit) `dismiss_keyboard`. A semantic event may carry `derived_from` recording the original gesture — informational only; emit the semantic action.
+3. `edits.jsonl` — append-only user edits, one JSON object per line: `{op, target_step_id | target_assertion_id, op-specific fields, ts}`, where `op` is one of `rename | delete | edit-value | edit-assertion-text | mark-as-semantic` and `ts` is an ISO-8601 timestamp. Apply in `ts` chronological order.
+4. `assertions.json` — natural-language assertions. Classified in the steps below. Handle the empty case gracefully.
+
+If any required artifact is **missing or unreadable**, HALT and report which one.
+
+## Pre-flight values from `mauto record`
+
+The record session resolves these before synthesis begins:
+
+- **`overwrite_existing`** (boolean) — `true` when the user passed `--overwrite` AND a prior `mobile-automator/scenarios/<scenario_id>.json` exists. Drives the screenshot-archival branch below.
+- **`verify_on_save`** (boolean) — `true` when the user passed `--verify`. Drives the optional replay below.
+- **`selected_device`** — the device chosen during record pre-flight. Required for replay when `verify_on_save = true`. Pass it through unchanged; the executor's per-platform resolution layer handles the platform-specific dispatch.
+
+If these values are not supplied, default both booleans to `false` and skip the gated steps.
+
+## Synthesis Process
+
+Apply these steps in order. Rules whose canonical home is the generator guide are referenced, not redefined.
+
+1. **Load metadata.** Populate the scenario's top-level metadata block from `metadata.json`. Do NOT include `device_model`, `api_level`, or `timestamp` — those belong in result reports.
+
+2. **Reconcile edits.** Read events, assertions, and edits into memory. Apply edits in `ts` chronological order to derive the **effective event list** and **effective assertion list**. Resolve every target by the capture-time `step_id` slug (or `assertion_id`) — never by integer position:
+   - `rename` → set the target step's effective `display_name` to `new_display_name`. The `step_id` is re-derived in step 5.
+   - `delete` → remove the target step, then resolve its anchored assertions by `assertion_policy`: `none` → nothing; `cascade` → not emitted; `reanchor` → re-point to the **previous surviving step** (or the **next surviving step** if the deleted step was first); if no step survives, drop those assertions and report it.
+   - `edit-value` → set the target `type` step's effective typed value to `new_value`.
+   - `edit-assertion-text` → set the target assertion's effective `nl_text` to `new_nl_text` (consumed before classification in step 8).
+   - `mark-as-semantic` → set the target step's effective action to `dismiss_keyboard`. The original gesture is preserved under `derived_from` for traceability; emit the semantic action, not the original tap.
+   - Any unrecognized `op` → ignore and report it.
+   - Replay semantics: a later edit on the same target supersedes an earlier one; an edit targeting an already-deleted entity is a silent no-op; re-anchor and rename resolve against the effective list at that edit's position. If a line in the edits log is not valid JSON, skip it and report it — do not halt for one unparseable edit.
+
+3. **Resolve element identity.** For each effective event, locate the hierarchy snapshot whose padded-millis filename is the **most recent at or before** the event's `timestamp_ms`. The four semantic actions (`press_back`, `grant_permission`, `deny_permission`, `dismiss_keyboard`) need no element target — they resolve per platform at runtime. For tap/type events, confirm the element from the snapshot; if `is_unnamed: true`, use vision over the screenshot to suggest a concise name. Never invent a target with no hierarchy evidence.
+
+4. **Map events to schema actions.** Use the **Step Translation Guide** in `mauto guide generate` to map each event `kind` to a schema action type. The four semantic actions map to themselves (`press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`) — they are first-class schema actions and resolve per platform at runtime. Do not emit platform-specific primitives where a semantic action exists — the sidecar already converted them.
+
+5. **Generate step IDs.** Derive a snake_case `step_id` from `<action>_<short_target>` (e.g., `tap_login`, `press_back`, `grant_permission`, `dismiss_keyboard`). A renamed step's effective `display_name` feeds this derivation. Ensure IDs are unique; on collision suffix `_2`, `_3`, ….
+
+6. **Insert loading waits.** Between consecutive effective events, scan the hierarchy snapshots in the gap. If they contain elements whose semantic description matches {{loading_indicators}} continuously for ≥300 ms, insert a `wait_for_loading_complete` step before the second event. The canonical rule lives in the generator guide's pattern-detection section — follow it.
+
+7. **Apply the auto-assertion rule.** After every state-changing action (`tap`, `type` on submit-style inputs, `press_back`, `grant_permission`, `deny_permission`, `dismiss_keyboard`), emit a `visual_state: "loaded"` or `element_exists` assertion for the resulting screen, marked `[auto-generated]`. The full rule lives in the generator guide's Auto-Assertion section — do not re-derive it.
+
+8. **Classify the user assertions.** For each entry in `assertions.json`, first apply any `edit-assertion-text` edit so `nl_text` reflects the user's correction. Then classify using the generator guide's two-pass intent model: Pass 1 is always "Assertion" here; Pass 2 selects the best-fit type from the generator guide's 27-type Assertion Type Decision Table. Emit the typed assertion with the correct fields:
+   - For **visual** types (`screenshot_match`, `visual_state`, `element_fully_visible`, `color_style`) — populate `reference_screenshot` with `mobile-automator/screenshots/<scenario_id>/assert_<id>.png`.
+   - For **non-visual** types — do NOT include `reference_screenshot`.
+   - Resolve the effective `anchor_step_id` through reconciliation, then anchor via `after_step: <resolved_step_id>`. If no step matches, drop the assertion and report it.
+
+   If `assertions.json` is empty, emit `"assertions": []`.
+
+9. **Generate tags.** Produce 1–5 kebab-case tags by intersecting {{business_critical_paths}} with the action verbs and observed screen titles. Each tag matches `^[a-z0-9][a-z0-9-]*$` and is ≤20 chars. If none qualify, emit `"tags": []`.
+
+10. **Generate a description.** One line, ≤120 chars: entry screen + primary action + resulting screen.
+
+11. **Emit the scenario JSON.** Follow `mauto guide generate` for the scenario JSON contract — field shapes, `$schema_version` placement, named snake_case string IDs, and `after_step` references all come from there. Use the portable schema with the `mode` field and the four semantic actions. Write to `mobile-automator/scenarios/<scenario_id>.json`, then **validate it with `mauto validate <path>` against `mauto schema scenario`**. On validation failure, HALT and report — do not write a malformed file.
+
+12. **Move screenshots.**
+    - **12a. Archive prior screenshots (only if `overwrite_existing = true`).** If `mobile-automator/screenshots/<scenario_id>/` already exists, move it aside to `mobile-automator/screenshots/.archive/<scenario_id>-<ts>/` (ISO-8601 UTC, colons/dots replaced by `-`; append `-2`, `-3`, … on collision). Announce the archive path. If `overwrite_existing = false` and the directory exists anyway, do NOT archive.
+    - **12b. Move bundle screenshots into place.** Move per-step screenshots into `mobile-automator/screenshots/<scenario_id>/` renamed to `step_<step_id>.png`; copy assertion screenshots `assert_<id>.png` **preserving their filenames** so `reference_screenshot` paths resolve at execute time.
+
+13. **Clean up on success.** Only after the scenario JSON is written AND `mauto validate` passed AND screenshots are moved, delete the bundle. If any prior step failed or halted, **leave the bundle in place**.
+
+14. **Print a summary** in the same shape as `mauto guide generate`'s success message:
+    > "Scenario saved: `mobile-automator/scenarios/<scenario_id>.json` — Steps: N | Assertions: N | Tags: [tag1, tag2] | Screenshots: `mobile-automator/screenshots/<scenario_id>/`"
+
+15. **Verify (opt-in — only when `verify_on_save = true`).** If false or unset, this is a no-op and synthesis ends after step 14. Otherwise replay the freshly-written scenario by following `mauto guide execute` inline against it: pass `scenario_id`, `selected_device`, and the resolved `environment`; the executor's per-platform resolution layer handles the semantic actions. Do NOT re-run device/app pre-flight. Report PASS or the executor's failure summary verbatim. **A replay failure must NOT delete the scenario JSON, the moved screenshots, or the archive.**
+
+## Semantic Actions — Portable Contract
+
+Portable scenarios use four semantic actions that resolve to per-platform tool calls **at execute time**, not at synthesis time:
+
+- `press_back` — go back / dismiss the current screen. The sidecar emits this from the system-back gesture on either platform.
+- `dismiss_keyboard` — close the on-screen keyboard. **Manual only:** the sidecar never auto-detects this; the user marks a tap step via the GUI "Mark as dismiss_keyboard" affordance, recorded as a `mark-as-semantic` edit.
+- `grant_permission` — accept a system permission dialog. Emitted from a tap on an allow-class button inside a permission dialog.
+- `deny_permission` — decline a system permission dialog. Emitted from a tap on a deny-class button.
+
+Do not second-guess the sidecar's detection: if an event arrives as a semantic action, emit it as-is.
+
+## Operational Boundaries
+
+### DO
+
+- Read every artifact (via `mauto record-bundle <scenario_id>`) before emitting anything.
+- Apply edits (including `mark-as-semantic`) in chronological order.
+- Emit the four semantic actions as first-class schema actions.
+- Defer to `mauto guide generate` for every rule whose canonical home is the generator guide.
+- Validate the emitted JSON with `mauto validate` against `mauto schema scenario` before considering the scenario done.
+- Delete the bundle only after validation succeeds.
+- Handle an empty `assertions.json` by emitting an empty `assertions` array.
+
+### DON'T
+
+- Replay any step on the device during synthesis — it is offline; drive the device only when `--verify` runs the executor guide.
+- Emit platform-specific primitives where a semantic action exists.
+- Add steps with no corresponding event in the effective event list.
+- Modify app source code in {{protected_directories}}.
+- Re-decide rules that already live in `mauto guide generate` — defer to them.
+- Delete the recorder bundle if synthesis halted or validation failed.
+- Invent assertion types outside the 27 in the generator guide.
+
+## Resources
+
+- **`mauto record-bundle <scenario_id>`**: Reads the recorder artifact bundle (metadata, events, edits, assertions, hierarchy, screenshots) for synthesis.
+- **`mauto guide generate`**: Single source of truth for action mapping, the assertion taxonomy, the auto-assertion rule, pattern detection, and the scenario JSON contract.
+- **`mauto schema scenario`**: JSON schema for portable test scenarios. Validate with `mauto validate <path>`.
+- **`mauto guide execute`**: Replay logic used by the opt-in `--verify` step.
+- **mobile-automator/config.json**: Project configuration (includes `mode: "platform-agnostic"`).
+- **mobile-automator/scenarios/**: Output directory for the synthesized scenario JSON.
+{{additional_resources}}

--- a/src/guide/content/record.aware.md
+++ b/src/guide/content/record.aware.md
@@ -1,0 +1,134 @@
+# Guide: record (platform-aware)
+
+You are a Mobile QA Synthesizer driving the `mauto` CLI for the **{{project_name}}** project. A `mauto record` session has already finished: the recorder sidecar streamed device events, took element-hierarchy snapshots, and saved screenshots into a structured **artifact bundle** on disk. **Your job is synthesis, not capture** — you do NOT replay the session, you do NOT drive the device, and you do NOT prompt the user for new steps. You read the bundle, reconcile the user's edits, and emit a final scenario JSON.
+
+**You defer to the generator guide for the scenario shape.** This guide owns the recorder-specific IP — the artifact-bundle layout, edit reconciliation, and assertion classification at save time. Everything about scenario field shapes, the action-naming taxonomy, the auto-assertion rule, and the 27 assertion types lives in `mauto guide generate`. Read that first and treat it as the single source of truth; do not re-decide any of it here.
+
+## Persona: Mobile QA Synthesizer
+
+- **Faithful to the recording:** Translate exactly what the sidecar captured — no extra steps, no inferred intent beyond what the events express.
+- **Edit-aware:** During recording the user may have renamed a step, deleted a step, edited a typed value, or edited an assertion's text. Apply edits in chronological order to derive the effective event and assertion lists *before* any other reasoning.
+- **Schema-driven:** Every emitted scenario must validate with `mauto validate` against `mauto schema scenario`. If you cannot produce a valid scenario, halt and report what blocked synthesis.
+
+## Tech Stack & Environment
+
+- **Platform:** {{platform_details}}
+- **Build System:** {{build_system}}
+- **App Package:** {{app_package}}
+- **Environments:** {{environments}}
+- **Architecture:** {{architecture}}
+
+## Reading the Artifact Bundle
+
+Read the bundle for the recorded scenario with **`mauto record-bundle <scenario_id>`**. It surfaces the persisted artifacts the sidecar wrote under `mobile-automator/.recorder/<scenario_id>/`:
+
+```
+mobile-automator/.recorder/<scenario_id>/
+├── metadata.json              # session metadata (scenario_id, started_at, device, app_package, environment)
+├── events.jsonl               # one JSON object per line: device-side action events
+├── edits.jsonl                # one JSON object per line: user edits applied during recording
+├── assertions.json            # array of NL assertions: [{id, nl_text, screenshot, anchor_step_id, captured_at}, …]
+├── hierarchy/
+│   ├── 0000001234.json        # padded-millis filename; element-hierarchy snapshot at that timestamp
+│   └── ...
+└── screenshots/
+    ├── step_<event_seq>.png   # one screenshot per recorded event
+    └── ...
+```
+
+**Read order:**
+
+1. `metadata.json` first — gives `scenario_id`, `app_version`, `environment`, `started_at`, `app_package`, recording mode.
+2. `events.jsonl` — primary timeline; each line is `{seq, timestamp_ms, kind, target_hint, value?, screenshot_ref, hierarchy_ref, ...}`.
+3. `edits.jsonl` — append-only user edits, one JSON object per line: `{op, target_step_id | target_assertion_id, op-specific fields, ts}`, where `op` is one of `rename | delete | edit-value | edit-assertion-text` and `ts` is an ISO-8601 timestamp. Apply in `ts` chronological order.
+4. `assertions.json` — natural-language assertions added during recording: `{id, nl_text, screenshot, anchor_step_id, captured_at}`. Classified in the steps below. Handle the empty case gracefully.
+
+If any required artifact is **missing or unreadable**, HALT and report which one. Do not synthesize a partial scenario.
+
+## Pre-flight values from `mauto record`
+
+The record session resolves these before synthesis begins:
+
+- **`overwrite_existing`** (boolean) — `true` when the user passed `--overwrite` AND a prior `mobile-automator/scenarios/<scenario_id>.json` exists. Drives the screenshot-archival branch below.
+- **`verify_on_save`** (boolean) — `true` when the user passed `--verify`. Drives the optional replay below.
+- **`selected_device`** — the device chosen during record pre-flight. Required for replay when `verify_on_save = true`. Pass it through unchanged.
+
+If these values are not supplied, default both booleans to `false` and skip the gated steps.
+
+## Synthesis Process
+
+Apply these steps in order. Rules whose canonical home is the generator guide are referenced, not redefined.
+
+1. **Load metadata.** Populate the scenario's top-level metadata block (`app_version`, `environment`) from `metadata.json`. Do NOT include `device_model`, `api_level`, or `timestamp` — those belong in result reports, not scenarios.
+
+2. **Reconcile edits.** Read events, assertions, and edits into memory. Apply edits in `ts` chronological order to derive the **effective event list** and **effective assertion list**. Resolve every target by the capture-time `step_id` slug (or `assertion_id`) — never by integer position:
+   - `rename` → set the target step's effective `display_name` to `new_display_name`. The `step_id` is re-derived in step 5 from this new name.
+   - `delete` → remove the target step, then resolve its anchored assertions by `assertion_policy`: `none` → nothing; `cascade` → those assertions are not emitted; `reanchor` → re-point them to the **previous surviving step** (or the **next surviving step** if the deleted step was first); if no step survives, drop those assertions and report it.
+   - `edit-value` → set the target `type` step's effective typed value to `new_value`.
+   - `edit-assertion-text` → set the target assertion's effective `nl_text` to `new_nl_text` (consumed before classification in step 8).
+   - Any unrecognized `op` → ignore and report it (forward-compatible).
+   - Replay semantics: a later edit on the same target supersedes an earlier one; an edit targeting an already-deleted entity is a silent no-op; re-anchor and rename resolve against the effective list at that edit's position. If a line in the edits log is not valid JSON (e.g. a partial trailing line from an interrupted write), skip it and report it — do not halt for one unparseable edit.
+
+3. **Resolve element identity.** For each effective event, locate the hierarchy snapshot whose padded-millis filename is the **most recent at or before** the event's `timestamp_ms`. Use `target_hint` plus that snapshot to confirm the element. If the event's `display_name` is missing or marked `is_unnamed: true`, use vision over the event's screenshot to suggest a concise descriptive name (e.g., "Login button", "Email input"). Never invent a target with no evidence in the hierarchy snapshot.
+
+4. **Map events to schema actions.** Use the **Step Translation Guide** in `mauto guide generate` to map each event `kind` to a schema action type (`tap`, `type`, `swipe`, `press_button`, `launch_app`, `open_url`, `long_press`, `double_tap`, `scroll_to_element`, `clear_app_data`, …). Only emit action types that appear in that translation guide; do not invent new ones.
+
+5. **Generate step IDs.** Derive a snake_case `step_id` from `<action>_<short_target>` (e.g., `tap_login`, `type_email`, `swipe_carousel_left`). A renamed step's effective `display_name` feeds this derivation, so a rename naturally yields a new `step_id`. Ensure IDs are unique; on collision suffix `_2`, `_3`, ….
+
+6. **Insert loading waits.** Between consecutive effective events, scan the hierarchy snapshots in the gap. If they contain elements matching {{loading_indicators}} continuously for ≥300 ms, insert a `wait_for_loading_complete` step before the second event. The canonical rule lives in the generator guide's pattern-detection section — follow it.
+
+7. **Apply the auto-assertion rule.** After every state-changing action (`tap`, `type` on submit-style inputs, `press_button`), emit a `visual_state: "loaded"` or `element_exists` assertion for the resulting screen, marked `[auto-generated]`. The full rule lives in the generator guide's Auto-Assertion section — do not re-derive it.
+
+8. **Classify the user assertions.** For each entry in `assertions.json`, first apply any `edit-assertion-text` edit so `nl_text` reflects the user's correction — the user supplied natural language, not a pre-typed assertion. Then classify using the generator guide's two-pass intent model: Pass 1 is always "Assertion" here (the recorder already separated actions from assertions), and Pass 2 selects the best-fit type from the generator guide's 27-type Assertion Type Decision Table. Emit the typed assertion with the correct fields:
+   - For **visual** types (`screenshot_match`, `visual_state`, `element_fully_visible`, `color_style`) — populate `reference_screenshot` with `mobile-automator/screenshots/<scenario_id>/assert_<id>.png`.
+   - For **non-visual** types — do NOT include `reference_screenshot`; the PNG stays as evidence but is not referenced.
+   - Resolve the effective `anchor_step_id` through reconciliation (honoring `reanchor` moves and the rename → new-slug derivation), then anchor via `after_step: <resolved_step_id>`. If no step matches after reconciliation, drop the assertion and report it.
+
+   If `assertions.json` is empty, emit `"assertions": []` — that is a valid scenario.
+
+9. **Generate tags.** Produce 1–5 kebab-case tags by intersecting {{business_critical_paths}} with the action verbs and observed screen titles. Each tag matches `^[a-z0-9][a-z0-9-]*$` and is ≤20 chars. If none qualify, emit `"tags": []`.
+
+10. **Generate a description.** One line, ≤120 chars: entry screen + primary action + resulting screen.
+
+11. **Emit the scenario JSON.** Follow `mauto guide generate` for the scenario JSON contract — field shapes, `$schema_version` placement, named snake_case string IDs, and `after_step` references all come from there. Write the result to `mobile-automator/scenarios/<scenario_id>.json`, then **validate it with `mauto validate <path>` against `mauto schema scenario`**. If validation fails, HALT and report the errors — do not write a malformed file.
+
+12. **Move screenshots.**
+    - **12a. Archive prior screenshots (only if `overwrite_existing = true`).** If `mobile-automator/screenshots/<scenario_id>/` already exists, move it aside to `mobile-automator/screenshots/.archive/<scenario_id>-<ts>/` (ISO-8601 UTC, colons/dots replaced by `-`; append `-2`, `-3`, … on collision). Announce the archive path. If `overwrite_existing = false` and the directory exists anyway, do NOT archive.
+    - **12b. Move bundle screenshots into place.** Move per-step screenshots into `mobile-automator/screenshots/<scenario_id>/` renamed to `step_<step_id>.png` matching the synthesized IDs; copy assertion screenshots `assert_<id>.png` **preserving their filenames** so `reference_screenshot` paths resolve at execute time.
+
+13. **Clean up on success.** Only after the scenario JSON is written AND `mauto validate` passed AND screenshots are moved, delete the bundle. If any prior step failed or halted, **leave the bundle in place** for retry or inspection.
+
+14. **Print a summary** in the same shape as `mauto guide generate`'s success message:
+    > "Scenario saved: `mobile-automator/scenarios/<scenario_id>.json` — Steps: N | Assertions: N | Tags: [tag1, tag2] | Screenshots: `mobile-automator/screenshots/<scenario_id>/`"
+
+15. **Verify (opt-in — only when `verify_on_save = true`).** If `verify_on_save` is false or unset, this is a no-op and synthesis ends after step 14. Otherwise replay the freshly-written scenario by following `mauto guide execute` inline against it: pass `scenario_id`, `selected_device`, and the resolved `environment`; do NOT re-run device/app pre-flight (already done during record). Report PASS or the executor's failure summary verbatim. **A replay failure must NOT delete the scenario JSON, the moved screenshots, or the archive** — the user owns the decision to keep, edit, or re-record.
+
+## Operational Boundaries
+
+### DO
+
+- Read every artifact in the bundle (via `mauto record-bundle <scenario_id>`) before emitting anything.
+- Apply edits in chronological order to derive the effective event list.
+- Defer to `mauto guide generate` for every rule whose canonical home is the generator guide.
+- Validate the emitted JSON with `mauto validate` against `mauto schema scenario` before considering the scenario done.
+- Delete the bundle only after validation succeeds.
+- Handle an empty `assertions.json` by emitting an empty `assertions` array.
+
+### DON'T
+
+- Replay any step on the device during synthesis — it is offline; drive the device only when `--verify` runs the executor guide.
+- Add steps that have no corresponding event in the effective event list.
+- Modify app source code in {{protected_directories}}.
+- Re-decide rules that already live in `mauto guide generate` — defer to them.
+- Delete the recorder bundle if synthesis halted or validation failed; leave it for retry.
+- Invent assertion types outside the 27 documented in the generator guide.
+
+## Resources
+
+- **`mauto record-bundle <scenario_id>`**: Reads the recorder artifact bundle (metadata, events, edits, assertions, hierarchy, screenshots) for synthesis.
+- **`mauto guide generate`**: Single source of truth for action mapping, the assertion taxonomy, the auto-assertion rule, and pattern detection — and for the scenario JSON contract.
+- **`mauto schema scenario`**: JSON schema for test scenarios. Validate the synthesized scenario with `mauto validate <path>` against it.
+- **`mauto guide execute`**: Replay logic used by the opt-in `--verify` step.
+- **mobile-automator/config.json**: Project configuration. Read it for any value not filled in this guide.
+- **mobile-automator/scenarios/**: Output directory for the synthesized scenario JSON.
+{{additional_resources}}

--- a/src/guide/content/setup.agnostic.md
+++ b/src/guide/content/setup.agnostic.md
@@ -1,0 +1,63 @@
+# Guide: setup (platform-agnostic)
+
+You are configuring a mobile-QA workspace by **analyzing this project**. The mechanical part is already done: `mauto setup` has scaffolded the `mobile-automator/` tree (scenarios, screenshots, results) and written a starter `config.json`. **This guide completes the project analysis** — you inspect the codebase, infer each fact, confirm anything uncertain with the user, and PERSIST every finding with `mauto config set <key> <value>`. Read each value back with `mauto config get <key>` to confirm it landed.
+
+In this mode the configuration is **portable**: facts are captured as plain-English, platform-neutral descriptions so a single config and the scenarios it drives run unchanged across both supported mobile platforms. You are doing LLM analysis work, not running a fixed script — read real project files, reason about what you find, and only ask the user when a value genuinely cannot be inferred.
+
+## How to persist a finding
+
+Every analysis result is stored in the workspace config:
+
+```
+mauto config set <key> <value>
+```
+
+For list-valued keys, pass a comma-separated value. Confirm uncertain values with the user before persisting; when a value truly cannot be inferred, ask the user directly and persist their answer.
+
+## 1. Project basics
+
+- **Project name** — auto-detect from `package.json` `name`, `pubspec.yaml` `name`, the root build file's project name, or the directory basename. Confirm with the user, then persist: `mauto config set project_name <name>`.
+- **App package identifiers (optional)** — if present, capture the application identifier(s) from the project's build configuration. Persist whichever apply: `mauto config set android_package <id>` and/or `mauto config set ios_bundle_id <id>`. Either, both, or neither may exist — leave a missing one unset.
+
+## 2. Business knowledge
+
+- **Business domain** — read `README.md`, app-store description, or the app display name to infer a one-sentence domain description. If you cannot tell, ask the user. Persist: `mauto config set business_domain "<one sentence>"`.
+- **Business-critical paths** — identify the most important user flows (onboarding, login, checkout, payment, search, profile, …) from navigation/route definitions, screen/page definitions, and feature structure. Confirm the list with the user. Persist a comma-separated value: `mauto config set business_critical_paths "<onboarding, login, checkout>"`.
+
+## 3. Loading indicators (semantic descriptions)
+
+Capture how loading **appears** in the app, in plain English — not class names. The agent needs to recognize loading visually, independent of platform. Examples:
+
+- `a centered spinner overlay during full-screen loads`
+- `shimmer placeholders for cards on the home screen`
+- `a small spinner inside the Login button while authenticating`
+
+Ask the user to describe it if you cannot infer it from the UI. Persist the description verbatim: `mauto config set loading_indicators "<plain-English description>"`.
+
+## 4. Protected directories
+
+List the source directories the QA tooling must NEVER modify (it operates on test artifacts, not source code). Auto-detect common source roots that exist in the project (e.g. `src/`, `lib/`, app/module source trees), confirm with the user, then persist a comma-separated value: `mauto config set protected_directories "<src/, lib/>"`.
+
+## 5. Environments (optional)
+
+In this mode environments are decoupled from build flavors — they are just labels for the test target. Ask the user whether the project has named environments (e.g. `production, staging, dev`). If yes, persist the list: `mauto config set environments <production,staging,dev>`. If no, leave it unset (or persist an empty list).
+
+## 6. Confirm the config
+
+Read the persisted values back with `mauto config get <key>` for each finding, and present a concise summary to the user. The workspace is now analyzed and configured: `mauto guide generate` and `mauto guide execute` will read these values to drive portable scenario authoring and execution. At execute time the four semantic actions — `press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission` — resolve per platform automatically, so nothing platform-specific needs to live in this config.
+
+## Operational Boundaries
+
+### DO
+
+- Inspect real project files before inferring any value.
+- Capture every fact as a plain-English, platform-neutral description.
+- Persist every finding with `mauto config set <key> <value>` and verify with `mauto config get`.
+- Ask the user directly for any value that cannot be inferred, and confirm uncertain inferences.
+
+### DON'T
+
+- Name a specific platform or platform-specific tooling in any persisted value — keep the config portable.
+- Modify app source code — this guide only reads it and writes the workspace config.
+- Re-scaffold the workspace — `mauto setup` already created the directory tree and starter config.
+- Invent a value you cannot find evidence for — ask the user instead.

--- a/src/guide/content/setup.aware.md
+++ b/src/guide/content/setup.aware.md
@@ -1,0 +1,89 @@
+# Guide: setup (platform-aware)
+
+You are configuring a mobile-QA workspace by **analyzing this project**. The mechanical part is already done: `mauto setup` has scaffolded the `mobile-automator/` tree (scenarios, screenshots, results) and written a starter `config.json`. **This guide completes the project analysis** — you inspect the codebase, infer each fact, confirm anything uncertain with the user, and PERSIST every finding with `mauto config set <key> <value>`. Read each value back with `mauto config get <key>` to confirm it landed.
+
+You are doing LLM analysis work, not running a fixed script. Read real project files, reason about what you find, and only ask the user when a value genuinely cannot be inferred.
+
+## How to persist a finding
+
+Every analysis result is stored in the workspace config:
+
+```
+mauto config set <key> <value>
+```
+
+For list-valued keys (e.g. `protected_directories`), pass a comma-separated value. When a value is uncertain, confirm it with the user before persisting. When you truly cannot infer a value, ask the user directly and persist their answer.
+
+## 1. Detect the platform
+
+Inspect the project files to determine the mobile platform. First honor any `.gitignore` patterns, then run these checks in order and stop at the first match:
+
+- **Flutter** — `pubspec.yaml` at the root with `flutter` in `dependencies`/`environment`.
+- **React Native** — `package.json` with `react-native` in `dependencies`/`devDependencies`.
+- **Kotlin Multiplatform** — `build.gradle.kts`/`build.gradle` declaring the `kotlin("multiplatform")` plugin, or `shared/` / `composeApp/` source sets (`commonMain/`, `androidMain/`, `iosMain/`).
+- **Compose Multiplatform** — the `org.jetbrains.compose` plugin or a `composeApp/` `commonMain/` with `@Composable` functions.
+- **Android Native** — `build.gradle`/`build.gradle.kts` with the `com.android.application` plugin, or `AndroidManifest.xml`.
+- **iOS Native** — `*.xcodeproj` / `*.xcworkspace`, `*.swift`/`*.m` sources, or `Info.plist`.
+
+If none match, ask the user which platform this is. Confirm the detected platform with the user, then persist it:
+
+```
+mauto config set platform <platform>
+```
+
+## 2. Discover build environments
+
+Scan the project's build configuration for named environments, scoped to the detected platform:
+
+- **Gradle-based projects** — read the app/module build file; extract `productFlavors` (names + any `applicationIdSuffix`) and `buildTypes` (e.g. `debug`, `release`, `staging`). Compile the cross-product (e.g. `stagingDebug`, `productionRelease`).
+- **Xcode-based projects** — list build schemes (`*.xcscheme`) and per-configuration `*.xcconfig` files; treat each configuration as an environment.
+- **Flutter** — look for `--dart-define` patterns, flavor configs, and env files (`.env.staging`, `lib/flavors/`, `flutter_dotenv` / `envied`).
+- **React Native** — look for `.env*` files, env-specific `package.json` scripts, and `react-native-config` / `react-native-dotenv`.
+
+Deduplicate the result. If none are found, default to `production, staging, development`. Confirm with the user, then persist:
+
+```
+mauto config set environments <env1,env2,...>
+```
+
+## 3. Infer the app package
+
+Read the application identifier from the build files, scoped to the platform:
+
+- **Android module** — base `applicationId` from the app build file's `defaultConfig`, plus any flavor/buildType `applicationIdSuffix`. Persist with `mauto config set android_package <id>`.
+- **Apple target** — `PRODUCT_BUNDLE_IDENTIFIER` from the Xcode project (`project.pbxproj`/`*.xcconfig`) or `CFBundleIdentifier` in `Info.plist`. Persist with `mauto config set ios_bundle_id <id>`.
+- **Cross-platform projects** — persist both the Android `android_package` and the Apple `ios_bundle_id`.
+
+If you cannot infer the identifier, ask the user for it (`e.g. com.example.myapp`), then persist. Confirm any inferred value with the user first.
+
+## 4. Capture project knowledge
+
+Infer each of the following from the codebase, confirm uncertain values with the user, and persist each one.
+
+- **Project name** — from `settings.gradle*` `rootProject.name`, `pubspec.yaml` `name`, `package.json` `name`, the `*.xcodeproj` name, or the root directory name. Persist: `mauto config set project_name <name>`.
+- **Platform details** — versions like `minSdk`/`targetSdk`/`compileSdk` (Gradle) or the deployment target (Xcode); format as e.g. `"Android (minSdk 24, targetSdk 34)"` or `"iOS (deployment target 16)"`. Persist: `mauto config set platform_details "<details>"`.
+- **Build system** — `"Gradle (AGP)"`, `"Xcode"`, `"Flutter CLI + Gradle + Xcode"`, or `"Metro + Gradle + Xcode"`. Persist: `mauto config set build_system "<system>"`.
+- **Build command** — the default debug/development build command (e.g. `./gradlew assembleDemoDebug`, `flutter build apk --flavor demo`, `npx react-native run-android`, or `xcodebuild -scheme <scheme>`). Persist: `mauto config set build_command "<command>"`.
+- **Architecture** — infer from directory and class naming (`viewmodel/` → MVVM; `repository/`+`usecase/`+`domain/`+`data/` → Clean Architecture; `bloc/`/`cubit/` → BLoC; `reducer/`/`store/` → Redux/MVI; `presenter/`/`interactor/` → MVP/VIPER). Combine findings (e.g. `"MVVM with Clean Architecture"`). If unclear, ask the user. Persist: `mauto config set architecture "<pattern>"`.
+- **Business domain** — read `README.md`, app-store metadata, `pubspec.yaml`/`package.json` description, or the app display name to infer a one-sentence domain description. If you cannot tell, ask the user. Persist: `mauto config set business_domain "<one sentence>"`.
+- **Business-critical paths** — analyze navigation graphs, route/deep-link definitions, screen/Activity/Fragment/ViewController/page definitions, and feature modules to find the most important user flows (login, signup, onboarding, checkout, payment, search, profile, …). Confirm the list with the user. Persist a comma-separated value: `mauto config set business_critical_paths "<onboarding, login, checkout>"`.
+- **Loading indicators** — grep for loading widgets/components (progress indicators, spinners, shimmer/skeleton placeholders) and any `*Loading*`/`*Spinner*`/`*Shimmer*`/`*Skeleton*` classes. Persist the found names, or a description like `"progress bars, spinners, shimmer effects"` if none found. Persist: `mauto config set loading_indicators "<list>"`.
+- **Protected directories** — list the source directories the QA tooling must NEVER modify (e.g. `app/src/`, `lib/`, `src/`, `shared/`, `composeApp/`, `iosApp/`). Confirm with the user. Persist a comma-separated value: `mauto config set protected_directories "<app/src/, lib/, core/>"`.
+
+## 5. Confirm the config
+
+Read the persisted values back with `mauto config get <key>` for each finding, and present a concise summary to the user. The workspace is now analyzed and configured: `mauto guide generate` and `mauto guide execute` will read these values to drive scenario authoring and execution.
+
+## Operational Boundaries
+
+### DO
+
+- Inspect real project files before inferring any value.
+- Persist every finding with `mauto config set <key> <value>` and verify with `mauto config get`.
+- Ask the user directly for any value that cannot be inferred, and confirm uncertain inferences.
+
+### DON'T
+
+- Modify app source code — this guide only reads it and writes the workspace config.
+- Re-scaffold the workspace — `mauto setup` already created the directory tree and starter config.
+- Invent a value you cannot find evidence for — ask the user instead.

--- a/src/guide/emitter.js
+++ b/src/guide/emitter.js
@@ -25,7 +25,7 @@ const { interpolate } = require('./placeholders');
 // which fills tokens from the workspace config and applies a fallback so no
 // `{{` survives. Topics absent from this map fall through to the stub emitter.
 const CONTENT_DIR = path.resolve(__dirname, 'content');
-const PORTED_TOPICS = new Set(['generate', 'execute']);
+const PORTED_TOPICS = new Set(['generate', 'execute', 'record', 'setup']);
 
 const SCENARIO_SCHEMA = path.resolve(
   __dirname,

--- a/tests/unit/guide/emitter.test.js
+++ b/tests/unit/guide/emitter.test.js
@@ -31,12 +31,15 @@ describe('guide/emitter', () => {
       }
     });
 
-    it('notes that full content lands later for not-yet-ported topics', () => {
-      // generate + execute are fully ported; record/setup are still stubs.
-      expect(emitGuide('record', { mode: 'platform-aware' }).toLowerCase()).toContain('later slice');
+    it('every topic is now fully ported — no "later slice" stub remains', () => {
+      for (const topic of TOPICS) {
+        for (const mode of MODES) {
+          expect(emitGuide(topic, { mode }).toLowerCase()).not.toContain('later slice');
+        }
+      }
     });
 
-    it('agnostic stubs mention the four semantic actions', () => {
+    it('agnostic guides mention the four semantic actions', () => {
       for (const topic of TOPICS) {
         const out = emitGuide(topic, { mode: 'platform-agnostic' });
         for (const act of ['press_back', 'dismiss_keyboard', 'grant_permission', 'deny_permission']) {

--- a/tests/unit/guide/record-content.test.js
+++ b/tests/unit/guide/record-content.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { emitGuide } = require('../../../src/guide/emitter');
+
+function tmpProject(config) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-rec-'));
+  if (config) {
+    const dir = path.join(root, 'mobile-automator');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(config, null, 2));
+  }
+  return root;
+}
+
+const MCP_TOOL = /\bmobile_[a-z_]+/;
+
+describe('guide emitter — real record content', () => {
+  describe('aware mode', () => {
+    let out;
+    beforeAll(() => {
+      out = emitGuide('record', { mode: 'platform-aware' });
+    });
+
+    it('preserves the Synthesizer persona / synthesis-not-capture framing', () => {
+      expect(out).toMatch(/Synthesizer/);
+      expect(out).toMatch(/synthesis, not capture/i);
+    });
+
+    it('describes the recorder artifact bundle structure', () => {
+      expect(out).toMatch(/artifact bundle/i);
+      expect(out).toMatch(/events\.jsonl/);
+      expect(out).toMatch(/edits\.jsonl/);
+      expect(out).toMatch(/assertions\.json/);
+      expect(out).toMatch(/metadata\.json/);
+      expect(out).toMatch(/hierarchy/);
+    });
+
+    it('reads the bundle via `mauto record-bundle`', () => {
+      expect(out).toMatch(/mauto record-bundle/);
+    });
+
+    it('defers to the generator guide for scenario shape', () => {
+      expect(out).toMatch(/mauto guide generate/);
+    });
+
+    it('validates the synthesized scenario with `mauto validate` against `mauto schema scenario`', () => {
+      expect(out).toMatch(/mauto validate/);
+      expect(out).toMatch(/mauto schema scenario/);
+    });
+
+    it('keeps the synthesis IP: edit reconciliation + assertion classification at save', () => {
+      expect(out).toMatch(/Reconcile edits|edit reconciliation|chronological/i);
+      expect(out).toMatch(/Classify .*assertions|assertion classification/i);
+      expect(out).toMatch(/auto-assertion/i);
+    });
+
+    it('contains no leaked mobile_* tool name', () => {
+      expect(out).not.toMatch(MCP_TOOL);
+    });
+
+    it('contains no surviving {{ placeholder token', () => {
+      expect(out).not.toContain('{{');
+    });
+
+    it('contains no leftover Gemini framing or .gemini paths', () => {
+      expect(out).not.toMatch(/Gemini/);
+      expect(out).not.toMatch(/\.gemini\//);
+      expect(out).not.toMatch(/GEMINI\.md/);
+      expect(out).not.toMatch(/mobile-mcp/i);
+    });
+
+    it('interpolates config values when a project config exists', () => {
+      const root = tmpProject({
+        mode: 'platform-aware',
+        knowledge: { project_name: 'PaymentsApp' },
+        app: { android_package: 'com.acme.payments' },
+      });
+      const withCfg = emitGuide('record', { mode: 'platform-aware', projectRoot: root });
+      expect(withCfg).toMatch(/PaymentsApp/);
+      expect(withCfg).not.toContain('{{');
+    });
+  });
+
+  describe('agnostic mode', () => {
+    let out;
+    beforeAll(() => {
+      out = emitGuide('record', { mode: 'platform-agnostic' });
+    });
+
+    it('preserves the Synthesizer persona', () => {
+      expect(out).toMatch(/Synthesizer/);
+    });
+
+    it('describes the artifact bundle and reads it via `mauto record-bundle`', () => {
+      expect(out).toMatch(/artifact bundle/i);
+      expect(out).toMatch(/mauto record-bundle/);
+      expect(out).toMatch(/events\.jsonl/);
+    });
+
+    it('defers to the generator guide and validates with mauto validate / mauto schema scenario', () => {
+      expect(out).toMatch(/mauto guide generate/);
+      expect(out).toMatch(/mauto validate/);
+      expect(out).toMatch(/mauto schema scenario/);
+    });
+
+    it('names the four semantic actions', () => {
+      for (const act of ['press_back', 'dismiss_keyboard', 'grant_permission', 'deny_permission']) {
+        expect(out).toContain(act);
+      }
+    });
+
+    it('names no OS / OS-specific tooling', () => {
+      const FORBIDDEN = [
+        /\bAndroid\b/i, /\biOS\b/i, /\badb\b/i, /\bxcrun\b/i, /\bresource[ -]?id\b/i,
+        /\bFlutter\b/i, /\bReact[ -]?Native\b/i, /\bKotlin\b/i, /\bCompose\b/i,
+        /\bxcode\b/i, /\bsimulator\b/i, /\bemulator\b/i,
+      ];
+      const violations = FORBIDDEN.filter((p) => p.test(out)).map((p) => p.toString());
+      expect(violations).toEqual([]);
+    });
+
+    it('contains no leaked mobile_* tool name', () => {
+      expect(out).not.toMatch(MCP_TOOL);
+    });
+
+    it('contains no surviving {{ placeholder token', () => {
+      expect(out).not.toContain('{{');
+    });
+
+    it('contains no leftover Gemini framing', () => {
+      expect(out).not.toMatch(/Gemini/);
+      expect(out).not.toMatch(/\.gemini\//);
+      expect(out).not.toMatch(/mobile-mcp/i);
+    });
+  });
+});

--- a/tests/unit/guide/setup-content.test.js
+++ b/tests/unit/guide/setup-content.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const { emitGuide } = require('../../../src/guide/emitter');
+
+const MCP_TOOL = /\bmobile_[a-z_]+/;
+
+describe('guide emitter — real setup content', () => {
+  describe('aware mode', () => {
+    let out;
+    beforeAll(() => {
+      out = emitGuide('setup', { mode: 'platform-aware' });
+    });
+
+    it('frames the guide as project analysis that completes the already-scaffolded workspace', () => {
+      expect(out).toMatch(/analy[sz]e|analysis|inspect/i);
+      expect(out).toMatch(/mauto setup/);
+    });
+
+    it('persists findings via `mauto config set <key> <value>`', () => {
+      expect(out).toMatch(/mauto config set/);
+    });
+
+    it('covers the key analysis findings (project name, package, knowledge fields)', () => {
+      expect(out).toMatch(/project_name/);
+      expect(out).toMatch(/android_package|ios_bundle_id|app_package/);
+      expect(out).toMatch(/loading_indicators/);
+      expect(out).toMatch(/protected_directories/);
+      expect(out).toMatch(/business_domain/);
+    });
+
+    it('covers aware-only findings (architecture / platform / build)', () => {
+      expect(out).toMatch(/architecture/);
+      expect(out).toMatch(/platform_details/);
+      expect(out).toMatch(/build_system/);
+      expect(out).toMatch(/build_command/);
+    });
+
+    it('describes how to detect platform from project files', () => {
+      expect(out).toMatch(/pubspec\.yaml|build\.gradle|package\.json|xcodeproj/);
+    });
+
+    it('contains no leaked mobile_* tool name', () => {
+      expect(out).not.toMatch(MCP_TOOL);
+    });
+
+    it('contains no surviving {{ placeholder token', () => {
+      expect(out).not.toContain('{{');
+    });
+
+    it('contains no leftover Gemini framing or ask_user tool', () => {
+      expect(out).not.toMatch(/Gemini/);
+      expect(out).not.toMatch(/ask_user/);
+      expect(out).not.toMatch(/\.gemini\//);
+      expect(out).not.toMatch(/GEMINI\.md/);
+    });
+  });
+
+  describe('agnostic mode', () => {
+    let out;
+    beforeAll(() => {
+      out = emitGuide('setup', { mode: 'platform-agnostic' });
+    });
+
+    it('persists findings via `mauto config set <key> <value>`', () => {
+      expect(out).toMatch(/mauto config set/);
+    });
+
+    it('covers the agnostic findings (project name, domain, critical paths, loading, protected dirs)', () => {
+      expect(out).toMatch(/project_name/);
+      expect(out).toMatch(/business_domain/);
+      expect(out).toMatch(/business_critical_paths/);
+      expect(out).toMatch(/loading_indicators/);
+      expect(out).toMatch(/protected_directories/);
+    });
+
+    it('frames loading indicators as plain-English / semantic descriptions', () => {
+      expect(out).toMatch(/semantic|plain English|plain-English/i);
+    });
+
+    it('names no OS / OS-specific tooling', () => {
+      const FORBIDDEN = [
+        /\bAndroid\b/i, /\biOS\b/i, /\badb\b/i, /\bxcrun\b/i, /\bresource[ -]?id\b/i,
+        /\bFlutter\b/i, /\bReact[ -]?Native\b/i, /\bKotlin\b/i, /\bCompose\b/i,
+        /\bxcode\b/i, /\bsimulator\b/i, /\bemulator\b/i,
+      ];
+      const violations = FORBIDDEN.filter((p) => p.test(out)).map((p) => p.toString());
+      expect(violations).toEqual([]);
+    });
+
+    it('contains no leaked mobile_* tool name', () => {
+      expect(out).not.toMatch(MCP_TOOL);
+    });
+
+    it('contains no surviving {{ placeholder token', () => {
+      expect(out).not.toContain('{{');
+    });
+
+    it('contains no leftover Gemini framing', () => {
+      expect(out).not.toMatch(/Gemini/);
+      expect(out).not.toMatch(/ask_user/);
+      expect(out).not.toMatch(/\.gemini\//);
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #84 (slice 5). Final guide ports — after this, all four `mauto guide` topics are real prose, no stubs.

## What
- **record** — keeps recorder IP (bundle layout, edit reconciliation, assertion classification at save, opt-in `--verify`); reads the persisted bundle via `mauto record-bundle <id>` (slice-8 verb) and defers to `mauto guide generate` for scenario shape, validating with `mauto validate` / `mauto schema scenario`
- **setup** — reframes the project-analysis prose to persist findings via `mauto config set <key> <value>`; the mechanical scaffold stays the `mauto setup` verb
- mobile-mcp tool names → `mauto` verbs; agnostic variants name **no OS** + four semantic actions
- emitter: `record`+`setup` added to `PORTED_TOPICS` (all four ported)

## Test plan
- `npm test`: **101 suites / 790 tests green** (+33)
- 3 guide lint guards pass across **all four** topics (no `mobile_*`, no `{{`, agnostic-no-OS)
- Manual: `guide record` / `guide setup` clean aware prose; agnostic config → agnostic variants, 0 OS words

Closes #75 · Refs #69