### PR TITLE
fix(press): resolve the four semantic actions per-platform (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2]
+
+### 🐛 Fixed
+
+- `mauto press` now resolves the four platform-agnostic semantic actions (`press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`) to per-platform mechanics on Android and iOS instead of forwarding the raw token to mobile-mcp (which only understands hardware buttons). Android `press_back`/`dismiss_keyboard` map to the `BACK` button; iOS `press_back` is the left-edge interactive-pop swipe; permission actions tap the system dialog's Allow/Deny affordance by label; iOS keyboard dismissal taps a return key or swipes down. An action that cannot be resolved on the connected platform now fails honestly (`ok:false`, `device` error) rather than as a silent no-op or a bogus button press. Hardware buttons (`BACK`/`HOME`/`ENTER`) keep their existing passthrough. (#112)
+
 ## [0.20.1]
 
 ### 🐛 Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ const configManager = require('./config/manager');
 const { scaffold } = require('./setup/scaffold');
 const guideEmitter = require('./guide/emitter');
 const { ADAPTERS } = require('./init/adapters');
+const { isSemanticAction, ACTION_METHOD, selectResolver } = require('./device/semantic-press');
 
 // Map the user-facing --mode flag onto the stored config mode values.
 const MODE_ALIASES = {
@@ -192,6 +193,24 @@ async function handlePress({ deviceBridge }, button) {
       exitKind: 'invalid_input',
     };
   }
