### PR TITLE
cli slice 8 — recorder decoupling: persist bundle + record-bundle + tap source

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -12,6 +12,7 @@ const configManager = require('./config/manager');
 const { scaffold } = require('./setup/scaffold');
 const guideEmitter = require('./guide/emitter');
 const { ADAPTERS } = require('./init/adapters');
+const bundleReader = require('./recorder/bundle-reader');
 
 // Map the user-facing --mode flag onto the stored config mode values.
 const MODE_ALIASES = {
@@ -367,6 +368,37 @@ function handleInit({ projectRoot, adapters = ADAPTERS }, agent) {
   };
 }
 
+// --- Slice 8: decoupled recorder bundle reader ----------------------------
+//
+// `mauto record-bundle <id>` reads the artifact bundle the recorder PERSISTED
+// on a successful Save (under mobile-automator/.recorder/<id>/) so an agent can
+// synthesize a scenario offline. `--consume` deletes the bundle after a
+// successful read (post-synthesis cleanup). A missing bundle is an
+// invalid_input error (exit 3) — there is nothing to read.
+function handleRecordBundle({ projectRoot, reader = bundleReader }, scenarioId, opts = {}) {
+  let bundle;
+  try {
+    bundle = reader.readBundle(projectRoot, scenarioId);
+  } catch (err) {
+    return {
+      envelope: fail(
+        'invalid_input',
+        err.message || `no recording bundle for ${scenarioId}`,
+        'record one first with mauto record'
+      ),
+      exitKind: 'invalid_input',
+    };
+  }
+
+  let consumed = false;
+  if (opts.consume) {
+    reader.consume(projectRoot, scenarioId);
+    consumed = true;
+  }
+
+  return { envelope: ok({ ...bundle, consumed }), exitKind: 'ok' };
+}
+
 // ---------------------------------------------------------------------------
 // Program wiring
 // ---------------------------------------------------------------------------
@@ -603,6 +635,15 @@ function buildProgram(deps = {}) {
     });
 
   program
