### PR TITLE
fix(device): surface mobile-mcp failures + read accessibility labels in content assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1]
+
+### 🐛 Fixed
+
+- Device verbs no longer report `ok:true` for failed mobile-mcp calls. `parseToolResult` now surfaces both MCP `isError` results and mobile-mcp's `ActionableError` failures (returned as plain text with the sentinel `". Please fix the issue and try again."` and no `isError` flag), so `tap`/`press`/`screenshot`/etc. fail honestly instead of laundering the error into a success envelope. This also fixes `mauto screenshot` silently writing no file (`bridge.js` passed `path` instead of mobile-mcp's `saveTo`).
+- Content assertions (`text_contains`, `element_text`, `text_not_empty`, `pattern_match`, `value_matches_variable`, `text_changed`) now read an element's `accessibility_label` when it has no text node. Previously they inspected only `text`, so they silently failed on label-driven UIs (Flutter/RN and other agnostic targets) where visible content is exposed through accessibility labels.
+
 ## [0.20.0]
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {

--- a/src/assertion/evaluator.js
+++ b/src/assertion/evaluator.js
@@ -36,12 +36,18 @@ const MECHANICAL_TYPES = new Set([
   'text_changed',
 ]);
 
-function textOf(e) {
-  return (e && typeof e.text === 'string') ? e.text : '';
-}
-
 function labelOf(e) {
   return (e && typeof e.accessibility_label === 'string') ? e.accessibility_label : '';
+}
+
+// The element's displayed content for content assertions. A real text node
+// wins; when an element carries none (common in agnostic UIs that expose
+// content through Semantics/accessibility labels rather than text), fall back
+// to the accessibility label so content assertions work on label-driven apps
+// instead of always seeing an empty string.
+function textOf(e) {
+  if (e && typeof e.text === 'string' && e.text.length > 0) return e.text;
+  return labelOf(e);
 }
 
 // An element "matches" a target string if the target appears (case-insensitive)

--- a/src/device/bridge.js
+++ b/src/device/bridge.js
@@ -27,7 +27,10 @@ class DeviceBridge {
   }
 
   async screenshot(destPath) {
-    const result = await this._call('mobile_save_screenshot', { path: destPath });
+    // mobile-mcp's save-screenshot tool names the destination `saveTo` (not
+    // `path`); passing the wrong key makes it a silent no-op that still reports
+    // success. It returns a confirmation string, so we resolve to destPath.
+    const result = await this._call('mobile_save_screenshot', { saveTo: destPath });
     return (result && result.path) || destPath;
   }
 

--- a/src/device/mobile-mcp-client.js
+++ b/src/device/mobile-mcp-client.js
@@ -87,10 +87,33 @@ function makeCall({ rawCall, device = null }) {
   return { call };
 }
 
+// Collect the text content blocks from an MCP tool result into one string.
+function textContent(res) {
+  const content = res && res.content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((c) => c && c.type === 'text' && typeof c.text === 'string')
+    .map((c) => c.text)
+    .join('\n');
+}
+
+// mobile-mcp returns *recoverable* failures (its `ActionableError`) as ordinary
+// text content WITHOUT the `isError` flag, appending this sentinel so an agent
+// reads the hint and retries. We must treat those as failures too, otherwise
+// the error text gets laundered into a successful `{ok:true}` envelope.
+const MOBILE_MCP_ACTIONABLE_SUFFIX = '. Please fix the issue and try again.';
+
 // mobile-mcp returns its payload as text content that is itself JSON.
 // Parse defensively: prefer JSON text content, fall back to raw text/struct.
 function parseToolResult(res) {
   if (!res) return null;
+
+  // `isError` covers "real exceptions"; the sentinel covers ActionableError.
+  // Surface both so device verbs fail honestly instead of reporting ok:true.
+  if (res.isError) {
+    throw new Error(textContent(res) || 'mobile-mcp tool call failed');
+  }
+
   if (res.structuredContent !== undefined) return res.structuredContent;
 
   const content = res.content;
@@ -105,9 +128,15 @@ function parseToolResult(res) {
         // not JSON; keep looking, fall through to raw join
       }
     }
-    if (texts.length) return texts.join('\n');
+    if (texts.length) {
+      const joined = texts.join('\n');
+      if (joined.endsWith(MOBILE_MCP_ACTIONABLE_SUFFIX)) {
+        throw new Error(joined);
+      }
+      return joined;
+    }
   }
   return res;
 }
 
