### PR TITLE
release: graduate v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0]
+
 ### ♻️ Changed
 
 - **Device-session connection layer deepened behind one seam (no behavior change).** The daemon-vs-oneshot decision used to be threaded through `resolveDeviceConnection`'s six-concern body (four injected seams + a real handle-file write per test) and re-wired a second time by `cli.js`'s session handlers. It now has one owner: a new `src/device/connection.js` exposes a single verb-facing `acquireConnection({device, projectRoot}) -> {bridge, close}` that hides the decision entirely (the resolver's `source` stays private), plus `isSessionAlive`/`startSession`/`endSession` that `handleSessionStart/Status/End` delegate to. The pure `chooseConnectionStrategy({alive, handleDevice, requestedDevice, autostart}) -> 'daemon'|'oneshot'|'spawn-then-daemon'` is split out of the effectful resolver so the branching is tested value-in/value-out (no `tmpRoot`/`writeHandle`/fakes). `cli.js`'s `realDeviceBridge` is now a thin alias to `acquireConnection`, and the duplicated inline `try/finally` in the `elements`/`screenshot` actions collapses into `withBridge`. `session-protocol.js`'s four pass-through codecs fold into a single `FrameParser.encode()`. End-to-end request reading drops from ~7 session modules to ~3 (cli → connection → bridge). ([#123](https://github.com/sh3lan93/mobile-automator/issues/123), Refs [#116](https://github.com/sh3lan93/mobile-automator/issues/116))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.21.0-rc.13",
+  "version": "0.21.0",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {


### PR DESCRIPTION
## Graduate `v0.21.0`

Collapses `## [Unreleased]` into `## [0.21.0]` and bumps `package.json` `0.21.0-rc.13 → 0.21.0`. No source changes — this is the release cut.

### What 0.21.0 ships
The whole **production-readiness audit (#116)** plus the **cross-session memory** feature:
- **Verbs:** seven faithful device verbs (`long-press`, `double-tap`, `launch`, `install`, `uninstall`, `open-url`, `orientation`) (#117); semantic `press` resolution (`press_back`/`dismiss_keyboard`/`grant_permission`/`deny_permission`) (#112).
- **Memory:** `mauto memory show` + auto-harvested per-scenario run-history (Slice 1, #131); `mauto memory add`/`forget` for agent-authored app-knowledge & preferences + "when to remember" guide instruction (Slice 2, #132).
- **Robustness:** session-daemon transport honesty + lifecycle/spawn-lock hardening (#122); uniform-envelope crash boundary (#120); atomic-honest `init --agent all` (#121); crash-atomic result store (#119); empty-coordinate rejection (#117).
- **Structure:** device-session connection-layer seam (#123); native Agent Skills for all hosts (#69).
- **Docs:** full migration off the Gemini-extension model to the `mauto` CLI + a stale-token guard (#124).

### Release checklist
- [x] `package.json` → `0.21.0` (untagged)
- [x] `[Unreleased]` collapsed into `[0.21.0]`; fresh empty `[Unreleased]` re-added
- [x] Full suite green
- [ ] On merge: tag the merge commit `v0.21.0` and push the tag (per the repo's gate-then-graduate pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
