### PR TITLE
feat(recorder): graduate the recorder to GA (ship in npm + de-experimentalize)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0]
+
+> **The interactive recorder graduates to generally available.** `mauto record` now ships in the npm package and is no longer flagged experimental. (Refs [#21](https://github.com/sh3lan93/mobile-automator/issues/21))
+
+### ✨ Added
+
+- **Recorder ships in the npm package** (Refs [#21](https://github.com/sh3lan93/mobile-automator/issues/21)). `package.json`'s `files` allowlist now includes `tools/recorder/src/` and `tools/recorder/web/`, so `mauto record` works on a plain `npm i -g mobile-automator` install — previously the sidecar was excluded from the published tarball and the command only ran in linked local checkouts. A new packaging guard test (`tests/unit/packaging.test.js`) asserts the sidecar entrypoint and GUI assets are present in `npm pack` output, preventing silent re-exclusion.
+
 ### 🐛 Fixed
 
 - **Recorder GUI now auto-opens (no more silent hang)** ([#65](https://github.com/sh3lan93/mobile-automator/issues/65), Refs [#21](https://github.com/sh3lan93/mobile-automator/issues/21)). `mauto record <name>` previously started the HTTP+WebSocket sidecar and the mobile-mcp device connection but never opened the browser GUI nor printed its URL, so the terminal hung on `mobile-mcp server running on stdio` waiting for a WebSocket message that could never arrive. `startLiveCapture` now prints `🌐 Recorder GUI: http://127.0.0.1:<port>/` to **stderr** (stdout stays reserved for the JSON envelope) and auto-launches the host's default browser (`open`/`xdg-open`/`start`) immediately after the HTTP server binds. The URL is always printed as a fallback when auto-open fails silently; `--no-gui` skips the launch for CI/headless runs. New `tools/recorder/src/server/browser-opener.js` helper, dependency-injected for tests.
+
+### 🔧 Changed
+
+- **Recorder is no longer experimental/gated.** The `MOBILE_AUTOMATOR_RECORDER=1` opt-in (already a no-op in the CLI — it was never enforced in code) and the "experimental" framing are removed from `README.md`, `tools/recorder/README.md`, and `CLAUDE.md`.
 
 ## [0.16.0]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ commands/mobile-automator/    setup, generate, execute, report, list-tags (.toml
 templates/
   mobile-automator-generator/{aware,agnostic}/SKILL.md
   mobile-automator-executor/{aware,agnostic}/SKILL.md
-  mobile-automator-recorder/{aware,agnostic}/SKILL.md # gated; both modes (aware + agnostic)
+  mobile-automator-recorder/{aware,agnostic}/SKILL.md # both modes (aware + agnostic)
   mobile-automator-generator/references/scenario_schema.json   # v2.1
   mobile-automator-executor/references/result_schema.json
   references/platform-resolutions.md                 # agnostic-mode runtime contract
@@ -61,9 +61,9 @@ Skill templates use `{{name}}` syntax. Setup gathers values, performs string rep
 
 Runtime fallback: skills can read `mobile-automator/config.json` if a placeholder wasn't populated.
 
-## Recorder (gated soft-launch, v0.12.0)
+## Recorder (graduated v0.17.0)
 
-PRD [#21](https://github.com/sh3lan93/mobile-automator/issues/21). Feature-complete across 13 slices (see `CHANGELOG.md` `## [0.12.0]`). The entire recorder surface (`/mobile-automator:record`, sidecar at `tools/recorder/`, GUI, recorder skill) is hidden unless `MOBILE_AUTOMATOR_RECORDER=1` is set in the environment — the env-var gate remains in v0.12.0 so the feature can mature in real-world use before being removed.
+PRD [#21](https://github.com/sh3lan93/mobile-automator/issues/21). Feature-complete across 13 slices (see `CHANGELOG.md` `## [0.12.0]`). The entire recorder surface (`mauto record`, sidecar at `tools/recorder/`, GUI) graduated in v0.17.0: it ships in the npm package (`tools/recorder/src/` + `tools/recorder/web/` are in `package.json`'s `files` allowlist) and is no longer gated. The `MOBILE_AUTOMATOR_RECORDER` env var is retired — it was never enforced in the CLI.
 
 - Aware-mode recorder skill installs at `.gemini/skills/mobile-automator-recorder/SKILL.md` from the `aware/` template. Uses 10 of 13 aware placeholders (skips `build_command`, `automation_extras`, `business_domain`).
 - Agnostic-mode recorder installs from the `agnostic/` template. It uses only the 6 agnostic placeholders; per-OS facts resolve at runtime via `templates/references/platform-resolutions.md`. The sidecar reinterprets OS gestures into the four semantic actions; `dismiss_keyboard` is a manual GUI mark.

--- a/README.md
+++ b/README.md
@@ -116,16 +116,16 @@ Most low-level verbs are called **by the agent**, not by you. The ones you'll ru
 | `mauto bootstrap` | Print the verb map + invariants (onboarding for any agent) |
 | `mauto validate <file>` | Validate a scenario JSON against the schema |
 | `mauto config get\|set <key> [value]` | Read / update workspace config |
-| `mauto record <name>` | Launch the interactive web recorder (experimental) |
+| `mauto record <name>` | Launch the interactive web recorder |
 | **Agent-driven verbs** | `elements`, `tap`, `type`, `swipe`, `press`, `screenshot`, `assert`, `result`, `schema` |
 
 Run `mauto <command> --help` for full flags.
 
 ---
 
-## 🎥 Recording (experimental)
+## 🎥 Recording
 
-`mauto record <name>` opens a browser GUI that captures live device interaction (taps, typing, swipes, hardware keys) and synthesizes a scenario JSON — the same format `generate` produces and `execute` replays. Requires `ffmpeg` on your `PATH` (and `adb` for Android hardware-key capture). It's feature-complete but still maturing; file rough edges against [#21](https://github.com/sh3lan93/mobile-automator/issues/21).
+`mauto record <name>` opens a browser GUI that captures live device interaction (taps, typing, swipes, hardware keys) and synthesizes a scenario JSON — the same format `generate` produces and `execute` replays. Requires `ffmpeg` on your `PATH` (and `adb` for Android hardware-key capture). Report issues at [#21](https://github.com/sh3lan93/mobile-automator/issues/21).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {
@@ -19,7 +19,9 @@
   },
   "files": [
     "bin/",
-    "src/"
+    "src/",
+    "tools/recorder/src/",
+    "tools/recorder/web/"
   ],
   "scripts": {
     "test": "jest",

--- a/tests/unit/packaging.test.js
+++ b/tests/unit/packaging.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+// Guards against the recorder sidecar silently dropping out of the published
+// npm package via the package.json `files` allowlist. The recorder graduated
+// in v0.17.0; before that `files` was ["bin/","src/"], which excluded
+// tools/recorder/ — so `mauto record` worked only in linked local checkouts.
+describe('npm package contents (files allowlist)', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  let files;
+
+  beforeAll(() => {
+    const out = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    files = JSON.parse(out)[0].files.map((f) => f.path);
+  });
+
+  test.each([
+    'tools/recorder/src/lifecycle/live.js',
+    'tools/recorder/src/server/http-server.js',
+    'tools/recorder/web/index.html',
+    'tools/recorder/web/app.js',
+  ])('ships the recorder sidecar file %s', (p) => {
+    expect(files).toContain(p);
+  });
+});

--- a/tools/recorder/README.md
+++ b/tools/recorder/README.md
@@ -1,8 +1,6 @@
 # Recorder sidecar
 
-Sidecar process that drives the recorder GUI and captures device interactions for the experimental `/mobile-automator:record` command. The sidecar is invoked by `commands/mobile-automator/record.toml` after pre-flight (config, environment, device, app install) succeeds.
-
-The recorder feature is being built incrementally per [PRD #21](https://github.com/sh3lan93/mobile-automator/issues/21) and is gated behind the `MOBILE_AUTOMATOR_RECORDER=1` environment variable until graduation.
+Sidecar process that drives the recorder GUI and captures device interactions for `mauto record`. The `mauto` CLI spawns the sidecar after pre-flight (config, device, app install) succeeds.
 
 ## Supported targets
 
@@ -32,11 +30,8 @@ This is a Simulator-app preference (`com.apple.iphonesimulator` defaults key `Sh
 xcrun simctl boot "iPhone 16 Pro"
 open -a Simulator
 
-# Opt in to the experimental recorder
-export MOBILE_AUTOMATOR_RECORDER=1
-
-# Record a scenario — the pre-flight will detect the booted simulator
-gemini  # then: /mobile-automator:record my_scenario_name
+# Record a scenario — the pre-flight detects the booted simulator
+mauto record my_scenario_name --platform ios
 ```
 
 The pre-flight reads the device's `os` field returned by `mobile_list_available_devices()`, lowercases it, and forwards `--platform=ios` to the sidecar. The sidecar uses that to pick the iOS-tuned video tap-detector colour profile (`ios_simulator`, calibrated to the Simulator's mid-grey indicator) instead of the Android cyan-circle profile.


### PR DESCRIPTION
**Stacked on #101** (base = `recorder/65-auto-open-cli-port`). Review/merge #101 first; I'll retarget this to `main` once #101 lands. The diff here is graduation-only.

## Why

The `mauto record` recorder was fully built and already **ungated in code** (nothing checks any env var), but two things kept it from real users:

1. **It wasn't shipped.** `package.json` `files` was `["bin/", "src/"]` — excluding the sidecar at `tools/recorder/`. So `npm i -g mobile-automator` users had **no recorder at all**; it only worked in `npm link`'d checkouts. (`npm pack` went from 0 → 34 sidecar files.)
2. **Docs still called it experimental/gated** behind the retired `MOBILE_AUTOMATOR_RECORDER=1` env var (a no-op in the CLI).

## What this does

- **Ship it** — `files` now includes `tools/recorder/src/` and `tools/recorder/web/`. Runtime deps (`commander`, `pngjs`, `ws`) are already root dependencies, so nothing else is needed.
- **Guard it** — new `tests/unit/packaging.test.js` runs `npm pack --dry-run --json` and asserts the sidecar entrypoint + GUI assets ship. This converts the invisible publish-config gap (passes every unit test, yet ships a broken product) into a hard CI failure.
- **De-experimentalize docs** — strip "experimental"/gated framing + the retired env var from `README.md`, `tools/recorder/README.md`, `CLAUDE.md`.
- Bump `0.16.1 → 0.17.0`; CHANGELOG `## [0.17.0]` graduation section.

## Explicitly deferred (to the on-device validation pass)

- **No on-device validation** — your call; happens after this lands.
- **No `ffmpeg` pre-flight check.** The old Gemini `record.toml` had one; the CLI `mauto record` doesn't verify `ffmpeg` is present, so a missing binary silently yields no taps. Real rough edge, but a validation-phase fix — will file a follow-up issue.

## Test plan
- ✅ Full suite: **780/780** (94 suites).
- ✅ Packaging guard: **4/4**; `npm pack` now contains 34 `tools/recorder/` files (was 0).
- ✅ Lint guards: **21/21**.

Refs #21