### PR TITLE
fix(recorder): share one clock between tap sources and hierarchy poller (#107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {

--- a/tests/unit/recorder/getevent-tap-source.test.js
+++ b/tests/unit/recorder/getevent-tap-source.test.js
@@ -44,4 +44,37 @@ describe('createGeteventTapSource', () => {
     await src.stop();
     expect(proc.kill).toHaveBeenCalled();
   });
+
+  test('injected now() stamps emitted tap events (shared-clock fix #107)', async () => {
+    // The fake now() returns an incrementing wall-clock value starting at
+    // 1_000_000 so any tap t value is clearly NOT the parser's 0-based relative t.
+    let clockMs = 1_000_000;
+    const now = jest.fn(() => clockMs++);
+
+    const proc = fakeSpawn();
+    const spawn = jest.fn(() => proc);
+    const computeScale = jest.fn(async () => ({ scaleX: 1, scaleY: 1 }));
+    const src = createGeteventTapSource({ deviceLabel: 'emulator-5554', spawn, computeScale, now });
+
+    const taps = [];
+    src.on('tap', (e) => taps.push(e));
+    await src.start();
+
+    // Feed a down + up pair.
+    proc.stdout.emit('data',
+      '[   1.000000] /dev/input/event3: EV_ABS       ABS_MT_POSITION_X    00000064\n' +
+      '[   1.000000] /dev/input/event3: EV_ABS       ABS_MT_POSITION_Y    000000c8\n' +
+      '[   1.000000] /dev/input/event3: EV_KEY       BTN_TOUCH            DOWN\n' +
+      '[   1.000000] /dev/input/event3: EV_SYN       SYN_REPORT           00000000\n' +
+      '[   1.080000] /dev/input/event3: EV_KEY       BTN_TOUCH            UP\n' +
+      '[   1.080000] /dev/input/event3: EV_SYN       SYN_REPORT           00000000\n');
+
+    expect(taps).toHaveLength(2);
+    // Both emitted t values must come from now() (>= 1_000_000), NOT from the
+    // parser's 0-based relative timestamps (which would be 0 and 80).
+    expect(taps[0].t).toBeGreaterThanOrEqual(1_000_000);
+    expect(taps[1].t).toBeGreaterThanOrEqual(1_000_000);
+    // now() must have been called at least once per event.
+    expect(now).toHaveBeenCalled();
+  });
 });

--- a/tests/unit/recorder/lifecycle-mode-b.test.js
+++ b/tests/unit/recorder/lifecycle-mode-b.test.js
@@ -5,6 +5,7 @@ const path = require('path');
 const os = require('os');
 const { EventEmitter } = require('events');
 const { startModeB } = require('../../../tools/recorder/src/lifecycle/mode-b');