+
+  // Semantic actions are resolved to per-platform mechanics; a missing
+  // resolution is a hard error, never a bogus token forwarded to mobile-mcp.
+  if (isSemanticAction(b)) {
+    try {
+      const platform = await deviceBridge.getPlatform();
+      const resolver = selectResolver(platform, deviceBridge);
+      const { mechanism } = await resolver[ACTION_METHOD[b]]();
+      return {
+        envelope: ok({ pressed: b, resolved: { platform, mechanism } }),
+        exitKind: 'ok',
+      };
+    } catch (err) {
+      return deviceFail(err);
+    }
+  }
+
+  // Hardware/system button passthrough (BACK/HOME/ENTER…) — unchanged.
   try {
     await deviceBridge.pressButton(b);
     return { envelope: ok({ pressed: b }), exitKind: 'ok' };

--- a/src/device/bridge.js
+++ b/src/device/bridge.js
@@ -73,10 +73,23 @@ class DeviceBridge {
     return String(match.platform).toLowerCase();
   }
 
-  // Physical screen size in pixels, for geometry-based gestures.
+  // Physical screen size in pixels, for geometry-based gestures. mobile-mcp
+  // returns this as the human string "Screen size is <w>x<h> pixels" (not an
+  // object), so we parse the WxH out of it; a structured {width,height} shape is
+  // also accepted in case a future engine returns one. An unreadable size is a
+  // hard error — never silently 0/NaN, which would make geometry gestures no-ops.
   async getScreenSize() {
     const r = await this._call('mobile_get_screen_size', {});
-    return { width: Number(r && r.width), height: Number(r && r.height) };
+    if (r && typeof r === 'object' && r.width != null && r.height != null) {
+      return { width: Number(r.width), height: Number(r.height) };
+    }
+    const m = /(\d+)\s*x\s*(\d+)/i.exec(String(r));
+    if (!m) {
+      const err = new Error(`Could not read the device screen size from "${r}".`);
+      err.hint = 'Ensure a device or simulator is connected.';
+      throw err;
+    }
+    return { width: Number(m[1]), height: Number(m[2]) };
   }
 
   // Press a hardware/system button (BACK, HOME, ENTER, ...).

--- a/src/device/bridge.js
+++ b/src/device/bridge.js
@@ -2,15 +2,17 @@
 
 const { normalize, parseElements } = require('./element-model');
 const { normalizeDevices } = require('./device-model');
+const { resolveSingleDevice } = require('./device-resolver');
 
 // Thin wrapper over an injected mobile-mcp `call(toolName, args)` function.
 // Returns the agnostic element model and exposes only the primitives the CLI needs.
 class DeviceBridge {
-  constructor({ call }) {
+  constructor({ call, device = null }) {
     if (typeof call !== 'function') {
       throw new TypeError('DeviceBridge requires a `call` function (toolName, args) => Promise');
     }
     this._call = call;
+    this._device = device;
   }
 
   // Enumerate connected devices/simulators via mobile-mcp and return the
@@ -46,9 +48,35 @@ class DeviceBridge {
     return this._call('mobile_type_keys', { text, submit: false });
   }
 
-  // Swipe in a cardinal direction (up/down/left/right) from screen center.
-  async swipe({ direction } = {}) {
-    return this._call('mobile_swipe_on_screen', { direction });
+  // Swipe in a cardinal direction. Optional x/y set the start point and
+  // distance the travel — used by the iOS edge-swipe back gesture. Absent keys
+  // are not sent so the cardinal-from-center default is preserved.
+  async swipe({ direction, x, y, distance } = {}) {
+    const args = { direction };
+    if (x !== undefined) args.x = x;
+    if (y !== undefined) args.y = y;
+    if (distance !== undefined) args.distance = distance;
+    return this._call('mobile_swipe_on_screen', args);
+  }
+
+  // Platform ('android'/'ios') of the connected device. Uses the pinned id when
+  // one was provided, else the single auto-resolved device.
+  async getPlatform() {
+    const devices = normalizeDevices(await this._call('mobile_list_available_devices', {}));
+    const id = this._device || resolveSingleDevice(devices); // throws DeviceResolutionError on 0/many
+    const match = devices.find((d) => d.id === id);
+    if (!match || !match.platform) {
+      const err = new Error(`Cannot determine the platform of device "${id}".`);
+      err.hint = 'Ensure the device is listed by `mauto devices`.';
+      throw err;
+    }
+    return String(match.platform).toLowerCase();
+  }
+
+  // Physical screen size in pixels, for geometry-based gestures.
+  async getScreenSize() {
+    const r = await this._call('mobile_get_screen_size', {});
+    return { width: Number(r && r.width), height: Number(r && r.height) };
   }
 
   // Press a hardware/system button (BACK, HOME, ENTER, ...).

--- a/src/device/resolve-connection.js
+++ b/src/device/resolve-connection.js
@@ -65,17 +65,20 @@ async function resolveDeviceConnection({
 } = {}) {
   const oneShot = async () => {
     const { call, close } = await createCall({ device });
-    return { bridge: new DeviceBridge({ call }), close, source: 'oneshot' };
+    return { bridge: new DeviceBridge({ call, device }), close, source: 'oneshot' };
   };
 
   const daemonBacked = async () => {
     const conn = await client.tryConnect(projectRoot);
     if (!conn) return null;
+    // The verb's `device` may be null while the daemon is pinned to a device;
+    // fall back to the live handle's pin so getPlatform() resolves correctly.
+    const pinned = device || readHandleDevice(projectRoot);
     // close() is a no-op AND we must release our socket so the daemon's idle
     // timer can fire — wrap close to end the underlying socket but never stop
     // the shared daemon.
     return {
-      bridge: new DeviceBridge({ call: conn.call }),
+      bridge: new DeviceBridge({ call: conn.call, device: pinned }),
       close: async () => {
         try {
           await conn.close();

--- a/src/device/semantic-press/index.js
+++ b/src/device/semantic-press/index.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { AndroidResolver, IOSResolver, SemanticResolutionError } = require('./resolver');
+
+const ACTION_METHOD = {
+  press_back: 'pressBack',
+  dismiss_keyboard: 'dismissKeyboard',
+  grant_permission: 'grantPermission',
+  deny_permission: 'denyPermission',
+};
+
+const SEMANTIC_ACTIONS = Object.keys(ACTION_METHOD);
+
+function isSemanticAction(token) {
+  return Object.prototype.hasOwnProperty.call(ACTION_METHOD, token);
+}
+
+const STRATEGIES = { android: AndroidResolver, ios: IOSResolver };
+
+// Pick the per-platform resolver, or hard-fail (never silently forward).
+function selectResolver(platform, bridge) {
+  const Strategy = STRATEGIES[platform];
+  if (!Strategy) {
+    throw new SemanticResolutionError(
+      `No semantic-action resolver for platform "${platform}".`,
+      'Connect a supported Android or iOS device/simulator.'
+    );
+  }
+  return new Strategy(bridge);
+}
+
+module.exports = {
+  SEMANTIC_ACTIONS,
+  ACTION_METHOD,
+  isSemanticAction,
+  selectResolver,
+  SemanticResolutionError,
+};

--- a/src/device/semantic-press/labels.js
+++ b/src/device/semantic-press/labels.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// System permission-dialog button labels, per platform. Lowercase and
+// apostrophe-normalized so matching is locale-tolerant within English.
+const ALLOW_LABELS = {
+  android: ['allow', 'while using the app', 'allow only this time', 'ok', 'continue'],
+  ios: ['allow', 'allow while using app', 'allow once', 'ok'],
+};
+
+const DENY_LABELS = {
+  android: ['deny', "don't allow"],
+  ios: ["don't allow"],
+};
+
+function norm(s) {
+  return String(s == null ? '' : s).replace(/'/g, "'").trim().toLowerCase();
+}
+
+// First element whose visible text or accessibility label exactly equals one of
+// `labels` (after normalization). Returns the element plus the original label
+// that matched, or null.
+function findByLabels(elements, labels) {
+  const wanted = new Set(labels.map(norm));
+  for (const el of Array.isArray(elements) ? elements : []) {
+    for (const raw of [el.text, el.accessibility_label]) {
+      if (raw != null && wanted.has(norm(raw))) {
+        return { element: el, label: raw };
+      }
+    }
+  }
+  return null;
+}
+
+module.exports = { ALLOW_LABELS, DENY_LABELS, findByLabels };

--- a/src/device/semantic-press/labels.js
+++ b/src/device/semantic-press/labels.js
@@ -13,9 +13,11 @@ const DENY_LABELS = {
 };
 
 function norm(s) {
-  // Map the curly apostrophe U+2019 (written as an escape so the byte cannot be
-  // silently flattened to a straight quote) onto a straight quote, so "Don’t
-  // Allow" matches the straight-quoted entries in the label sets above.
+  // Map the curly apostrophe (U+2019, the ’ glyph in the regex below) onto a
+  // straight quote, so "Don’t Allow" matches the straight-quoted entries in the
+  // label sets above. The U+2019 byte must be preserved literally here; the
+  // guard assertion in labels.test.js fails loudly if it is ever flattened to a
+  // straight quote by editor/transport tooling.
   return String(s == null ? '' : s).replace(/’/g, "'").trim().toLowerCase();
 }
 

--- a/src/device/semantic-press/labels.js
+++ b/src/device/semantic-press/labels.js
@@ -13,7 +13,10 @@ const DENY_LABELS = {
 };
 
 function norm(s) {
-  return String(s == null ? '' : s).replace(/'/g, "'").trim().toLowerCase();
+  // Map the curly apostrophe U+2019 (written as an escape so the byte cannot be
+  // silently flattened to a straight quote) onto a straight quote, so "Don’t
+  // Allow" matches the straight-quoted entries in the label sets above.
+  return String(s == null ? '' : s).replace(/’/g, "'").trim().toLowerCase();
 }
 
 // First element whose visible text or accessibility label exactly equals one of

--- a/src/device/semantic-press/resolver.js
+++ b/src/device/semantic-press/resolver.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const { ALLOW_LABELS, DENY_LABELS, findByLabels } = require('./labels');
+
+// Raised when a semantic action cannot be performed on the current screen/
+// platform. `.kind`/`.hint` let the CLI map it onto the `device` envelope.
+class SemanticResolutionError extends Error {
+  constructor(message, hint) {
+    super(message);
+    this.name = 'SemanticResolutionError';
+    this.kind = 'device';
+    this.hint = hint;
+  }
+}
+
+// iOS return/confirm keys that dismiss the keyboard when tapped.
+const IOS_RETURN_KEYS = ['return', 'done', 'go', 'search', 'send', 'next'];
+
+class SemanticResolver {
+  constructor(bridge) {
+    this.bridge = bridge;
+  }
+
+  async _tapByLabels(labels, intent) {
+    const el = findByLabels(await this.bridge.listElements(), labels);
+    if (!el) {
+      throw new SemanticResolutionError(
+        `Could not find a "${intent}" affordance on screen.`,
+        'Ensure the relevant system dialog/control is visible before this step.'
+      );
+    }
+    await this.bridge.tap({ x: el.element.center[0], y: el.element.center[1] });
+    return { mechanism: `tap:${el.label}` };
+  }
+}
+
+class AndroidResolver extends SemanticResolver {
+  async pressBack() {
+    await this.bridge.pressButton('BACK');
+    return { mechanism: 'button:BACK' };
+  }
+
+  // BACK also hides the IME on Android. Caveat: with no keyboard open this pops
+  // the screen — accepted; mobile-mcp exposes no reliable IME-visible signal.
+  async dismissKeyboard() {
+    await this.bridge.pressButton('BACK');
+    return { mechanism: 'button:BACK' };
+  }
+
+  async grantPermission() {
+    return this._tapByLabels(ALLOW_LABELS.android, 'grant permission');
+  }
+
+  async denyPermission() {
+    return this._tapByLabels(DENY_LABELS.android, 'deny permission');
+  }
+}
+
+class IOSResolver extends SemanticResolver {
+  // No hardware back on iOS: left-edge interactive-pop gesture.
+  async pressBack() {
+    const { width, height } = await this.bridge.getScreenSize();
+    await this.bridge.swipe({
+      direction: 'right',
+      x: 1,
+      y: Math.round(height / 2),
+      distance: Math.round(width * 0.6),
+    });
+    return { mechanism: 'edge_swipe' };
+  }
+
+  // Primary: tap a return/Done key. Fallback: swipe down to dismiss.
+  async dismissKeyboard() {
+    const el = findByLabels(await this.bridge.listElements(), IOS_RETURN_KEYS);
+    if (el) {
+      await this.bridge.tap({ x: el.element.center[0], y: el.element.center[1] });
+      return { mechanism: `tap:${el.label}` };
+    }
+    await this.bridge.swipe({ direction: 'down' });
+    return { mechanism: 'swipe:down' };
+  }
+
+  async grantPermission() {
+    return this._tapByLabels(ALLOW_LABELS.ios, 'grant permission');
+  }
+
+  async denyPermission() {
+    return this._tapByLabels(DENY_LABELS.ios, 'deny permission');
+  }
+}
+
+module.exports = { SemanticResolver, AndroidResolver, IOSResolver, SemanticResolutionError };

--- a/src/device/semantic-press/resolver.js
+++ b/src/device/semantic-press/resolver.js
@@ -60,6 +60,14 @@ class IOSResolver extends SemanticResolver {
   // No hardware back on iOS: left-edge interactive-pop gesture.
   async pressBack() {
     const { width, height } = await this.bridge.getScreenSize();
+    // Without a real screen size the swipe would be a degenerate no-op that
+    // still reports success — hard-fail instead of silently doing nothing.
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      throw new SemanticResolutionError(
+        `Cannot perform the iOS back gesture without a valid screen size (got ${width}x${height}).`,
+        'Ensure a device or simulator is connected.'
+      );
+    }
     await this.bridge.swipe({
       direction: 'right',
       x: 1,

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -214,13 +214,45 @@ describe('cli handlers', () => {
   });
 
   describe('handlePress', () => {
-    test('presses a button', async () => {
+    test('hardware button still passes straight through to pressButton', async () => {
       const calls = [];
       const bridge = { pressButton: async (b) => { calls.push(b); } };
       const { envelope, exitKind } = await handlePress({ deviceBridge: bridge }, 'BACK');
       expect(exitKind).toBe('ok');
       expect(envelope.data).toEqual({ pressed: 'BACK' });
       expect(calls).toEqual(['BACK']);
+    });
+
+    test('semantic press_back resolves per platform and reports the mechanism', async () => {
+      const calls = [];
+      const bridge = {
+        getPlatform: async () => 'android',
+        pressButton: async (b) => { calls.push(['pressButton', b]); },
+      };
+      const { envelope, exitKind } = await handlePress({ deviceBridge: bridge }, 'press_back');
+      expect(exitKind).toBe('ok');
+      expect(envelope.data).toEqual({
+        pressed: 'press_back',
+        resolved: { platform: 'android', mechanism: 'button:BACK' },
+      });
+      expect(calls).toEqual([['pressButton', 'BACK']]);
+    });
+
+    test('an unresolvable semantic action hard-fails (ok:false), never forwards', async () => {
+      const bridge = {
+        getPlatform: async () => 'android',
+        listElements: async () => [], // no Allow button on screen
+        tap: async () => {},
+      };
+      const { envelope, exitKind } = await handlePress({ deviceBridge: bridge }, 'grant_permission');
+      expect(exitKind).toBe('device');
+      expect(envelope.ok).toBe(false);
+      expect(envelope.error.kind).toBe('device');
+    });
+
+    test('empty action is invalid input', async () => {
+      const { exitKind } = await handlePress({ deviceBridge: {} }, '');
+      expect(exitKind).toBe('invalid_input');
     });
   });
 

--- a/tests/unit/device/bridge.test.js
+++ b/tests/unit/device/bridge.test.js
@@ -167,13 +167,29 @@ describe('getPlatform', () => {
 });
 
 describe('getScreenSize', () => {
-  test('returns width/height from mobile_get_screen_size', async () => {
+  test('parses mobile-mcp\'s real "Screen size is WxH pixels" string', async () => {
+    const call = async (tool) => {
+      // This is the shape mobile-mcp 0.0.55 actually returns (server.js:296).
+      if (tool === 'mobile_get_screen_size') return 'Screen size is 1080x1920 pixels';
+      return {};
+    };
+    const bridge = new DeviceBridge({ call });
+    expect(await bridge.getScreenSize()).toEqual({ width: 1080, height: 1920 });
+  });
+
+  test('also accepts a structured {width,height} shape', async () => {
     const call = async (tool) => {
       if (tool === 'mobile_get_screen_size') return { width: 1080, height: 1920 };
       return {};
     };
     const bridge = new DeviceBridge({ call });
     expect(await bridge.getScreenSize()).toEqual({ width: 1080, height: 1920 });
+  });
+
+  test('hard-fails (never NaN) when the size is unreadable', async () => {
+    const call = async () => 'no dimensions here';
+    const bridge = new DeviceBridge({ call });
+    await expect(bridge.getScreenSize()).rejects.toThrow(/screen size/i);
   });
 });
 

--- a/tests/unit/device/bridge.test.js
+++ b/tests/unit/device/bridge.test.js
@@ -138,3 +138,55 @@ describe('DeviceBridge', () => {
     });
   });
 });
+
+describe('getPlatform', () => {
+  test('returns the lowercased platform of the single connected device', async () => {
+    const call = async (tool) => {
+      if (tool === 'mobile_list_available_devices') {
+        return [{ id: 'emu-5554', name: 'Pixel', os: 'android', state: 'booted' }];
+      }
+      return {};
+    };
+    const bridge = new DeviceBridge({ call });
+    expect(await bridge.getPlatform()).toBe('android');
+  });
+
+  test('matches the pinned device id when several are connected', async () => {
+    const call = async (tool) => {
+      if (tool === 'mobile_list_available_devices') {
+        return [
+          { id: 'emu-5554', os: 'android' },
+          { id: 'sim-iphone', os: 'ios' },
+        ];
+      }
+      return {};
+    };
+    const bridge = new DeviceBridge({ call, device: 'sim-iphone' });
+    expect(await bridge.getPlatform()).toBe('ios');
+  });
+});
+
+describe('getScreenSize', () => {
+  test('returns width/height from mobile_get_screen_size', async () => {
+    const call = async (tool) => {
+      if (tool === 'mobile_get_screen_size') return { width: 1080, height: 1920 };
+      return {};
+    };
+    const bridge = new DeviceBridge({ call });
+    expect(await bridge.getScreenSize()).toEqual({ width: 1080, height: 1920 });
+  });
+});
+
+describe('swipe with coordinates', () => {
+  test('forwards optional x/y/distance and omits absent keys', async () => {
+    const calls = [];
+    const call = async (tool, args) => { calls.push([tool, args]); return {}; };
+    const bridge = new DeviceBridge({ call });
+    await bridge.swipe({ direction: 'right', x: 1, y: 960, distance: 648 });
+    expect(calls).toEqual([['mobile_swipe_on_screen', { direction: 'right', x: 1, y: 960, distance: 648 }]]);
+
+    calls.length = 0;
+    await bridge.swipe({ direction: 'down' });
+    expect(calls).toEqual([['mobile_swipe_on_screen', { direction: 'down' }]]);
+  });
+});

--- a/tests/unit/device/semantic-press/index.test.js
+++ b/tests/unit/device/semantic-press/index.test.js
@@ -1,0 +1,39 @@
+const {
+  selectResolver,
+  isSemanticAction,
+  SEMANTIC_ACTIONS,
+  ACTION_METHOD,
+} = require('../../../../src/device/semantic-press');
+const { AndroidResolver, IOSResolver, SemanticResolutionError } =
+  require('../../../../src/device/semantic-press/resolver');
+
+describe('selectResolver', () => {
+  test('returns the Android strategy for android', () => {
+    expect(selectResolver('android', {})).toBeInstanceOf(AndroidResolver);
+  });
+  test('returns the iOS strategy for ios', () => {
+    expect(selectResolver('ios', {})).toBeInstanceOf(IOSResolver);
+  });
+  test('hard-fails for an unsupported platform', () => {
+    expect(() => selectResolver('windows', {})).toThrow(SemanticResolutionError);
+  });
+});
+
+describe('isSemanticAction', () => {
+  test('recognizes all four semantic tokens', () => {
+    for (const a of SEMANTIC_ACTIONS) expect(isSemanticAction(a)).toBe(true);
+  });
+  test('rejects hardware buttons', () => {
+    expect(isSemanticAction('BACK')).toBe(false);
+  });
+});
+
+describe('completeness guard', () => {
+  test('every semantic action maps to a method implemented by both strategies', () => {
+    for (const action of SEMANTIC_ACTIONS) {
+      const method = ACTION_METHOD[action];
+      expect(typeof AndroidResolver.prototype[method]).toBe('function');
+      expect(typeof IOSResolver.prototype[method]).toBe('function');
+    }
+  });
+});

--- a/tests/unit/device/semantic-press/labels.test.js
+++ b/tests/unit/device/semantic-press/labels.test.js
@@ -18,6 +18,7 @@ describe('findByLabels', () => {
     expect(deny[0].text).toContain('’'); // guard: the input really is curly
     const hit = findByLabels(deny, DENY_LABELS.ios);
     expect(hit.element).toBe(deny[0]);
+    expect(hit.label).toBe('Don’t Allow'); // original, un-normalized label returned
   });
 
   test('returns null when nothing matches', () => {

--- a/tests/unit/device/semantic-press/labels.test.js
+++ b/tests/unit/device/semantic-press/labels.test.js
@@ -11,8 +11,11 @@ describe('findByLabels', () => {
     expect(hit).toEqual({ element: els[1], label: 'Allow' });
   });
 
-  test('normalizes curly apostrophes so "Don\'t Allow" matches', () => {
-    const deny = [{ text: "Don't Allow", accessibility_label: null, center: [1, 2] }];
+  test('normalizes curly apostrophes so "Don’t Allow" matches', () => {
+    // U+2019 (curly apostrophe) written as an escape so the byte cannot be
+    // silently normalized to a straight quote by editor/transport tooling.
+    const deny = [{ text: 'Don’t Allow', accessibility_label: null, center: [1, 2] }];
+    expect(deny[0].text).toContain('’'); // guard: the input really is curly
     const hit = findByLabels(deny, DENY_LABELS.ios);
     expect(hit.element).toBe(deny[0]);
   });

--- a/tests/unit/device/semantic-press/labels.test.js
+++ b/tests/unit/device/semantic-press/labels.test.js
@@ -1,0 +1,23 @@
+const { findByLabels, ALLOW_LABELS, DENY_LABELS } = require('../../../../src/device/semantic-press/labels');
+
+describe('findByLabels', () => {
+  const els = [
+    { text: 'Cancel', accessibility_label: null, center: [10, 20] },
+    { text: null, accessibility_label: 'Allow', center: [30, 40] },
+  ];
+
+  test('matches on accessibility_label, case-insensitively', () => {
+    const hit = findByLabels(els, ALLOW_LABELS.android);
+    expect(hit).toEqual({ element: els[1], label: 'Allow' });
+  });
+
+  test('normalizes curly apostrophes so "Don\'t Allow" matches', () => {
+    const deny = [{ text: 'Don\'t Allow', accessibility_label: null, center: [1, 2] }];
+    const hit = findByLabels(deny, DENY_LABELS.ios);
+    expect(hit.element).toBe(deny[0]);
+  });
+
+  test('returns null when nothing matches', () => {
+    expect(findByLabels(els, ['nope'])).toBeNull();
+  });
+});

--- a/tests/unit/device/semantic-press/labels.test.js
+++ b/tests/unit/device/semantic-press/labels.test.js
@@ -12,7 +12,7 @@ describe('findByLabels', () => {
   });
 
   test('normalizes curly apostrophes so "Don\'t Allow" matches', () => {
-    const deny = [{ text: 'Don\'t Allow', accessibility_label: null, center: [1, 2] }];
+    const deny = [{ text: "Don't Allow", accessibility_label: null, center: [1, 2] }];
     const hit = findByLabels(deny, DENY_LABELS.ios);
     expect(hit.element).toBe(deny[0]);
   });

--- a/tests/unit/device/semantic-press/resolver.test.js
+++ b/tests/unit/device/semantic-press/resolver.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const {
+  AndroidResolver,
+  IOSResolver,
+  SemanticResolutionError,
+} = require('../../../../src/device/semantic-press/resolver');
+
+function fakeBridge(overrides = {}) {
+  const calls = [];
+  const bridge = {
+    calls,
+    pressButton: async (b) => { calls.push(['pressButton', b]); },
+    tap: async (xy) => { calls.push(['tap', xy]); },
+    swipe: async (a) => { calls.push(['swipe', a]); },
+    listElements: async () => overrides.elements || [],
+    getScreenSize: async () => overrides.size || { width: 1080, height: 1920 },
+  };
+  return bridge;
+}
+
+describe('AndroidResolver', () => {
+  test('press_back presses the BACK button', async () => {
+    const b = fakeBridge();
+    const r = await new AndroidResolver(b).pressBack();
+    expect(r).toEqual({ mechanism: 'button:BACK' });
+    expect(b.calls).toEqual([['pressButton', 'BACK']]);
+  });
+
+  test('dismiss_keyboard presses BACK', async () => {
+    const b = fakeBridge();
+    const r = await new AndroidResolver(b).dismissKeyboard();
+    expect(r).toEqual({ mechanism: 'button:BACK' });
+    expect(b.calls).toEqual([['pressButton', 'BACK']]);
+  });
+
+  test('grant_permission taps the Allow affordance center', async () => {
+    const b = fakeBridge({ elements: [{ text: 'Allow', center: [500, 1500] }] });
+    const r = await new AndroidResolver(b).grantPermission();
+    expect(r).toEqual({ mechanism: 'tap:Allow' });
+    expect(b.calls).toEqual([['tap', { x: 500, y: 1500 }]]);
+  });
+
+  test('deny_permission hard-fails when no deny affordance is present', async () => {
+    const b = fakeBridge({ elements: [{ text: 'Allow', center: [1, 2] }] });
+    await expect(new AndroidResolver(b).denyPermission()).rejects.toThrow(SemanticResolutionError);
+  });
+});
+
+describe('IOSResolver', () => {
+  test('press_back edge-swipes right from the left edge at mid-height', async () => {
+    const b = fakeBridge({ size: { width: 1000, height: 2000 } });
+    const r = await new IOSResolver(b).pressBack();
+    expect(r).toEqual({ mechanism: 'edge_swipe' });
+    expect(b.calls).toEqual([['swipe', { direction: 'right', x: 1, y: 1000, distance: 600 }]]);
+  });
+
+  test('dismiss_keyboard taps a return key when present', async () => {
+    const b = fakeBridge({ elements: [{ text: 'Done', center: [900, 1200] }] });
+    const r = await new IOSResolver(b).dismissKeyboard();
+    expect(r).toEqual({ mechanism: 'tap:Done' });
+    expect(b.calls).toEqual([['tap', { x: 900, y: 1200 }]]);
+  });
+
+  test('dismiss_keyboard falls back to a downward swipe when no return key', async () => {
+    const b = fakeBridge({ elements: [] });
+    const r = await new IOSResolver(b).dismissKeyboard();
+    expect(r).toEqual({ mechanism: 'swipe:down' });
+    expect(b.calls).toEqual([['swipe', { direction: 'down' }]]);
+  });
+
+  test('grant_permission accepts an iOS-specific label', async () => {
+    const b = fakeBridge({ elements: [{ accessibility_label: 'Allow While Using App', center: [400, 1600] }] });
+    const r = await new IOSResolver(b).grantPermission();
+    expect(r).toEqual({ mechanism: 'tap:Allow While Using App' });
+    expect(b.calls).toEqual([['tap', { x: 400, y: 1600 }]]);
+  });
+});

--- a/tests/unit/device/semantic-press/resolver.test.js
+++ b/tests/unit/device/semantic-press/resolver.test.js
@@ -55,6 +55,12 @@ describe('IOSResolver', () => {
     expect(b.calls).toEqual([['swipe', { direction: 'right', x: 1, y: 1000, distance: 600 }]]);
   });
 
+  test('press_back hard-fails (no swipe) when the screen size is unreadable', async () => {
+    const b = fakeBridge({ size: { width: NaN, height: NaN } });
+    await expect(new IOSResolver(b).pressBack()).rejects.toThrow(SemanticResolutionError);
+    expect(b.calls).toEqual([]); // never emit a degenerate no-op swipe
+  });
+
   test('dismiss_keyboard taps a return key when present', async () => {
     const b = fakeBridge({ elements: [{ text: 'Done', center: [900, 1200] }] });
     const r = await new IOSResolver(b).dismissKeyboard();


### PR DESCRIPTION
## What & why

`mauto press <action>` performed **no semantic-action resolution**: it forwarded the raw token straight to mobile-mcp's `mobile_press_button`, which only understands hardware buttons (`BACK`/`HOME`/`ENTER`). The four platform-agnostic verbs the agnostic guides are built on — `press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission` — therefore never resolved. Since v0.20.1's error-surfacing fix they fail loudly (`Button "press_back" is not supported`), but they still fail. This is the core of the platform-agnostic promise (scenario schema 2.1 records these as first-class actions), so any agnostic scenario containing a `press_back` step could not replay.

This PR adds the missing **per-platform resolution layer**, keyed by the connected device's platform.

## Approach

Per-platform **strategy classes** selected by the device platform:

- **New module `src/device/semantic-press/`**
  - `labels.js` — system permission-dialog allow/deny label sets + `findByLabels` (case-insensitive, curly-apostrophe-normalizing).
  - `resolver.js` — `AndroidResolver` / `IOSResolver` implementing the four actions via existing bridge primitives; each returns a `{ mechanism }` descriptor or throws `SemanticResolutionError`.
  - `index.js` — `selectResolver(platform, bridge)` (hard-throws on an unsupported platform), the action→method map, `isSemanticAction`, and a **completeness guard test** so a future missing resolution fails CI.
- **`DeviceBridge`** gains read-only `getPlatform()` / `getScreenSize()` and a coordinate-aware `swipe()`.
- **`handlePress`** branches: the four semantic tokens route through the resolver; hardware buttons keep their unchanged passthrough.
- **`resolve-connection.js`** threads the resolved device id into the bridge so `getPlatform()` disambiguates when several devices are connected.

### Per-platform mechanics

| Action | Android | iOS |
|---|---|---|
| `press_back` | `BACK` button | left-edge interactive-pop swipe |
| `dismiss_keyboard` | `BACK` | tap return key, else swipe down |
| `grant_permission` | tap "Allow"/… by label | tap "Allow While Using App"/… by label |
| `deny_permission` | tap "Deny"/"Don't allow" | tap "Don't Allow" |

### Failure contract

A missing/unresolvable resolution (unsupported platform, no permission affordance on screen, unreadable screen size) is a **hard `ok:false` device error** — never a silent `ok:true`, never a bogus token forwarded. This is the invariant the whole issue exists to protect.

## Test plan

- New unit tests, all fake-driven (no device/simulator in CI): `DeviceBridge` reads/swipe, `labels.js`, both resolver strategies, `selectResolver`/guard, and `handlePress` routing (semantic + hard-fail + hardware passthrough).
- Full suite: **38 suites / 361 tests green**, lint guards included.
- Version bumped `0.20.1 → 0.20.2` (CI version-bump gate); CHANGELOG entry added.

## ⚠️ iOS validation caveat

The **iOS gesture paths (`press_back` edge-swipe, `dismiss_keyboard`) were validated only at the unit level with a faked bridge — not on a real simulator.** Per the design doc, live iOS validation is manual/out of scope for this slice; the CHANGELOG entry should not be read as a verified-on-device iOS claim. Android paths use the same primitives the rest of the CLI already exercises.

## Review note

A whole-branch review caught a real defect now fixed in this PR: mobile-mcp's `mobile_get_screen_size` returns the human string `"Screen size is <w>x<h> pixels"` (not an object), so an earlier `getScreenSize()` returned `{NaN,NaN}` and iOS `press_back` degenerated into a no-op that still reported success. It now parses the real string, hard-fails on an unreadable size, and `IOSResolver.pressBack()` refuses to emit a degenerate swipe. Regression tests feed the real string shape.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