+    .command('record-bundle <id>')
+    .description('Read the persisted recorder artifact bundle for a scenario (for offline synthesis)')
+    .option('--consume', 'delete the bundle after a successful read', false)
+    .action((id, opts) => {
+      const r = handleRecordBundle({ projectRoot }, id, { consume: Boolean(opts.consume) });
+      emit(r, humanFlag());
+    });
+
+  program
     .command('mcp')
     .description('Run the MCP prompts server (stdio) exposing the mauto workflows as prompts')
     .action(async () => {
@@ -652,4 +693,5 @@ module.exports = {
   handleSchema,
   handleBootstrap,
   handleInit,
+  handleRecordBundle,
 };

--- a/src/recorder/bundle-reader.js
+++ b/src/recorder/bundle-reader.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// Reader for recorder artifact bundles persisted under
+//   <projectRoot>/mobile-automator/.recorder/<scenario_id>/
+//
+// Slice 8 decouples recording from synthesis: the recorder now PERSISTS the
+// bundle on a successful Save (instead of deleting it), and a separate offline
+// step (`mauto record-bundle <id>`) reads the structured bundle so an agent can
+// synthesize a scenario JSON. After synthesis the caller `consume`s the bundle
+// to delete it. The bundle shape is platform-agnostic — it carries whatever the
+// recorder wrote; no OS-specific assumptions live here.
+
+const fs = require('fs');
+const path = require('path');
+
+const SCREENSHOT_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+
+function bundleRoot(projectRoot, scenarioId) {
+  return path.join(projectRoot, 'mobile-automator', '.recorder', scenarioId);
+}
+
+// Parse a JSON-lines file into an array of objects. Missing file → []. Blank
+// lines are skipped. A malformed line throws (corrupt bundle is a hard error).
+function readJsonl(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return raw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+function readJsonFile(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+// List hierarchy snapshots as {t, path}. Filenames are zero-padded timestamps
+// (e.g. 0001000.json → t=1000). Sorted ascending by t so the consumer can scan
+// chronologically.
+function readHierarchy(root) {
+  const dir = path.join(root, 'hierarchy');
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => ({ t: Number.parseInt(path.basename(f, '.json'), 10), path: path.join(dir, f) }))
+    .filter((e) => Number.isFinite(e.t))
+    .sort((a, b) => a.t - b.t);
+}
+
+function readScreenshots(root) {
+  const dir = path.join(root, 'screenshots');
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f) => SCREENSHOT_EXTS.has(path.extname(f).toLowerCase()))
+    .sort()
+    .map((f) => path.join(dir, f));
+}
+
+/**
+ * Read a persisted recorder bundle into a structured object.
+ *
+ * @returns {{
+ *   scenario_id: string,
+ *   root: string,
+ *   metadata: object,
+ *   events: object[],
+ *   hierarchy: {t:number, path:string}[],
+ *   assertions: object[],
+ *   edits: object[],
+ *   screenshots: string[]
+ * }}
+ * @throws if the bundle directory does not exist.
+ */
+function readBundle(projectRoot, scenarioId) {
+  const root = bundleRoot(projectRoot, scenarioId);
+  if (!fs.existsSync(root)) {
+    throw new Error(`no recording bundle for ${scenarioId}`);
+  }
+
+  return {
+    scenario_id: scenarioId,
+    root,
+    metadata: readJsonFile(path.join(root, 'metadata.json'), {}),
+    events: readJsonl(path.join(root, 'events.jsonl')),
+    hierarchy: readHierarchy(root),
+    assertions: readJsonFile(path.join(root, 'assertions.json'), []),
+    edits: readJsonl(path.join(root, 'edits.jsonl')),
+    screenshots: readScreenshots(root),
+  };
+}
+
+// Delete the bundle (post-synthesis cleanup). Idempotent — no-op when absent.
+function consume(projectRoot, scenarioId) {
+  const root = bundleRoot(projectRoot, scenarioId);
+  if (fs.existsSync(root)) fs.rmSync(root, { recursive: true, force: true });
+}
+
+module.exports = { readBundle, consume, bundleRoot };

--- a/tests/integration/recorder/end-to-end.test.js
+++ b/tests/integration/recorder/end-to-end.test.js
@@ -10,18 +10,24 @@
 //   2. A test-fixture deterministic synthesizer ("mock AI") reads the
 //      bundle's `events.jsonl` and writes a v2.1 scenario JSON, mirroring
 //      the contract that the real recorder skill template fulfils. It also
-//      promotes the bundle's screenshots/ directory to the public location
-//      and calls `cleanupOnSuccess` (the same hook the skill calls after
-//      successful synthesis).
+//      promotes the bundle's screenshots/ directory to the public location.
 //   3. `handleSaveMessage` (Task 2.6) is invoked with an injected `onDone`
 //      callback to capture the signalled exit code without `process.exit`.
 //
-// The test then pins three invariants from the issue's acceptance criteria:
+// Slice 8 (recorder decoupling, #77): a SUCCESSFUL Save now PERSISTS the
+// artifact bundle under `mobile-automator/.recorder/<id>/` — recording is a
+// standalone step and synthesis (which reads + consumes the bundle) is
+// decoupled. The synthesizer below therefore no longer deletes the bundle, and
+// invariant C asserts the bundle PERSISTS after Save (cleanup is the separate
+// `consume` step exercised by the bundle-reader tests). CANCEL still removes.
+//
+// The test then pins these invariants from the issue's acceptance criteria:
 //
 //   A. `mobile-automator/scenarios/<id>.json` exists and validates against
 //      the v2.1 scenario schema.
 //   B. `mobile-automator/screenshots/<id>/` exists.
-//   C. `mobile-automator/.recorder/<id>/` is gone (cleanup-on-Success).
+//   C. `mobile-automator/.recorder/<id>/` PERSISTS after the Save flow, and a
+//      subsequent Cancel removes it.
 //
 // Per #22 scope: tap-only flow, no real AI, no real browser. This test does
 // NOT validate the real AI's behaviour — that contract is covered by the
@@ -36,7 +42,7 @@ const os = require('os');
 
 const { runScriptedSession } = require('../../../tools/recorder/src/lifecycle');
 const { ArtifactsStore } = require('../../../tools/recorder/src/artifacts');
-const { handleSaveMessage } = require('../../../tools/recorder/src/session-handlers');
+const { handleSaveMessage, handleCancelMessage } = require('../../../tools/recorder/src/session-handlers');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 const SCENARIO_SCHEMA_PATH = path.join(
@@ -143,10 +149,11 @@ function validateScenarioAgainstSchema(scenario, schema) {
 // --- Test-fixture deterministic synthesizer ("mock AI") --------------------
 //
 // Mirrors the recorder skill's contract: read the artifact bundle, emit a
-// v2.1 scenario JSON, move screenshots to the public location, and call
-// cleanupOnSuccess. Lives here (not in production code) on purpose — the
-// real synthesis is the AI's job; this stand-in exists only to pin the
-// shape-of-the-bundle contract.
+// v2.1 scenario JSON, and move screenshots to the public location. Lives here
+// (not in production code) on purpose — the real synthesis is the AI's job;
+// this stand-in exists only to pin the shape-of-the-bundle contract. Post
+// slice 8 it does NOT delete the bundle: Save persists it, and consuming the
+// bundle is a separate decoupled step (covered by the bundle-reader tests).
 
 function synthesizeScenario(projectRoot, scenarioId) {
   const bundleRoot = path.join(projectRoot, 'mobile-automator', '.recorder', scenarioId);
@@ -224,9 +231,10 @@ function synthesizeScenario(projectRoot, scenarioId) {
   const scenarioPath = path.join(scenariosDir, `${scenarioId}.json`);
   fs.writeFileSync(scenarioPath, JSON.stringify(scenario, null, 2));
 
-  // Cleanup: the real skill does this in step 13 of its Process.
+  // Slice 8: the bundle PERSISTS on Save — no cleanupOnSuccess here. The
+  // store is returned so the Save handler can run and the test can later
+  // exercise the explicit Cancel-removes path.
   const store = new ArtifactsStore({ projectRoot, scenarioId });
-  store.cleanupOnSuccess();
 
   return { scenarioPath, store };
 }
@@ -241,6 +249,7 @@ describe('recorder end-to-end (record → save → cleanup)', () => {
   let publicScreenshotsDir;
   let bundleRoot;
   let exitCode;
+  let store;
 
   beforeAll(async () => {
     scenarioId = 'login_flow';
@@ -260,10 +269,11 @@ describe('recorder end-to-end (record → save → cleanup)', () => {
     bundleRoot = path.join(tmp, 'mobile-automator', '.recorder', scenarioId);
     expect(fs.existsSync(bundleRoot)).toBe(true); // sanity — lifecycle ran
 
-    // (2) Mock-AI synthesis: bundle → scenario JSON + screenshots; then
-    //     cleanupOnSuccess (mirrors what the recorder skill does).
+    // (2) Mock-AI synthesis: bundle → scenario JSON + screenshots. Slice 8:
+    //     synthesis no longer deletes the bundle (Save persists it).
     const out = synthesizeScenario(tmp, scenarioId);
     scenarioPath = out.scenarioPath;
+    store = out.store;
     scenariosDir = path.join(tmp, 'mobile-automator', 'scenarios');
     publicScreenshotsDir = path.join(tmp, 'mobile-automator', 'screenshots', scenarioId);
 
@@ -309,7 +319,16 @@ describe('recorder end-to-end (record → save → cleanup)', () => {
     expect(fs.statSync(publicScreenshotsDir).isDirectory()).toBe(true);
   });
 
-  test('C. mobile-automator/.recorder/<id>/ is gone after Save flow', () => {
+  test('C. mobile-automator/.recorder/<id>/ PERSISTS after the Save flow', () => {
+    // Slice 8 decouples recording from synthesis: a successful Save keeps the
+    // bundle so the offline `mauto record-bundle <id>` step can read it.
+    expect(fs.existsSync(bundleRoot)).toBe(true);
+  });
+
+  test('C. a subsequent Cancel removes the persisted bundle', () => {
+    // Runs after the persist assertion (Jest preserves declaration order).
+    // CANCEL is still the destructive path: cleanupOnCancel nukes the tree.
+    handleCancelMessage({ store, onDone: () => {} });
     expect(fs.existsSync(bundleRoot)).toBe(false);
   });
 

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -22,6 +22,7 @@ const {
   handleSchema,
   handleBootstrap,
   handleInit,
+  handleRecordBundle,
 } = require('../../src/cli');
 const Ajv = require('ajv');
 
@@ -419,6 +420,57 @@ describe('cli handlers', () => {
       expect(envelope.ok).toBe(false);
       expect(envelope.error.kind).toBe('invalid_input');
       expect(envelope.hint).toContain('claude');
+    });
+  });
+
+  describe('handleRecordBundle (read persisted recorder bundle)', () => {
+    const REPO_ROOT = path.resolve(__dirname, '..', '..');
+    const FIXTURE = path.join(REPO_ROOT, 'tests', 'fixtures', 'recorder', 'sample-bundle');
+
+    function copyTree(src, dest) {
+      fs.mkdirSync(dest, { recursive: true });
+      for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+        const s = path.join(src, entry.name);
+        const d = path.join(dest, entry.name);
+        if (entry.isDirectory()) copyTree(s, d);
+        else fs.copyFileSync(s, d);
+      }
+    }
+
+    function seed(scenarioId) {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-recbundle-'));
+      copyTree(FIXTURE, path.join(projectRoot, 'mobile-automator', '.recorder', scenarioId));
+      return projectRoot;
+    }
+
+    test('reads the bundle envelope (events parsed, hierarchy listed)', () => {
+      const projectRoot = seed('login_flow');
+      const { envelope, exitKind } = handleRecordBundle({ projectRoot }, 'login_flow', {});
+      expect(exitKind).toBe('ok');
+      expect(envelope.ok).toBe(true);
+      expect(envelope.data.scenario_id).toBe('login_flow');
+      expect(envelope.data.events).toHaveLength(3);
+      expect(envelope.data.hierarchy).toHaveLength(2);
+      // Without --consume the bundle is left in place.
+      expect(fs.existsSync(path.join(projectRoot, 'mobile-automator', '.recorder', 'login_flow'))).toBe(true);
+    });
+
+    test('--consume deletes the bundle after a successful read', () => {
+      const projectRoot = seed('login_flow');
+      const { envelope, exitKind } = handleRecordBundle({ projectRoot }, 'login_flow', { consume: true });
+      expect(exitKind).toBe('ok');
+      expect(envelope.data.consumed).toBe(true);
+      expect(fs.existsSync(path.join(projectRoot, 'mobile-automator', '.recorder', 'login_flow'))).toBe(false);
+    });
+
+    test('missing bundle -> invalid_input (exit 3) with a record hint', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-recbundle-missing-'));
+      const { envelope, exitKind } = handleRecordBundle({ projectRoot }, 'nope', {});
+      expect(exitKind).toBe('invalid_input');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('invalid_input');
+      expect(envelope.error.message).toContain('no recording bundle for nope');
+      expect(envelope.hint).toContain('mauto record');
     });
   });
 });

--- a/tests/unit/recorder/bundle-reader.test.js
+++ b/tests/unit/recorder/bundle-reader.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { readBundle, consume } = require('../../../src/recorder/bundle-reader');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const FIXTURE_PLAIN = path.join(REPO_ROOT, 'tests', 'fixtures', 'recorder', 'sample-bundle');
+const FIXTURE_ASSERTIONS = path.join(
+  REPO_ROOT, 'tests', 'fixtures', 'recorder', 'sample-bundle-with-assertions'
+);
+
+// Recursively copy a directory tree (the fixture) into a tmp bundle location.
+function copyTree(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyTree(s, d);
+    else fs.copyFileSync(s, d);
+  }
+}
+
+function seedBundle(fixtureDir, scenarioId) {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-reader-'));
+  const bundleRoot = path.join(projectRoot, 'mobile-automator', '.recorder', scenarioId);
+  copyTree(fixtureDir, bundleRoot);
+  return { projectRoot, bundleRoot };
+}
+
+describe('bundle-reader.readBundle', () => {
+  let projectRoot;
+  let bundleRoot;
+
+  afterEach(() => {
+    if (projectRoot && fs.existsSync(projectRoot)) {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('parses metadata, events.jsonl, hierarchy, assertions, edits, screenshots', () => {
+    ({ projectRoot, bundleRoot } = seedBundle(FIXTURE_PLAIN, 'login_flow'));
+
+    const bundle = readBundle(projectRoot, 'login_flow');
+
+    expect(bundle.scenario_id).toBe('login_flow');
+    expect(bundle.metadata).toMatchObject({ scenario_id: 'login_flow', mode: 'platform-aware' });
+
+    // events.jsonl parsed into an array of objects.
+    expect(Array.isArray(bundle.events)).toBe(true);
+    expect(bundle.events).toHaveLength(3);
+    expect(bundle.events[0]).toMatchObject({ seq: 1, kind: 'tap', step_id: 'tap_login' });
+
+    // hierarchy listed as {t, path} entries, sorted by t.
+    expect(Array.isArray(bundle.hierarchy)).toBe(true);
+    expect(bundle.hierarchy).toHaveLength(2);
+    expect(bundle.hierarchy[0].t).toBe(1000);
+    expect(bundle.hierarchy[1].t).toBe(2000);
+    expect(fs.existsSync(bundle.hierarchy[0].path)).toBe(true);
+
+    // assertions / edits.
+    expect(bundle.assertions).toEqual([]);
+    expect(bundle.edits).toEqual([]);
+
+    // screenshots: array of paths (none present beyond .gitkeep is filtered).
+    expect(Array.isArray(bundle.screenshots)).toBe(true);
+  });
+
+  test('parses assertions, edits, and screenshots when present', () => {
+    ({ projectRoot, bundleRoot } = seedBundle(FIXTURE_ASSERTIONS, 'login_flow'));
+
+    const bundle = readBundle(projectRoot, 'login_flow');
+
+    expect(bundle.assertions).toHaveLength(2);
+    expect(bundle.assertions[0]).toMatchObject({ id: 'a1', anchor_step_id: 'tap_login' });
+
+    // screenshots are real .png files in the fixture.
+    const names = bundle.screenshots.map((p) => path.basename(p)).sort();
+    expect(names).toEqual(['assert_a1.png', 'assert_a2.png', 'step_1.png']);
+    for (const p of bundle.screenshots) expect(fs.existsSync(p)).toBe(true);
+  });
+
+  test('throws a clear error when the bundle is missing', () => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-reader-missing-'));
+    expect(() => readBundle(projectRoot, 'does_not_exist')).toThrow(/no recording bundle/i);
+  });
+});
+
+describe('bundle-reader.consume', () => {
+  test('deletes the bundle directory', () => {
+    const { projectRoot } = seedBundle(FIXTURE_PLAIN, 'login_flow');
+    const bundleRoot = path.join(projectRoot, 'mobile-automator', '.recorder', 'login_flow');
+    expect(fs.existsSync(bundleRoot)).toBe(true);
+
+    consume(projectRoot, 'login_flow');
+
+    expect(fs.existsSync(bundleRoot)).toBe(false);
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  test('is safe when the bundle does not exist', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bundle-reader-consume-'));
+    expect(() => consume(projectRoot, 'nope')).not.toThrow();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+});

--- a/tests/unit/recorder/recorder-device-io.smoke.test.js
+++ b/tests/unit/recorder/recorder-device-io.smoke.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Smoke test only — must NOT spawn mobile-mcp.
+//
+// Slice 8 wiring: the recorder's mobile-mcp `call` is now backed by the
+// CLI-owned connection (src/device/mobile-mcp-client.createCall) instead of the
+// in-process stub. The factory stays INJECTABLE so existing recorder tests keep
+// injecting fakes. This test only asserts the module shape and that injection
+// works — it never connects to a device.
+
+const { createRecorderCall } = require('../../../tools/recorder/src/capture/recorder-device-io');
+
+describe('recorder-device-io (smoke)', () => {
+  test('exports createRecorderCall', () => {
+    expect(typeof createRecorderCall).toBe('function');
+  });
+
+  test('returns a { call, close } shape from an injected factory (no spawn)', async () => {
+    const fakeCalls = [];
+    const fakeFactory = async ({ device } = {}) => ({
+      call: async (tool, args) => {
+        fakeCalls.push({ tool, args, device });
+        return { ok: true };
+      },
+      close: async () => {},
+    });
+
+    const { call, close } = await createRecorderCall({ device: 'emu-5554', createCall: fakeFactory });
+    expect(typeof call).toBe('function');
+    expect(typeof close).toBe('function');
+
+    const r = await call('mobile_list_elements_on_screen', {});
+    expect(r).toEqual({ ok: true });
+    expect(fakeCalls[0]).toMatchObject({ tool: 'mobile_list_elements_on_screen', device: 'emu-5554' });
+
+    await close();
+  });
+
+  test('defaults to the real createCall factory without invoking it', () => {
+    // We can't call the default factory here (it would spawn mobile-mcp), but
+    // we can confirm the module wires the real one in by default by checking it
+    // does not throw at require-time and the default is a function reference.
+    const mod = require('../../../tools/recorder/src/capture/recorder-device-io');
+    expect(typeof mod.createRecorderCall).toBe('function');
+  });
+});

--- a/tests/unit/recorder/tap-source.smoke.test.js
+++ b/tests/unit/recorder/tap-source.smoke.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Smoke test only — DO NOT require a real device.
+//
+// Slice 8 (best-effort): the live tap source plugs mobile-mcp screen recording
+// into capture/video-tap-detector and emits {t, kind, x, y} events shaped
+// exactly like mode-b's `deps.tapSource` expects. This test exercises the
+// emitter interface and the frame→tap path with SYNTHETIC frames and a FAKE
+// bridge — the real on-device path (screen-record start/stop + ffmpeg frame
+// extraction) is the known PRD build risk and needs on-device validation.
+
+const fs = require('fs');
+const path = require('path');
+
+const { createTapSource } = require('../../../tools/recorder/src/capture/tap-source');
+
+const FRAMES_DIR = path.resolve(
+  __dirname, '..', '..', 'fixtures', 'recorder', 'video-frames'
+);
+
+describe('tap-source (smoke)', () => {
+  test('exposes the emitter interface (.on / start / stop)', () => {
+    const src = createTapSource({ bridge: {} });
+    expect(typeof src.on).toBe('function');
+    expect(typeof src.start).toBe('function');
+    expect(typeof src.stop).toBe('function');
+  });
+
+  test('emits a down→up tap sequence from synthetic frames via the detector', () => {
+    // A frame with the indicator dot, then one without → down then up.
+    const withDot = fs.readFileSync(path.join(FRAMES_DIR, 'dot-at-50-30.png'));
+    const noDot = fs.readFileSync(path.join(FRAMES_DIR, 'no-indicator.png'));
+
+    const src = createTapSource({ bridge: {}, color: 'light_blue' });
+    const taps = [];
+    src.on('tap', (ev) => taps.push(ev));
+
+    // Drive the detector directly with synthetic frames (no device, no ffmpeg).
+    src._processFrames([
+      { t: 0, buf: withDot },
+      { t: 33, buf: noDot },
+    ]);
+
+    const kinds = taps.map((t) => t.kind);
+    expect(kinds).toContain('down');
+    expect(kinds).toContain('up');
+    for (const ev of taps) {
+      expect(typeof ev.t).toBe('number');
+      expect(typeof ev.x).toBe('number');
+      expect(typeof ev.y).toBe('number');
+    }
+  });
+});

--- a/tools/recorder/src/capture/recorder-device-io.js
+++ b/tools/recorder/src/capture/recorder-device-io.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// Slice 8: bridge the recorder's mobile-mcp device I/O onto the CLI-owned
+// connection. Previously the live Mode-B lifecycle defaulted `call` to an
+// in-process stub (`async () => ({ elements: [] })`); this factory wires it to
+// the real CLI client (src/device/mobile-mcp-client.createCall) so a standalone
+// `mauto record` run drives a real device through the same connection the rest
+// of the CLI uses.
+//
+// The `createCall` dependency is INJECTABLE: tests pass a fake factory so they
+// never spawn mobile-mcp, while the live path defaults to the real one. The
+// real factory is required LAZILY so loading this module (and the recorder)
+// does not pull in the MCP SDK until a live device session actually starts.
+
+const path = require('path');
+
+// Default factory: the CLI-owned mobile-mcp client at the repo root. Resolved
+// from this file's location (tools/recorder/src/capture → repo root/src/device).
+function defaultCreateCall(args) {
+  // Lazy require so the MCP SDK only loads for a live session.
+  // eslint-disable-next-line global-require
+  const { createCall } = require(path.resolve(__dirname, '..', '..', '..', '..', 'src', 'device', 'mobile-mcp-client'));
+  return createCall(args);
+}
+
+/**
+ * Build the recorder's mobile-mcp call surface.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.device]      device id to pin (passed through to the client)
+ * @param {function} [opts.createCall] injectable factory ({device}) => Promise<{call, close}>
+ * @returns {Promise<{call: function, close: function}>}
+ */
+async function createRecorderCall({ device, createCall = defaultCreateCall } = {}) {
+  const conn = await createCall({ device });
+  return {
+    call: conn.call,
+    close: typeof conn.close === 'function' ? conn.close : async () => {},
+  };
+}
+
+module.exports = { createRecorderCall };

--- a/tools/recorder/src/capture/tap-source.js
+++ b/tools/recorder/src/capture/tap-source.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// Live tap source for the Mode-B pipeline (slice 8, BEST-EFFORT).
+//
+// Mode-B's coalescing pipeline consumes a `tapSource` that fires `tap` events
+// shaped `{ t, kind:'down'|'up'|'move', x, y }` (see lifecycle/mode-b.js). Until
+// now that source was a TODO and only tests injected it. This module provides
+// the real source: it drives mobile-mcp screen recording, extracts frames, runs
+// them through `video-tap-detector` (which emits exactly that event shape from
+// the OS touch indicator), and forwards each detected event to `tap` listeners.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// ⚠️  ON-DEVICE VALIDATION REQUIRED. This is the known PRD build risk (#69/#77).
+// The frame→tap DETECTION path is unit-verifiable with synthetic frames (see
+// tap-source.smoke.test.js) and is exercised here. But the END-TO-END live path
+// — mobile-mcp `mobile_start_screen_recording` / `mobile_stop_screen_recording`
+// semantics, the produced video container/codec, ffmpeg frame extraction timing,
+// and the "Show taps" / iOS touch-indicator being enabled on the target — CANNOT
+// be verified in CI and needs validation on a real device/emulator before this
+// path can be trusted. The detector colour calibration also assumes the OS touch
+// indicator overlay is on.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const { EventEmitter } = require('events');
+
+const { VideoTapDetector } = require('./video-tap-detector');
+
+/**
+ * @param {object} opts
+ * @param {object} opts.bridge  McpBridge-like with startScreenRecording()/stopScreenRecording()
+ * @param {string} [opts.color] detector colour profile ('light_blue' | 'ios_simulator')
+ * @param {number} [opts.fps]   frame-extraction rate
+ * @param {string} [opts.workDir] scratch dir for extracted frames
+ * @returns {EventEmitter & {start, stop, _processFrames}}
+ */
+function createTapSource({ bridge, color = 'light_blue', fps = 30, workDir } = {}) {
+  const emitter = new EventEmitter();
+  const detector = new VideoTapDetector({
+    color,
+    fps,
+    // The detector calls this for every down/move/up it finds; re-emit as `tap`.
+    emit: (ev) => emitter.emit('tap', ev),
+  });
+
+  let recording = false;
+
+  // Pure detection seam — feed already-extracted frames straight through the
+  // detector. Used by the smoke test (synthetic frames, no device, no ffmpeg).
+  emitter._processFrames = (frames) => detector.processFrames(frames);
+
+  // Live path (NOT CI-verifiable — see the on-device caveat above).
+  emitter.start = async () => {
+    if (recording) return;
+    if (!bridge || typeof bridge.startScreenRecording !== 'function') {
+      throw new Error('tap-source requires a bridge with startScreenRecording()');
+    }
+    recording = true;
+    await bridge.startScreenRecording();
+  };
+
+  emitter.stop = async () => {
+    if (!recording) return;
+    recording = false;
+    const videoPath = await bridge.stopScreenRecording();
+    if (!videoPath) return;
+    // Extract frames to a scratch dir and run them through the detector. ffmpeg
+    // availability + the recording's container/codec are device-dependent.
+    const outDir = workDir || fs.mkdtempSync(path.join(os.tmpdir(), 'tap-frames-'));
+    const frames = await detector.extractFrames(videoPath, outDir);
+    detector.processFrames(frames);
+  };
+
+  return emitter;
+}
+
+module.exports = { createTapSource };

--- a/tools/recorder/src/lifecycle/live.js
+++ b/tools/recorder/src/lifecycle/live.js
@@ -58,6 +58,13 @@ async function startLiveCapture({
   // emit mode without an extra round-trip.
   wsCtx.broadcast({ type: 'mode', mode: emitMode });
 
+  // Slice 8: the live path drives a real device by default. Tests that inject a
+  // fake startModeB/startC3 never reach the device wiring; tests that exercise
+  // the real handler can still opt out by setting deps.useLiveDevice === false.
+  const handlerDeps = deps.useLiveDevice === undefined
+    ? { ...deps, useLiveDevice: true }
+    : deps;
+
   const handlerArgs = {
     store,
     wsCtx,
@@ -67,7 +74,7 @@ async function startLiveCapture({
     platform,
     appPackage,
     opts,
-    deps,
+    deps: handlerDeps,
   };
 
   let exitCode;

--- a/tools/recorder/src/lifecycle/mode-b.js
+++ b/tools/recorder/src/lifecycle/mode-b.js
@@ -43,13 +43,14 @@ function snakeCase(s) {
  * resolves with the exit code (0 on Save, 130 on Cancel or browser timeout,
  * 2 on device disconnect, etc.).
  *
- * NOTE — live tap source is a TODO. The first "live" run won't actually
- * capture taps until the tap source is implemented properly: mobile-mcp's
- * frame-streaming surface is the natural source (combined with the existing
- * `capture/video-tap-detector.js` module) but the deep integration is out of
- * scope for this slice. Tests inject taps via `deps.tapSource` (an emitter
- * that fires `{t, kind:'down'|'up'|'move', x, y}` events) so the rest of the
- * pipeline can be exercised end-to-end.
+ * Slice 8 — the live tap source is now wired by default in the live path
+ * (`deps.useLiveDevice`): `capture/tap-source.js` drives mobile-mcp screen
+ * recording through `capture/video-tap-detector.js` and emits
+ * `{t, kind:'down'|'up'|'move', x, y}` taps. That end-to-end live path is
+ * BEST-EFFORT and needs on-device validation (the known PRD build risk — see
+ * tap-source.js). Tests still inject `deps.tapSource` to drive the pipeline
+ * deterministically without a device; a missing tap source in non-live mode is
+ * fine — it just means no live taps are captured.
  *
  * `deps` is the seam for tests:
  *   • mcpBridge — pre-constructed bridge (skip the default ctor)
@@ -75,9 +76,24 @@ async function startModeB({
   const emitMode = cfg.mode;
 
   // ---- Bridge + poller -----------------------------------------------------
+  //
+  // Slice 8: the live device `call` is backed by the CLI-owned mobile-mcp
+  // connection (capture/recorder-device-io → src/device/mobile-mcp-client).
+  // Tests keep injecting fakes via `deps.mcpBridge` or `deps.mcpCall`, which
+  // short-circuit the live wiring so nothing spawns. When neither is provided
+  // and a `deps.deviceLabel` is available, the live path opens a real
+  // connection (kept injectable through `deps.createRecorderCall`).
+  let deviceConn = null;
+  let mcpCall = deps.mcpCall;
+  if (!deps.mcpBridge && !mcpCall && deps.useLiveDevice) {
+    const { createRecorderCall } = require('../capture/recorder-device-io');
+    const _createRecorderCall = deps.createRecorderCall || createRecorderCall;
+    deviceConn = await _createRecorderCall({ device: deps.deviceLabel });
+    mcpCall = deviceConn.call;
+  }
 
   const mcpBridge = deps.mcpBridge || new McpBridge({
-    call: deps.mcpCall || (async () => ({ elements: [] })),
+    call: mcpCall || (async () => ({ elements: [] })),
   });
 
   const pollIntervalMs = deps.pollIntervalMs || DEFAULT_POLL_INTERVAL_MS;
@@ -130,13 +146,21 @@ async function startModeB({
     },
   });
 
-  // ---- Live tap source (TODO) ---------------------------------------------
-  // See the file-level doc comment: the real tap source plugs into mobile-mcp
-  // frame streaming + capture/video-tap-detector. For now we honour the
-  // injected `deps.tapSource` so tests can drive the pipeline, but a missing
-  // tapSource is fine — it just means no live taps are captured this slice.
-  if (deps.tapSource && typeof deps.tapSource.on === 'function') {
-    deps.tapSource.on('tap', (ev) => {
+  // ---- Live tap source -----------------------------------------------------
+  // Tests inject `deps.tapSource` to drive the pipeline. The live path (slice 8)
+  // defaults to capture/tap-source, which plugs mobile-mcp screen recording into
+  // video-tap-detector to produce {t, kind, x, y} taps. This end-to-end live
+  // path is BEST-EFFORT and needs on-device validation (see tap-source.js).
+  let tapSource = deps.tapSource;
+  let ownsTapSource = false;
+  if (!tapSource && deps.useLiveDevice) {
+    const { createTapSource } = require('../capture/tap-source');
+    const _createTapSource = deps.createTapSource || createTapSource;
+    tapSource = _createTapSource({ bridge: mcpBridge });
+    ownsTapSource = true;
+  }
+  if (tapSource && typeof tapSource.on === 'function') {
+    tapSource.on('tap', (ev) => {
       try { classifier.feed(ev); } catch (_e) { /* swallow */ }
     });
   }
@@ -155,6 +179,15 @@ async function startModeB({
     // Tear down failure-orchestrator watchdogs (crash + browser timers).
     if (failureCtx && typeof failureCtx.stopAll === 'function') {
       try { failureCtx.stopAll(); } catch (_e) { /* swallow */ }
+    }
+    // Stop a tap source we own (the live one). Best-effort + async; we don't
+    // await it here since finish() is sync, but errors must not leak.
+    if (ownsTapSource && tapSource && typeof tapSource.stop === 'function') {
+      try { Promise.resolve(tapSource.stop()).catch(() => {}); } catch (_e) { /* swallow */ }
+    }
+    // Close the live device connection (no-op when tests injected a fake).
+    if (deviceConn && typeof deviceConn.close === 'function') {
+      try { deviceConn.close(); } catch (_e) { /* swallow */ }
     }
     resolveExit(code);
   }
@@ -224,9 +257,14 @@ async function startModeB({
     }
   });
 
-  // ---- Start the poller and yield -----------------------------------------
+  // ---- Start the poller (and live tap source) and yield -------------------
 
   try { hierarchyPoller.start(); } catch (_e) { /* swallow */ }
+  // Start a tap source we own. Best-effort: a device/recording failure here is
+  // swallowed so the rest of the session (hierarchy, assertions) still runs.
+  if (ownsTapSource && tapSource && typeof tapSource.start === 'function') {
+    try { Promise.resolve(tapSource.start()).catch(() => {}); } catch (_e) { /* swallow */ }
+  }
 
   return exitPromise;
 }


### PR DESCRIPTION
Stacked on #86 (slice 7). Makes recording a standalone, agent-free step and decouples synthesis.

## What
- **Persist on save** — the artifact bundle now survives a successful Save (cancel still deletes). End-to-end test updated to assert persist-on-save + delete-on-cancel. (The success path already persisted in production; the only "delete on save" was in a test mock.)
- **`mauto record-bundle <id> [--consume]`** — `bundle-reader` parses metadata/events/hierarchy/assertions/edits/screenshots; `--consume` does post-synthesis cleanup; missing bundle → `invalid_input` exit 3. Fully tested against the fixture bundle.
- **Device I/O wired** to the CLI-owned mobile-mcp (`createCall`), kept injectable so existing fakes still drive tests; live only on the real entry path.
- **Live tap source** (mobile-mcp screen recording → `video-tap-detector`) implemented best-effort. Frame→tap detection unit-verified with synthetic frames.

## ⚠️ Known on-device risk
The end-to-end live tap path is **not CI-verifiable** and needs validation on a real device/emulator (mobile-mcp screen-recording codec, ffmpeg frame timing, OS touch-indicator calibration). Flagged in code + this is the PRD's called-out build risk.

## Test plan
- `npm test`: **107 suites / 824 tests green** (+14, no regressions)
- Manual: `record-bundle <id>` prints the parsed bundle; `--consume` deletes it; missing → exit 3

Closes #77 · Refs #69