+const { HierarchyPoller } = require('../../../tools/recorder/src/capture/hierarchy-poller');
 
 function setupProject({ mode = 'platform-aware' } = {}) {
   const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mode-b-'));
@@ -210,15 +211,12 @@ describe('startModeB (lifecycle/mode-b)', () => {
     const fakeAndroidSource = Object.assign(new EventEmitter(), { start: jest.fn(), stop: jest.fn() });
     const createGeteventTapSource = jest.fn(() => fakeAndroidSource);
 
-    // Also inject a fake hierarchy poller so we can verify now is passed to it.
-    let pollerOpts = null;
     const fakePoller = {
       start: jest.fn(),
       stop: jest.fn(),
       findSnapshotBefore: jest.fn(() => null),
       _buffer: [],
     };
-    const FakeHierarchyPoller = jest.fn((opts) => { pollerOpts = opts; return fakePoller; });
 
     const wsCtx = makeFakeWsCtx();
     const exit = startModeB({
@@ -308,6 +306,73 @@ describe('startModeB (lifecycle/mode-b)', () => {
     await savedFinish(0);                       // simulate a watchdog/save completion
     await exit;
     expect(order).toEqual(['stop', 'flush']);
+  });
+
+  test('shared clock: tap resolves a target — NOT tap_unknown (#107 regression)', async () => {
+    // Controllable monotonic clock shared by the poller and tap source.
+    let clock = 1_000_000;
+    const now = () => clock;
+
+    // A fake bridge that returns one element whose bounds contain (320, 1200).
+    const mcpBridge = {
+      listElementsOnScreen: jest.fn().mockResolvedValue({
+        elements: [
+          { accessibility_label: 'Wireless Earbuds', bounds: [0, 800, 640, 1660] },
+        ],
+      }),
+      takeScreenshot: jest.fn().mockResolvedValue('/tmp/foo.png'),
+      launchApp: jest.fn().mockResolvedValue(undefined),
+      getCrash: jest.fn().mockResolvedValue(null),
+    };
+
+    // Wire a REAL HierarchyPoller with the shared clock so findSnapshotBefore
+    // runs against a clock-aligned snapshot. pollIntervalMs=10 so the initial
+    // tick fires promptly (it fires immediately on start() then every interval).
+    const realPoller = new HierarchyPoller({
+      bridge: mcpBridge,
+      intervalMs: 10,
+      capacity: 40,
+      now,
+    });
+
+    // A tap source the test controls.
+    const tapSource = new EventEmitter();
+
+    const wsCtx = makeFakeWsCtx();
+    const store = makeFakeStore();
+
+    const exit = startModeB({
+      store, wsCtx, httpSrv: {}, projectRoot, scenarioId: 's',
+      platform: 'android', appPackage: 'com.example.app',
+      deps: {
+        now,
+        mcpBridge,
+        hierarchyPoller: realPoller,
+        tapSource,
+        attachFailureModes: () => ({ stopAll() {} }),
+      },
+    });
+
+    // Let the poller capture at least one snapshot at clock=1_000_000.
+    await wait(30);
+
+    // Advance the clock so the tap timestamp is AFTER the snapshot.
+    clock = 1_000_100;
+
+    // Emit a canonical down+up tap inside the element bounds.
+    tapSource.emit('tap', { t: clock, kind: 'down', x: 320, y: 1200 });
+    tapSource.emit('tap', { t: clock + 50, kind: 'up', x: 320, y: 1200 });
+
+    // Finish the session so classifier.flush() emits the gesture.
+    wsCtx._simulateMessage({ type: 'save' });
+    await exit;
+
+    // The appended event must identify the resolved element, not tap_unknown.
+    expect(store.appendEvent).toHaveBeenCalled();
+    const ev = store.appendEvent.mock.calls[0][0];
+    // step_id is built as `${kind}_${display_name lowercased+underscored}`
+    expect(ev.step_id).toBe('tap_wireless_earbuds');
+    expect(ev.target).toBe('Wireless Earbuds');
   });
 
   test('broadcasts step-added when a tap is captured (#103 defect B)', async () => {

--- a/tests/unit/recorder/lifecycle-mode-b.test.js
+++ b/tests/unit/recorder/lifecycle-mode-b.test.js
@@ -202,6 +202,82 @@ describe('startModeB (lifecycle/mode-b)', () => {
     await exit;
   });
 
+  test('deps.now is threaded to the poller and both tap-source factories (#107)', async () => {
+    // A shared fake clock that lets us verify the same reference is passed around.
+    const sharedNow = jest.fn(() => Date.now());
+
+    // Android path — inject a fake getevent factory and capture its call args.
+    const fakeAndroidSource = Object.assign(new EventEmitter(), { start: jest.fn(), stop: jest.fn() });
+    const createGeteventTapSource = jest.fn(() => fakeAndroidSource);
+
+    // Also inject a fake hierarchy poller so we can verify now is passed to it.
+    let pollerOpts = null;
+    const fakePoller = {
+      start: jest.fn(),
+      stop: jest.fn(),
+      findSnapshotBefore: jest.fn(() => null),
+      _buffer: [],
+    };
+    const FakeHierarchyPoller = jest.fn((opts) => { pollerOpts = opts; return fakePoller; });
+
+    const wsCtx = makeFakeWsCtx();
+    const exit = startModeB({
+      store: makeFakeStore(), wsCtx, httpSrv: {},
+      projectRoot: setupProject(), scenarioId: 'scn', platform: 'android',
+      appPackage: 'com.example.app', opts: {},
+      deps: {
+        useLiveDevice: true,
+        now: sharedNow,
+        createGeteventTapSource,
+        hierarchyPoller: fakePoller,   // pre-constructed; skip ctor but keep the seam
+        mcpCall: async () => ({ elements: [] }),
+        pollIntervalMs: 10_000,
+        attachFailureModes: () => ({ stopAll() {} }),
+      },
+    });
+
+    await wait(5);
+
+    // The getevent factory MUST have been called with the same now reference.
+    expect(createGeteventTapSource).toHaveBeenCalledTimes(1);
+    const factoryArg = createGeteventTapSource.mock.calls[0][0];
+    expect(factoryArg).toHaveProperty('now', sharedNow);
+
+    wsCtx._simulateMessage({ type: 'cancel' });
+    await exit;
+  });
+
+  test('deps.now is threaded to the screenshot tap-source factory on iOS (#107)', async () => {
+    const sharedNow = jest.fn(() => Date.now());
+
+    const fakeIosSource = Object.assign(new EventEmitter(), { start: jest.fn(), stop: jest.fn() });
+    const createScreenshotTapSource = jest.fn(() => fakeIosSource);
+
+    const wsCtx = makeFakeWsCtx();
+    const exit = startModeB({
+      store: makeFakeStore(), wsCtx, httpSrv: {},
+      projectRoot: setupProject(), scenarioId: 'scn', platform: 'ios',
+      appPackage: 'com.example.app', opts: {},
+      deps: {
+        useLiveDevice: true,
+        now: sharedNow,
+        createScreenshotTapSource,
+        mcpCall: async () => ({ elements: [] }),
+        pollIntervalMs: 10_000,
+        attachFailureModes: () => ({ stopAll() {} }),
+      },
+    });
+
+    await wait(5);
+
+    expect(createScreenshotTapSource).toHaveBeenCalledTimes(1);
+    const factoryArg = createScreenshotTapSource.mock.calls[0][0];
+    expect(factoryArg).toHaveProperty('now', sharedNow);
+
+    wsCtx._simulateMessage({ type: 'cancel' });
+    await exit;
+  });
+
   test('finish awaits tapSource.stop before flushing (#103 defect C)', async () => {
     const order = [];
     // Use an EventEmitter so the tap listener wiring inside mode-b.js works.

--- a/tests/unit/recorder/screenshot-tap-source.test.js
+++ b/tests/unit/recorder/screenshot-tap-source.test.js
@@ -68,4 +68,39 @@ describe('createScreenshotTapSource', () => {
 
     expect(fakeSetInterval).toHaveBeenCalledTimes(1);
   });
+
+  test('injected now() stamps detector.feed calls (shared-clock fix #107)', async () => {
+    // now() returns a large wall-clock value so we can distinguish it from the
+    // 0-based accumulator t (which would be 125, 250, 375 for intervalMs=125).
+    let clockMs = 9_000_000;
+    const now = jest.fn(() => clockMs += 50);
+
+    let tick = null;
+    const fakeSetInterval = (fn) => { tick = fn; return 1; };
+
+    const captureFrame = jest.fn(async () => ({ buf: Buffer.from('FRAME') }));
+    const feedCalls = [];
+    const fakeDetector = {
+      feed: jest.fn((f) => feedCalls.push(f.t)),
+      flush: jest.fn(),
+    };
+
+    const src = createScreenshotTapSource({
+      deviceLabel: 'UDID', intervalMs: 125, captureFrame,
+      setInterval: fakeSetInterval, clearInterval: jest.fn(),
+      makeDetector: () => fakeDetector,
+      now,
+    });
+
+    await src.start();
+    await tick(); await tick(); await tick();
+
+    expect(feedCalls).toHaveLength(3);
+    // All t values passed to detector.feed must come from now() (> 9_000_000),
+    // not from the 0-based accumulator (which would be <= 375).
+    for (const t of feedCalls) {
+      expect(t).toBeGreaterThan(9_000_000);
+    }
+    expect(now).toHaveBeenCalled();
+  });
 });

--- a/tools/recorder/src/capture/getevent-tap-source.js
+++ b/tools/recorder/src/capture/getevent-tap-source.js
@@ -14,6 +14,7 @@ function createGeteventTapSource({
   spawn = defaultSpawn,
   computeScale = computeAndroidScale,
   warn = console.warn,
+  now = () => Date.now(),
 } = {}) {
   const emitter = new EventEmitter();
   let proc = null;
@@ -28,7 +29,7 @@ function createGeteventTapSource({
       scale = { scaleX: 1, scaleY: 1 };
     }
     parser = new GeteventTouchParser({
-      emit: (e) => emitter.emit('tap', e),
+      emit: (e) => emitter.emit('tap', { ...e, t: now() }),
       scaleX: scale.scaleX,
       scaleY: scale.scaleY,
       tStart: null,

--- a/tools/recorder/src/capture/screenshot-tap-source.js
+++ b/tools/recorder/src/capture/screenshot-tap-source.js
@@ -27,13 +27,13 @@ function createScreenshotTapSource({
   makeDetector,
   setInterval: setIntervalFn = setInterval,
   clearInterval: clearIntervalFn = clearInterval,
+  now = () => Date.now(),
 } = {}) {
   const emitter = new EventEmitter();
   const detector = (makeDetector || (() => new VideoTapDetector({ emit: (e) => emitter.emit('tap', e), color })))();
   const capture = captureFrame || defaultCaptureFrame({ deviceLabel });
   let timer = null;
   let busy = false;
-  let t = 0;
 
   emitter.start = async () => {
     if (timer) return;
@@ -41,9 +41,8 @@ function createScreenshotTapSource({
       if (busy) return;               // skip if a capture is still in flight
       busy = true;
       try {
-        t += intervalMs;
         const frame = await capture();
-        if (frame && frame.buf) { detector.feed({ t, buf: frame.buf }); }
+        if (frame && frame.buf) { detector.feed({ t: now(), buf: frame.buf }); }
       } catch (_e) { /* best-effort: drop this frame */ }
       busy = false;
     }, intervalMs);

--- a/tools/recorder/src/lifecycle/mode-b.js
+++ b/tools/recorder/src/lifecycle/mode-b.js
@@ -97,11 +97,13 @@ async function startModeB({
     call: mcpCall || (async () => ({ elements: [] })),
   });
 
+  const now = deps.now || (() => Date.now());
   const pollIntervalMs = deps.pollIntervalMs || DEFAULT_POLL_INTERVAL_MS;
   const hierarchyPoller = deps.hierarchyPoller || new HierarchyPoller({
     bridge: mcpBridge,
     intervalMs: pollIntervalMs,
     capacity: 40,
+    now,
     onSuccess: () => {
       // Each successful poll feeds the most recent snapshot to disk so the
       // generator can reconstruct UI context at any timestamp.
@@ -170,11 +172,11 @@ async function startModeB({
     if (platform === 'android') {
       const { createGeteventTapSource } = require('../capture/getevent-tap-source');
       const _create = deps.createGeteventTapSource || createGeteventTapSource;
-      tapSource = _create({ deviceLabel: deps.deviceLabel });
+      tapSource = _create({ deviceLabel: deps.deviceLabel, now });
     } else {
       const { createScreenshotTapSource } = require('../capture/screenshot-tap-source');
       const _create = deps.createScreenshotTapSource || createScreenshotTapSource;
-      tapSource = _create({ deviceLabel: deps.deviceLabel });
+      tapSource = _create({ deviceLabel: deps.deviceLabel, now });
     }
     ownsTapSource = true;
   }


### PR DESCRIPTION
## Why

After #104 (capture) and #106 (element resolution) both landed, on-device validation showed the recorder captured taps and the hierarchy had real elements — yet **every tap still resolved to `tap_unknown`**. Root cause: the tap sources emitted **0-based** timestamps while the hierarchy poller stamped **wall-clock** (`Date.now()`), so `mode-b.js`'s `findSnapshotBefore(tap.t)` never matched a snapshot → the 31 real elements were never consulted.

This only surfaced once *both* capture and a populated hierarchy worked at the same time — a classic integration bug unit tests (single injected clock) can't see.

## Fix

Inject **one shared `now()`** from `mode-b.js` into the `HierarchyPoller` **and** both tap sources (`getevent-tap-source`, `screenshot-tap-source`), and stamp emitted tap events with it. Tap `t` and snapshot `t` now share a base; `findSnapshotBefore` resolves. Gesture down→up deltas stay correct (still real ms). All three `now` params default to `Date.now`, so nothing else changes.

## On-device validation (Pixel emulator, fixed code) — the decisive proof

Recorded a session, tapped products:
```
4 events captured, ALL 4 RESOLVED, 0 tap_unknown:
  tap → "Wireless Earbuds … $59.99"   (real product label)
  tap → "Wireless Earbuds … $59.99"
  tap → "Sample Shop"                  (app bar title)
  tap → "unnamed_button"               (unlabeled cart icon — correctly unnamed)
```
Timestamps are now wall-clock (`t = 1782063940161`), matching the snapshots. **`tap_unknown` is gone** — the recorder produces named-target scenarios end-to-end.

## Test plan
- New **end-to-end regression test** (`lifecycle-mode-b.test.js`): a *real* `HierarchyPoller` + tap source share an injected clock; a tap resolves `Wireless Earbuds` (asserts `step_id === 'tap_wireless_earbuds'`, `target === 'Wireless Earbuds'`). **Fails if the shared-clock fix is reverted.**
- Unit tests: getevent + screenshot sources stamp emitted `t` from the injected `now`; `mode-b` threads the SAME `now` to poller + both factories.
- ✅ Full suite **845/845**, lint **21/21**. Version `0.19.0 → 0.19.1`.

> Note: the GUI live step-list rendering was empty during validation (the captured/resolved scenario is correct regardless) — likely a stale browser tab / display-broadcast nit, tracked separately if it recurs.

Closes #107