### PR TITLE
cli follow-up — add `mauto record <name>` launch command (PR-review gap)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -399,6 +399,60 @@ function handleRecordBundle({ projectRoot, reader = bundleReader }, scenarioId, 
   return { envelope: ok({ ...bundle, consumed }), exitKind: 'ok' };
 }
 
+// --- Slice 10: launch the web recorder ------------------------------------
+//
+// `mauto record <name>` launches the recorder sidecar (the live web GUI) so a
+// human can record a scenario. The sidecar is long-lived: the handler simply
+// awaits it and maps its numeric exit code onto the envelope contract.
+//
+// `startLiveCapture` is injected. It defaults to the REAL recorder, lazily
+// required so tests (which inject a fake) never load or launch the sidecar.
+async function handleRecord({
+  scenarioId,
+  opts = {},
+  projectRoot,
+  startLiveCapture = require('../tools/recorder/src/lifecycle/live').startLiveCapture,
+}) {
+  const mode = opts.mode
+    ? MODE_ALIASES[opts.mode]
+    : configManager.resolveMode(configManager.load(projectRoot));
+
+  const code = await startLiveCapture({
+    projectRoot,
+    scenarioId,
+    platform: opts.platform || 'android',
+    mode,
+    opts: {
+      noGui: opts.gui === false,
+      preconditionsModal: !!opts.preconditionsModal,
+      allowSensitiveInput: !!opts.allowSensitiveInput,
+      verify: !!opts.verify,
+      overwrite: !!opts.overwrite,
+    },
+  });
+
+  if (code === 0) {
+    return {
+      envelope: ok({
+        scenario_id: scenarioId,
+        recorded: true,
+        next: `mauto record-bundle ${scenarioId} then follow mauto guide record to synthesize`,
+      }),
+      exitKind: 'ok',
+    };
+  }
+  if (code === 130) {
+    return { envelope: fail('cancel', 'recording cancelled', null), exitKind: 'cancel' };
+  }
+  if (code === 2) {
+    return {
+      envelope: fail('device', 'device disconnected during recording', 'reconnect the device and rerun mauto record'),
+      exitKind: 'device',
+    };
+  }
+  return { envelope: fail('internal', `recorder exited with code ${code}`, null), exitKind: 'internal' };
+}
+
 // ---------------------------------------------------------------------------
 // Program wiring
 // ---------------------------------------------------------------------------
@@ -635,6 +689,21 @@ function buildProgram(deps = {}) {
     });
 
   program
+    .command('record <name>')
+    .description('Launch the web recorder to capture a scenario interactively')
+    .option('--platform <platform>', 'android | ios', 'android')
+    .option('--mode <mode>', 'aware | agnostic (override the workspace config mode)')
+    .option('--overwrite', 'overwrite an existing scenario', false)
+    .option('--verify', 'replay the scenario via execute after Save', false)
+    .option('--allow-sensitive-input', 'opt out of sensitive-input warnings', false)
+    .option('--no-gui', 'run without launching the browser GUI')
+    .option('--preconditions-modal', 'show the preconditions modal before recording', false)
+    .action(async (name, opts) => {
+      const r = await handleRecord({ scenarioId: name, opts, projectRoot });
+      emit(r, humanFlag());
+    });
+
+  program
     .command('record-bundle <id>')
     .description('Read the persisted recorder artifact bundle for a scenario (for offline synthesis)')
     .option('--consume', 'delete the bundle after a successful read', false)
@@ -694,4 +763,5 @@ module.exports = {
   handleBootstrap,
   handleInit,
   handleRecordBundle,
+  handleRecord,
 };

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -23,6 +23,7 @@ const {
   handleBootstrap,
   handleInit,
   handleRecordBundle,
+  handleRecord,
 } = require('../../src/cli');
 const Ajv = require('ajv');
 
