### PR TITLE
fix(recorder): GUI WebSocket connects to the served port, not hardcoded 7681

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {

--- a/tests/unit/recorder/web-ws-url.test.js
+++ b/tests/unit/recorder/web-ws-url.test.js
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+// Mark the environment so app.js does not auto-connect a real WebSocket.
+window.__RECORDER_TEST__ = true;
+
+const path = require('path');
+const appPath = path.resolve(__dirname, '../../../tools/recorder/web/app.js');
+
+// eslint-disable-next-line import/no-dynamic-require
+const app = require(appPath);
+
+describe('recorderWsUrl', () => {
+  test('builds a ws:// URL from an http: location', () => {
+    expect(app.recorderWsUrl({ protocol: 'http:', host: '127.0.0.1:56166' }))
+      .toBe('ws://127.0.0.1:56166/ws');
+  });
+
+  test('builds a wss:// URL from an https: location', () => {
+    expect(app.recorderWsUrl({ protocol: 'https:', host: 'example.test:443' }))
+      .toBe('wss://example.test:443/ws');
+  });
+
+  test('result does NOT contain the old hardcoded port 7681 (regression guard)', () => {
+    expect(app.recorderWsUrl({ protocol: 'http:', host: '127.0.0.1:40000' }))
+      .not.toContain('7681');
+  });
+});

--- a/tools/recorder/web/app.js
+++ b/tools/recorder/web/app.js
@@ -870,6 +870,11 @@
     return panel;
   }
 
+  function recorderWsUrl(location) {
+    var scheme = (location && location.protocol === 'https:') ? 'wss:' : 'ws:';
+    return scheme + '//' + location.host + '/ws';
+  }
+
   function _setMode(m) {
     _mode = m;
   }
@@ -884,6 +889,7 @@
   }
 
   // Expose to the browser global.
+  root.recorderWsUrl = recorderWsUrl;
   root.renderStepRow = renderStepRow;
   root.appendStep = appendStep;
   root.attachWsClient = attachWsClient;
@@ -906,6 +912,7 @@
   // Expose to CommonJS (jest).
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
+      recorderWsUrl: recorderWsUrl,
       renderStepRow: renderStepRow,
       appendStep: appendStep,
       attachWsClient: attachWsClient,
@@ -929,9 +936,6 @@
 
   // Auto-connect only in a real browser, never under tests.
   if (typeof window !== 'undefined' && !window.__RECORDER_TEST__ && typeof window.WebSocket !== 'undefined') {
-    const port = (typeof process !== 'undefined' && process.env && process.env.MOBILE_AUTOMATOR_RECORDER_PORT)
-      || (window.MOBILE_AUTOMATOR_RECORDER_PORT)
-      || '7681';
     try {
       var pendingAnchorStepId = null;
 
@@ -942,7 +946,7 @@
       }
 
       var ws = attachWsClient({
-        url: 'ws://localhost:' + port + '/ws',
+        url: recorderWsUrl(window.location),
         onStepAdded: appendStep,
         onAssertionScreenshotReady: function (payload) {
           if (pendingAnchorStepId === null) return;


### PR DESCRIPTION
## Why

The recorder browser GUI's **live step list was always empty** during recording — even though events were captured, resolved, and broadcast by the sidecar. Root cause: the GUI's WebSocket connected to a **hardcoded `ws://localhost:7681/ws`**, but the sidecar listens on a **random** port (`http-server.js` `server.listen(0)`), and that port was never communicated to the page. So the WS connection was refused (swallowed by the bootstrap's `catch`) and no `step-added` message ever reached the GUI.

The mode banner still showed because `/api/mode` is a **relative** fetch (hits the real port). That's why it looked "connected but empty."

### Why it was never caught
- `app.js:932` derived the port from `process.env` (undefined in browsers) → `window.MOBILE_AUTOMATOR_RECORDER_PORT` (never set — no inline script in `index.html`) → fell back to `'7681'`.
- Every web unit test sets `window.__RECORDER_TEST__ = true`, which **skips the auto-connect bootstrap entirely** — so the buggy URL line had **zero test coverage**.

## Fix

The WS server is attached to the **same** HTTP server that served the page, so it's same-origin. Derive the WS URL from `window.location` via a new pure, exported `recorderWsUrl(location)` helper (`ws://<host>/ws`, `wss:` for https), and remove the dead port-derivation. This also closes the bootstrap's test-coverage gap.

## Validation

- **Unit:** `recorderWsUrl` — http→ws, https→wss, and a regression guard that the result never contains `7681`.
- **Real-browser end-to-end (device-free):** started the GUI's http+ws server standalone, loaded it in a real browser via Playwright, and broadcast `step-added` messages. Result: the GUI derived `ws://127.0.0.1:54810/ws` (the actual served port) and **rendered 2 step rows** — `1. tap "Wireless Earbuds"` (cached-replay path) + `2. tap "Smart Watch"` (live-broadcast path). Both WS delivery paths render.
- ✅ Full suite **848/848**, lint **21/21**. Version `0.19.1 → 0.19.2`.

This completes the recorder: with #104/#106/#107 (capture, resolution, shared clock) already merged, steps now also render **live in the GUI**.