### PR TITLE
chore(test): scope jest discovery to repo tests, excluding nested worktrees

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,11 @@
 module.exports = {
   testEnvironment: 'node',
-  testMatch: ['**/tests/**/*.test.js'],
+  // Scope discovery to THIS repo's tests. The repo hosts nested git worktrees
+  // under .claude/worktrees/ (Claude Code convention) plus a node_modules
+  // symlink into a sibling worktree; without anchoring, jest's glob recurses
+  // into those checkouts and runs stale copies of tests from merged branches.
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.js'],
+  testPathIgnorePatterns: ['/node_modules/', '/\\.claude/', '/\\.worktrees/'],
   verbose: true,
 };


### PR DESCRIPTION
## What

Anchor jest test discovery to this repo's own `tests/` directory so it no longer recurses into the nested git worktrees under `.claude/worktrees/`.

- `roots: ['<rootDir>/tests']`
- `testMatch: ['**/*.test.js']` (now relative to `roots`)
- `testPathIgnorePatterns: ['/node_modules/', '/\\.claude/', '/\\.worktrees/']`

## Why

`testMatch: ['**/tests/**/*.test.js']` is an unanchored glob. The repo hosts nested git worktrees under `.claude/worktrees/` (Claude Code convention) plus a `node_modules` symlink into a sibling worktree, so the glob recursed into those checkouts and ran **stale test copies from already-merged branches** — including tests validating the now-deleted `templates/` tree.

Two problems with that:
1. The run was bloated to **396 suites / 2833 tests** (most of it duplicate/stale).
2. Stale copies validating deleted files could silently mask a real regression in the live code.

## Test plan

| | Before | After |
|---|---|---|
| Suites | 396 | **83** |
| Tests | 2833 | **690**, all passing |
| Stale paths discovered | many | **0** |
| Run time | 5.4s | 1.5s |

- `npx jest` -> 83 suites / 690 tests, all green; `jest --listTests` shows no `.claude/worktrees`, `.worktrees`, `node_modules`, or `templates/` paths.
- `npm run lint:guides` -> 21 pass; `npm run lint:schema-additive` -> 2 pass (explicit path args still resolve under `roots`).

Surfaced while validating the CLI migration PRD. Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)