@@ -471,6 +472,166 @@ describe('cli handlers', () => {
       expect(envelope.error.kind).toBe('invalid_input');
       expect(envelope.error.message).toContain('no recording bundle for nope');
       expect(envelope.hint).toContain('mauto record');
+    });
+  });
+
+  describe('handleRecord (launch the web recorder)', () => {
+    // A fake startLiveCapture that records its call args and returns a fixed
+    // exit code. It proves the REAL recorder is never launched: if a test ever
+    // reached the real sidecar it would try to bring up the HTTP/WS server.
+    function fakeCapture(code) {
+      const calls = [];
+      const fn = async (args) => {
+        calls.push(args);
+        return code;
+      };
+      fn.calls = calls;
+      return fn;
+    }
+
+    function writeConfig(projectRoot, cfg) {
+      const dir = path.join(projectRoot, 'mobile-automator');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(cfg));
+    }
+
+    test('exit 0 -> ok envelope with scenario_id + recorded:true; forwards resolved args', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-record-'));
+      writeConfig(projectRoot, { mode: 'platform-agnostic' });
+      const startLiveCapture = fakeCapture(0);
+
+      const { envelope, exitKind } = await handleRecord({
+        scenarioId: 'login_flow',
+        opts: {
+          platform: 'ios',
+          verify: true,
+          overwrite: true,
+          allowSensitiveInput: true,
+          gui: false,
+          preconditionsModal: true,
+        },
+        projectRoot,
+        startLiveCapture,
+      });
+
+      expect(exitKind).toBe('ok');
+      expect(envelope.ok).toBe(true);
+      expect(envelope.data.scenario_id).toBe('login_flow');
+      expect(envelope.data.recorded).toBe(true);
+      expect(envelope.data.next).toContain('mauto record-bundle login_flow');
+
+      // The real recorder was never launched — only the fake was called.
+      expect(startLiveCapture.calls).toHaveLength(1);
+      const call = startLiveCapture.calls[0];
+      expect(call.projectRoot).toBe(projectRoot);
+      expect(call.scenarioId).toBe('login_flow');
+      expect(call.platform).toBe('ios');
+      // Mode resolved from the config file.
+      expect(call.mode).toBe('platform-agnostic');
+      expect(call.opts).toEqual({
+        noGui: true,
+        preconditionsModal: true,
+        allowSensitiveInput: true,
+        verify: true,
+        overwrite: true,
+      });
+    });
+
+    test('platform defaults to android and flags default to false', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-record-'));
+      const startLiveCapture = fakeCapture(0);
+
+      await handleRecord({
+        scenarioId: 'cart',
+        opts: {},
+        projectRoot,
+        startLiveCapture,
+      });
+
+      const call = startLiveCapture.calls[0];
+      expect(call.platform).toBe('android');
+      // No config -> platform-aware default.
+      expect(call.mode).toBe('platform-aware');
+      expect(call.opts).toEqual({
+        noGui: false,
+        preconditionsModal: false,
+        allowSensitiveInput: false,
+        verify: false,
+        overwrite: false,
+      });
+    });
+
+    test('--mode agnostic overrides config', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-record-'));
+      writeConfig(projectRoot, { mode: 'platform-aware' });
+      const startLiveCapture = fakeCapture(0);
+
+      await handleRecord({
+        scenarioId: 'flow',
+        opts: { mode: 'agnostic' },
+        projectRoot,
+        startLiveCapture,
+      });
+
+      expect(startLiveCapture.calls[0].mode).toBe('platform-agnostic');
+    });
+
+    test('--mode aware maps to platform-aware', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-record-'));
+      writeConfig(projectRoot, { mode: 'platform-agnostic' });
+      const startLiveCapture = fakeCapture(0);
+
+      await handleRecord({
+        scenarioId: 'flow',
+        opts: { mode: 'aware' },
+        projectRoot,
+        startLiveCapture,
+      });
+
+      expect(startLiveCapture.calls[0].mode).toBe('platform-aware');
+    });
+
+    test('exit 130 -> cancel envelope', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-record-'));
+      const { envelope, exitKind } = await handleRecord({
+        scenarioId: 'flow',
+        opts: {},
+        projectRoot,
+        startLiveCapture: fakeCapture(130),
+      });
+      expect(exitKind).toBe('cancel');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('cancel');
+      expect(envelope.error.message).toContain('cancelled');
+    });
+
+    test('exit 2 -> device envelope with reconnect hint', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-record-'));
+      const { envelope, exitKind } = await handleRecord({
+        scenarioId: 'flow',
+        opts: {},
+        projectRoot,
+        startLiveCapture: fakeCapture(2),
+      });
+      expect(exitKind).toBe('device');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('device');
+      expect(envelope.error.message).toContain('disconnected');
+      expect(envelope.hint).toContain('reconnect');
+    });
+
+    test('other non-zero exit -> internal envelope', async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-record-'));
+      const { envelope, exitKind } = await handleRecord({
+        scenarioId: 'flow',
+        opts: {},
+        projectRoot,
+        startLiveCapture: fakeCapture(7),
+      });
+      expect(exitKind).toBe('internal');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('internal');
+      expect(envelope.error.message).toContain('code 7');
     });
   });
 });


### PR DESCRIPTION
Stacked on #88. Fixes the gap a PR review identified: `mauto record` (launch the web recorder) was referenced in the PRD (User Story 13) and a CLI hint but never registered — only `record-bundle` (the reader) existed.

## What
- Registered `mauto record <name>` with `--platform/--mode/--overwrite/--verify/--allow-sensitive-input/--no-gui/--preconditions-modal`
- `handleRecord` resolves mode from config (or `--mode`), awaits the recorder sidecar's `startLiveCapture(...)`, and maps exit codes → envelope (0 = ok with `record-bundle` next-step hint, 130 = cancel, 2 = device, else internal)
- `startLiveCapture` is injectable and **never launched in tests**; the line-387 hint now references a real command

## Test plan
- `npm test`: **83 suites / 690 tests green** (+7, no regressions)
- `mauto record --help` shows the command; `mauto --help` lists it
- Real GUI/browser launch path is smoke-only (no device/GUI in CI)

Refs #69