### PR TITLE
fix(recorder): auto-open the GUI in the default browser (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Recorder GUI now auto-opens (no more silent hang)** ([#65](https://github.com/sh3lan93/mobile-automator/issues/65), Refs [#21](https://github.com/sh3lan93/mobile-automator/issues/21)). `mauto record <name>` previously started the HTTP+WebSocket sidecar and the mobile-mcp device connection but never opened the browser GUI nor printed its URL, so the terminal hung on `mobile-mcp server running on stdio` waiting for a WebSocket message that could never arrive. `startLiveCapture` now prints `🌐 Recorder GUI: http://127.0.0.1:<port>/` to **stderr** (stdout stays reserved for the JSON envelope) and auto-launches the host's default browser (`open`/`xdg-open`/`start`) immediately after the HTTP server binds. The URL is always printed as a fallback when auto-open fails silently; `--no-gui` skips the launch for CI/headless runs. New `tools/recorder/src/server/browser-opener.js` helper, dependency-injected for tests.
+
 ## [0.16.0]
 
 ### ✨ Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {

--- a/tests/unit/recorder/browser-opener.test.js
+++ b/tests/unit/recorder/browser-opener.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { openInBrowser } = require('../../../tools/recorder/src/server/browser-opener');
+
+function makeFakeProc() {
+  return { unref: jest.fn() };
+}
+
+describe('openInBrowser (server/browser-opener)', () => {
+  const url = 'http://127.0.0.1:54321/';
+
+  test('darwin spawns `open` with [url] and unrefs', () => {
+    const proc = makeFakeProc();
+    const spawn = jest.fn().mockReturnValue(proc);
+    const warn = jest.fn();
+    openInBrowser({ url, platform: 'darwin', spawn, warn });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith('open', [url], expect.objectContaining({ detached: true, stdio: 'ignore' }));
+    expect(proc.unref).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('linux spawns `xdg-open` with [url]', () => {
+    const proc = makeFakeProc();
+    const spawn = jest.fn().mockReturnValue(proc);
+    const warn = jest.fn();
+    openInBrowser({ url, platform: 'linux', spawn, warn });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith('xdg-open', [url], expect.objectContaining({ detached: true, stdio: 'ignore' }));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('win32 spawns `cmd` with [/c, start, "", url]', () => {
+    const proc = makeFakeProc();
+    const spawn = jest.fn().mockReturnValue(proc);
+    const warn = jest.fn();
+    openInBrowser({ url, platform: 'win32', spawn, warn });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith('cmd', ['/c', 'start', '', url], expect.objectContaining({ detached: true, stdio: 'ignore' }));
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('unsupported platform does not spawn and warns', () => {
+    const spawn = jest.fn();
+    const warn = jest.fn();
+    openInBrowser({ url, platform: 'sunos', spawn, warn });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('sunos');
+  });
+
+  test('noGui: true does not spawn', () => {
+    const spawn = jest.fn();
+    const warn = jest.fn();
+    openInBrowser({ url, platform: 'darwin', noGui: true, spawn, warn });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('falsy url does not spawn', () => {
+    const spawn = jest.fn();
+    const warn = jest.fn();
+    openInBrowser({ url: '', platform: 'darwin', spawn, warn });
+    expect(spawn).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('spawn throwing synchronously is swallowed and warns', () => {
+    const spawn = jest.fn(() => { throw new Error('ENOENT'); });
+    const warn = jest.fn();
+    expect(() => openInBrowser({ url, platform: 'darwin', spawn, warn })).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('ENOENT');
+  });
+});

--- a/tests/unit/recorder/lifecycle-live.test.js
+++ b/tests/unit/recorder/lifecycle-live.test.js
@@ -30,8 +30,8 @@ function makeFakeWsCtx() {
   };
 }
 
-function makeFakeHttpSrv() {
-  return { port: 0, server: {}, close: jest.fn().mockResolvedValue(undefined) };
+function makeFakeHttpSrv(port = 0) {
+  return { port, server: {}, close: jest.fn().mockResolvedValue(undefined) };
 }
 
 describe('startLiveCapture (lifecycle/live)', () => {
@@ -53,6 +53,7 @@ describe('startLiveCapture (lifecycle/live)', () => {
         attachWsServer: jest.fn().mockReturnValue(wsCtx),
         startC3: jest.fn().mockResolvedValue(0),
         startModeB: jest.fn().mockResolvedValue(0),
+        openInBrowser: jest.fn(),
       },
     });
 
@@ -79,6 +80,7 @@ describe('startLiveCapture (lifecycle/live)', () => {
         attachWsServer: attachWs,
         startC3: jest.fn().mockResolvedValue(0),
         startModeB: jest.fn().mockResolvedValue(0),
+        openInBrowser: jest.fn(),
       },
     });
     expect(startHttp).toHaveBeenCalledWith(expect.objectContaining({
@@ -107,6 +109,7 @@ describe('startLiveCapture (lifecycle/live)', () => {
         attachWsServer: jest.fn().mockReturnValue(wsCtx),
         startC3,
         startModeB,
+        openInBrowser: jest.fn(),
       },
     });
 
@@ -140,6 +143,7 @@ describe('startLiveCapture (lifecycle/live)', () => {
         attachWsServer: jest.fn().mockReturnValue(wsCtx),
         startC3,
         startModeB,
+        openInBrowser: jest.fn(),
       },
     });
 
@@ -161,9 +165,93 @@ describe('startLiveCapture (lifecycle/live)', () => {
         attachWsServer: jest.fn().mockReturnValue(wsCtx),
         startC3: jest.fn().mockResolvedValue(0),
         startModeB: jest.fn().mockResolvedValue(0),
+        openInBrowser: jest.fn(),
       },
     });
     expect(wsCtx._broadcasts).toContainEqual({ type: 'mode', mode: 'platform-aware' });
+  });
+
+  test('auto-opens browser after HTTP server starts (before mode handler)', async () => {
+    const wsCtx = makeFakeWsCtx();
+    const httpSrv = makeFakeHttpSrv(54321);
+    const openInBrowser = jest.fn();
+    const startModeB = jest.fn().mockImplementation(() => {
+      // Order proof: the browser must already be opened by the time the mode
+      // handler runs.
+      expect(openInBrowser).toHaveBeenCalledTimes(1);
+      return Promise.resolve(0);
+    });
+
+    await startLiveCapture({
+      projectRoot,
+      scenarioId: 'scn',
+      platform: 'android',
+      mode: 'b',
+      opts: { noGui: false },
+      deps: {
+        startHttpServer: jest.fn().mockResolvedValue(httpSrv),
+        attachWsServer: jest.fn().mockReturnValue(wsCtx),
+        startC3: jest.fn().mockResolvedValue(0),
+        startModeB,
+        openInBrowser,
+      },
+    });
+
+    expect(openInBrowser).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'http://127.0.0.1:54321/',
+      noGui: false,
+    }));
+  });
+
+  test('passes noGui:true through to the browser opener', async () => {
+    const wsCtx = makeFakeWsCtx();
+    const httpSrv = makeFakeHttpSrv(54321);
+    const openInBrowser = jest.fn();
+
+    await startLiveCapture({
+      projectRoot,
+      scenarioId: 'scn',
+      platform: 'android',
+      mode: 'b',
+      opts: { noGui: true },
+      deps: {
+        startHttpServer: jest.fn().mockResolvedValue(httpSrv),
+        attachWsServer: jest.fn().mockReturnValue(wsCtx),
+        startC3: jest.fn().mockResolvedValue(0),
+        startModeB: jest.fn().mockResolvedValue(0),
+        openInBrowser,
+      },
+    });
+
+    expect(openInBrowser).toHaveBeenCalledWith(expect.objectContaining({ noGui: true }));
+  });
+
+  test('always prints the GUI URL to stderr', async () => {
+    const wsCtx = makeFakeWsCtx();
+    const httpSrv = makeFakeHttpSrv(54321);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await startLiveCapture({
+        projectRoot,
+        scenarioId: 'scn',
+        platform: 'android',
+        mode: 'b',
+        opts: {},
+        deps: {
+          startHttpServer: jest.fn().mockResolvedValue(httpSrv),
+          attachWsServer: jest.fn().mockReturnValue(wsCtx),
+          startC3: jest.fn().mockResolvedValue(0),
+          startModeB: jest.fn().mockResolvedValue(0),
+          openInBrowser: jest.fn(),
+        },
+      });
+
+      const printed = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(printed).toContain('http://127.0.0.1:54321/');
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 
   test('closes WS + HTTP server on completion', async () => {
@@ -180,6 +268,7 @@ describe('startLiveCapture (lifecycle/live)', () => {
         attachWsServer: jest.fn().mockReturnValue(wsCtx),
         startC3: jest.fn().mockResolvedValue(0),
         startModeB: jest.fn().mockResolvedValue(0),
+        openInBrowser: jest.fn(),
       },
     });
     expect(wsCtx.close).toHaveBeenCalled();

--- a/tools/recorder/src/lifecycle/live.js
+++ b/tools/recorder/src/lifecycle/live.js
@@ -3,6 +3,7 @@
 const { ArtifactsStore } = require('../artifacts');
 const { startHttpServer } = require('../server/http-server');
 const { attachWsServer } = require('../server/ws-protocol');
+const { openInBrowser } = require('../server/browser-opener');
 const { loadProjectConfig, resolveModeAndDefaults } = require('../config');
 
 /**
@@ -30,6 +31,7 @@ async function startLiveCapture({
   const _attachWs = deps.attachWsServer || attachWsServer;
   const _startC3 = deps.startC3 || require('./c3').startC3;
   const _startModeB = deps.startModeB || require('./mode-b').startModeB;
+  const _openBrowser = deps.openInBrowser || openInBrowser;
 
   // Project config drives aware-vs-agnostic emit downstream. Pre-#29 configs
   // are coerced to platform-aware by resolveModeAndDefaults.
@@ -53,6 +55,16 @@ async function startLiveCapture({
     allowSensitiveInput: !!opts.allowSensitiveInput,
   });
   const wsCtx = _attachWs({ httpServer: httpSrv.server });
+
+  // Print the recorder GUI URL and auto-launch the default browser (#65).
+  // The URL is written to STDERR (never stdout) so the verb's JSON envelope on
+  // stdout stays clean; it is logged unconditionally so the user always has a
+  // fallback if auto-open fails silently (unsupported platform, ENOENT) or if
+  // the tab is closed mid-recording. `--no-gui` (opts.noGui) skips the launch
+  // so CI / headless / test mode stays browser-free.
+  const guiUrl = `http://127.0.0.1:${httpSrv.port}/`;
+  console.error(`🌐 Recorder GUI: ${guiUrl}`);
+  _openBrowser({ url: guiUrl, noGui: !!opts.noGui });
 
   // Broadcast the initial mode message so any client that connects sees the
   // emit mode without an extra round-trip.

--- a/tools/recorder/src/server/browser-opener.js
+++ b/tools/recorder/src/server/browser-opener.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { spawn: defaultSpawn } = require('child_process');
+
+/**
+ * Open the given URL in the host OS's default browser.
+ *
+ * Best-effort: failures (unsupported platform, missing launcher binary, spawn
+ * throwing synchronously) are reported via the injected `warn` and swallowed
+ * so they cannot crash the recorder sidecar. The caller always prints the URL
+ * to stderr regardless, so a silent failure here is still recoverable.
+ *
+ * - `noGui: true` short-circuits without spawning (used by `--no-gui` so CI
+ *   and headless tests don't pop a browser).
+ * - `spawn` is injectable so the unit tests can drive each platform branch
+ *   without actually launching a browser. Mirrors the pattern in
+ *   `tools/recorder/src/capture/adb-getevent.js`.
+ *
+ * @param {object} args
+ * @param {string} args.url - URL to open. If falsy, no-ops silently.
+ * @param {string} [args.platform=process.platform] - OS branch selector.
+ * @param {boolean} [args.noGui=false] - When true, do not spawn anything.
+ * @param {Function} [args.spawn=child_process.spawn] - Spawn injector.
+ * @param {Function} [args.warn=console.warn] - Warning channel.
+ */
+function openInBrowser({
+  url,
+  platform = process.platform,
+  noGui = false,
+  spawn = defaultSpawn,
+  warn = console.warn,
+} = {}) {
+  if (noGui) return;
+  if (!url) return;
+
+  let cmd;
+  let args;
+  switch (platform) {
+    case 'darwin':
+      cmd = 'open';
+      args = [url];
+      break;
+    case 'linux':
+      cmd = 'xdg-open';
+      args = [url];
+      break;
+    case 'win32':
+      cmd = 'cmd';
+      args = ['/c', 'start', '', url];
+      break;
+    default:
+      warn(`[recorder] auto-open: unsupported platform ${platform}; open ${url} manually`);
+      return;
+  }
+
+  try {
+    const proc = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+    if (proc && typeof proc.unref === 'function') {
+      proc.unref();
+    }
+  } catch (err) {
+    warn(`[recorder] auto-open failed (${err && err.message ? err.message : err}); open ${url} manually`);
+  }
+}
+
+module.exports = { openInBrowser };


### PR DESCRIPTION
## What & why

`mauto record <name>` started the HTTP+WebSocket sidecar and the mobile-mcp device connection but **never opened the recorder GUI nor printed its URL**, so the terminal hung on `mobile-mcp server running on stdio` waiting for a WebSocket message that could never arrive. The GUI was served at a random `127.0.0.1:<port>` the user was never told about — `startModeB` then blocks on `exitPromise`, which only resolves on a Save/Cancel message from that unreachable GUI.

Every doc already claimed this behavior exists (README, CHANGELOG, the manual-test checklist all say "opens a browser GUI"), but the launch was never wired into the sidecar.

## What this does

`startLiveCapture`, immediately after the HTTP server binds:
- prints `🌐 Recorder GUI: http://127.0.0.1:<port>/` to **stderr** (stdout stays reserved for the JSON envelope) as an always-present fallback when auto-open fails silently or the tab is closed mid-recording;
- auto-launches the host's default browser (`open` / `xdg-open` / `start`) via a new `tools/recorder/src/server/browser-opener.js` helper. `--no-gui` (`opts.noGui`) skips the launch for CI/headless.

This **ports issue #65 onto the post-CLI-migration `live.js`** — the original fix on `recorder/65-auto-open-browser` (PR #68) predated the CLI-migration rewrite of `live.js` and no longer applies. **Supersedes #68.**

### Deliberate deviation from the historical patch
The URL is written to **stderr via `console.error`**, not stdout, to honor the locked one-JSON-envelope-per-verb invariant.

## Test plan
- New `tests/unit/recorder/browser-opener.test.js` — 7 cases: darwin/linux/win32 spawn args, unsupported-platform warn, `noGui`, falsy url, synchronous-throw swallowing.
- Extended `tests/unit/recorder/lifecycle-live.test.js` — auto-open-before-mode-handler ordering, `noGui` passthrough, always-prints-URL-to-stderr; existing real-`startLiveCapture` tests now inject a fake opener so **the suite never spawns a real browser**.
- ✅ Full suite: **776/776 passing** (93 suites).
- ✅ Lint guards (`npm run lint:guides`): **21/21**.
- ✅ Version bumped `0.16.0` → `0.16.1` (CI version-bump gate; touches `tools/`). CHANGELOG entry under `[Unreleased]`.

> **Note:** `package.json` `files` is `["bin/", "src/"]`, which excludes `tools/` — the recorder isn't shipped in the published npm package, only in `npm link`'d local checkouts. Out of scope here; flagging for a follow-up.

Refs #65
Refs #21