-module.exports = { createCall, makeCall };
+module.exports = { createCall, makeCall, parseToolResult };

--- a/tests/unit/assertion/evaluator.test.js
+++ b/tests/unit/assertion/evaluator.test.js
@@ -116,13 +116,33 @@ describe('evaluate — mechanical types', () => {
     ).toBe(false);
   });
 
+  test('text_contains reads accessibility_label when text is null (agnostic apps)', () => {
+    // Agnostic UIs (Flutter/RN/etc.) commonly expose visible content through
+    // Semantics labels with no text node; content assertions must see it.
+    const cartItem = el(null, { accessibility_label: 'Wireless Earbuds\nQty 1\n$59.99' });
+    expect(
+      evaluate(
+        { type: 'text_contains', target: 'Wireless Earbuds', expected: 'Qty 1' },
+        { elements: [cartItem] }
+      ).pass
+    ).toBe(true);
+    expect(
+      evaluate(
+        { type: 'text_contains', target: 'Wireless Earbuds', expected: 'Qty 9' },
+        { elements: [cartItem] }
+      ).pass
+    ).toBe(false);
+  });
+
   test('text_not_empty', () => {
     expect(
       evaluate({ type: 'text_not_empty', target: 'Hello' }, { elements: [el('Hello')] }).pass
     ).toBe(true);
+    // An element whose only content is its accessibility label counts as
+    // non-empty in agnostic mode (the label is the displayed content).
     expect(
       evaluate({ type: 'text_not_empty', target: 'X' }, { elements: [el('', { accessibility_label: 'X' })] }).pass
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test('pattern_match against element text', () => {

--- a/tests/unit/device/bridge.test.js
+++ b/tests/unit/device/bridge.test.js
@@ -78,7 +78,7 @@ describe('DeviceBridge', () => {
   });
 
   describe('screenshot', () => {
-    test('invokes mobile_save_screenshot with the dest path and returns result.path', async () => {
+    test('invokes mobile_save_screenshot with the dest path under the saveTo key', async () => {
       const calls = [];
       const call = async (tool, args) => {
         calls.push([tool, args]);
@@ -86,7 +86,7 @@ describe('DeviceBridge', () => {
       };
       const bridge = new DeviceBridge({ call });
       const p = await bridge.screenshot('/tmp/req.png');
-      expect(calls).toEqual([['mobile_save_screenshot', { path: '/tmp/req.png' }]]);
+      expect(calls).toEqual([['mobile_save_screenshot', { saveTo: '/tmp/req.png' }]]);
       expect(p).toBe('/tmp/actual.png');
     });
 

--- a/tests/unit/device/mobile-mcp-client-inject.test.js
+++ b/tests/unit/device/mobile-mcp-client-inject.test.js
@@ -1,5 +1,5 @@
 'use strict';
-const { makeCall } = require('../../../src/device/mobile-mcp-client');
+const { makeCall, parseToolResult } = require('../../../src/device/mobile-mcp-client');
 const { DeviceResolutionError } = require('../../../src/device/device-resolver');
 
 function rawWith(devices) {
@@ -53,5 +53,39 @@ describe('makeCall device threading', () => {
       call('mobile_swipe_on_screen', { direction: 'up' }),
     ]);
     expect(calls.filter((c) => c.tool === 'mobile_list_available_devices')).toHaveLength(1);
+  });
+});
+
+describe('parseToolResult error surfacing', () => {
+  test('throws with the mobile-mcp message when isError is set', () => {
+    const res = { isError: true, content: [{ type: 'text', text: 'Error: boom' }] };
+    expect(() => parseToolResult(res)).toThrow('Error: boom');
+  });
+
+  test('throws on an ActionableError returned as plain text without isError', () => {
+    // mobile-mcp returns ActionableError failures as text + this sentinel suffix
+    // and NO isError flag (e.g. an unsupported press button). Must still fail.
+    const res = {
+      content: [{ type: 'text', text: 'Button "press_back" is not supported. Please fix the issue and try again.' }],
+    };
+    expect(() => parseToolResult(res)).toThrow(/not supported/);
+  });
+
+  test('does not throw on ordinary success text', () => {
+    const res = { content: [{ type: 'text', text: 'Screenshot saved to: /tmp/x.png' }] };
+    expect(parseToolResult(res)).toBe('Screenshot saved to: /tmp/x.png');
+  });
+
+  test('throws a generic message when isError is set without text content', () => {
+    expect(() => parseToolResult({ isError: true, content: [] })).toThrow(/mobile-mcp/i);
+  });
+
+  test('returns parsed JSON text content on success', () => {
+    const res = { content: [{ type: 'text', text: '{"path":"/tmp/x.png"}' }] };
+    expect(parseToolResult(res)).toEqual({ path: '/tmp/x.png' });
+  });
+
+  test('returns structuredContent when present on success', () => {
+    expect(parseToolResult({ structuredContent: { a: 1 } })).toEqual({ a: 1 });
   });
 });


### PR DESCRIPTION
## What & why

A live `mauto guide generate` run against the sample-app cart flow doubled as an end-to-end test of the device layer and surfaced three defects. This PR fixes two of them (the third, semantic-press resolution, is tracked separately in #112).

### A — Device verbs swallowed failures → false `ok:true`
`parseToolResult` (`src/device/mobile-mcp-client.js`) never inspected failures, so any failed mobile-mcp call was laundered into a success envelope. Two layers:
1. It ignored the MCP `isError` flag.
2. mobile-mcp returns its recoverable `ActionableError` failures as **plain text content with no `isError` flag**, appending the sentinel `". Please fix the issue and try again."` (see its `tool()` wrapper in `lib/server.js`).

Now both are surfaced as thrown errors, so `tap`/`press`/`screenshot`/etc. fail honestly. This also un-masks the screenshot break where `bridge.js` passed `path` instead of mobile-mcp's `saveTo` parameter — which made `mauto screenshot` report success while writing no file.

### C — Content assertions ignored accessibility labels
`textOf()` (`src/assertion/evaluator.js`) read only `e.text`. On label-driven UIs (Flutter/RN and other agnostic targets) `text` is `null` and visible content lives in `accessibility_label`, so `text_contains`, `element_text`, `text_not_empty`, `pattern_match`, `value_matches_variable`, and `text_changed` all silently failed. `textOf()` now falls back to the accessibility label. One existing test that had encoded the old label-as-locator-only behavior was intentionally updated.

## Verification

- `npm test` → **334 passing, 35 suites** (lint guards included).
- Verified on an Android emulator against the sample-app:
  - `mauto press press_back` now returns `ok:false` (honest device error) instead of false success; valid buttons (`BACK`) still succeed.
  - `mauto assert text_contains --target "Wireless Earbuds" --expected "Qty 1"` now passes (binds product→quantity); negative control (Watch→Qty 1) correctly fails.
  - `mauto screenshot <path>` now writes the file.

## Version

Bumps `0.20.0` → `0.20.1` and adds CHANGELOG entries under a new `[0.20.1]` section (satisfies the version-bump gate; `v0.20.1` is not yet tagged).

## Follow-up

- #112 — `mauto press` semantic-action resolution (the agnostic "big risk" area; iOS has no hardware back, so it needs a real per-platform resolver, not a button remap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)