### PR TITLE
docs(site): refresh MkDocs site for v0.21.0 (memory, verbs, schema drift)

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -32,12 +32,13 @@ Any AI agent (Claude Code, Cursor, Gemini CLI, Copilot, and more) drives the wor
 
 The deterministic surface the agent drives. Every verb emits `{ok,data,error,hint,schema_version}`; `--human` is an opt-in readable flag.
 
-- **Device actions:** `elements`, `tap`, `type <text>`, `swipe`, `press <button>`, `screenshot <path>`
+- **Device actions:** `elements`, `tap`, `type <text>`, `swipe`, `press <button>`, `screenshot <path>`, `long-press`, `double-tap`, `launch <appId>`, `install <path>`, `uninstall <appId>`, `open-url <url>`, `orientation <portrait|landscape>`
 - **Author & verify:** `validate <file>`, `assert <type>`, `result add-step`, `result finalize`
 - **Workspace:** `setup`, `config get <key>`, `config set <key> <value>`
 - **Reasoning:** `guide <topic>`, `bootstrap`, `schema <name>`
 - **Agent integration:** `init --agent <host>`, `mcp` (MCP prompts server)
 - **Device session:** `session start|status|end`; `devices`, `devices use <id>`, `devices clear`
+- **Memory:** `memory show`, `memory add`, `memory forget` — the cross-session learning subsystem (see [Memory](memory.md) and the [CLI Verbs reference](../reference/cli-verbs.md))
 
 ### The mobile-mcp engine
 
@@ -75,6 +76,8 @@ For each step:
         ↓
 mauto result finalize → mobile-automator/results/
 ```
+
+On `mauto result finalize`, the **memory subsystem** (`src/memory/`) auto-harvests typed observations into a cross-session `mobile-automator/memory/` store, so the agent gets smarter about *this* app over time. The agent can also author durable app-knowledge and preferences directly via `mauto memory add` / `mauto memory forget`. See [Memory](memory.md).
 
 ## File Structure
 
@@ -176,27 +179,38 @@ Here's exactly what happens when you generate and execute a login test:
 
 4. Scenario JSON Created:
    {
-     "schema_version": "2.1",
+     "$schema_version": "2.1",
      "mode": "platform-aware",
-     "steps": {
-       "tap_login": {
-         "type": "tap",
-         "element": "login_button"
+     "steps": [
+       {
+         "id": "tap_login",
+         "action": "tap",
+         "target": "login_button",
+         "description": "Tap the login button"
        },
-       "enter_email": {
-         "type": "type",
-         "element": "email_field",
-         "text": "user@example.com"
+       {
+         "id": "enter_email",
+         "action": "type",
+         "target": "email_field",
+         "value": "user@example.com",
+         "description": "Enter the email address"
        },
-       "wait_spinner": {
-         "type": "wait_for_loading_complete"
-       },
-       "verify_success": {
-         "type": "element_text",
-         "element": "success_message",
-         "expected_exact": "Success"
+       {
+         "id": "wait_spinner",
+         "action": "wait_for_loading_complete",
+         "description": "Wait for the loading spinner to disappear"
        }
-     }
+     ],
+     "assertions": [
+       {
+         "id": "verify_success",
+         "after_step": "wait_spinner",
+         "type": "element_text",
+         "element_description": "success_message",
+         "expected_value": "Success",
+         "description": "Success message is shown after login"
+       }
+     ]
    }
 
 5. Execution Phase:

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -94,6 +94,7 @@ Instead of brittle selectors and pixel-by-pixel comparisons, the agent uses AI v
 - **Semantic testing** — AI vision understands your app, not just pixel values
 - **Schema-based** — Test scenarios and results follow JSON schemas for validation and IDE support
 - **Observational debugging** — Results capture flakiness, regressions, and execution context
+- **Cross-session memory** — The agent [remembers what it learns about your app](memory.md) across sessions, so it gets smarter over time
 - **Device through verbs only** — The agent drives the device exclusively through `mauto` verbs that wrap mobile-mcp
 
 ## Main Topics
@@ -101,6 +102,7 @@ Instead of brittle selectors and pixel-by-pixel comparisons, the agent uses AI v
 - **[Architecture Overview](architecture.md)** — Detailed system design and components
 - **[Brain/Hands Layering](three-tier-design.md)** — In-depth explanation of each layer and rationale
 - **[How Skills Work](skills.md)** — Native Agent Skills, guide content, and customization
+- **[Cross-Session Memory](memory.md)** — How the agent remembers what it learns about your app
 
 ## Why This Design?
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -1,0 +1,111 @@
+---
+description: "How mobile-automator's cross-session memory works - the run-history, app-knowledge, and preferences kinds, the memory verbs, and how the agent gets smarter about your app over time."
+---
+
+# Cross-Session Memory
+
+mobile-automator keeps a small, durable memory alongside your scenarios and results so the agent gets **smarter about *this* app over time** — instead of re-discovering the same flakiness, selectors, and conventions on every run.
+
+## Why It Exists
+
+Each generate or execute session starts fresh: the agent has the guide content and your `config.json`, but no recollection of what it learned last time. Memory closes that gap. It is a compact, human-readable record of durable knowledge that survives across sessions, so the agent can:
+
+- Avoid re-diagnosing known flaky steps or timing quirks
+- Reuse hard-won knowledge about *this* app's screens, flows, and conventions
+- Respect standing preferences about how you want tests written and run
+
+The `generate` and `execute` guides now instruct the agent to **consult memory before doing work** and to **record durable knowledge** it learns along the way.
+
+## Where Data Lives
+
+Memory lives in the `mobile-automator/memory/` directory, scaffolded by `mauto setup` alongside `scenarios/`, `screenshots/`, and `results/`. The files are plain, human-readable markdown — project data you can read, review, and (if you want the whole team to share what the agent has learned) commit to version control. The machine-local session state (sockets, pidfiles, the memory lock) lives separately under `mobile-automator/.session/`.
+
+```
+mobile-automator/
+├── config.json
+├── scenarios/
+├── screenshots/
+├── results/
+└── memory/
+    ├── run-history.md      # machine-owned (auto-harvested)
+    ├── app-knowledge.md    # agent-authored
+    └── preferences.md      # agent-authored
+```
+
+## The Three Kinds
+
+Memory is split into three **kinds**, each backed by its own file. The key distinction is ownership: one kind is machine-owned and auto-harvested; the other two are agent-authored.
+
+| Kind | File | Owner | How it's written | `add`/`forget` target? |
+|---|---|---|---|---|
+| `run-history` | `run-history.md` | Machine | Auto-harvested on `result finalize` | No |
+| `app-knowledge` | `app-knowledge.md` | Agent | `mauto memory add --kind app-knowledge` | Yes |
+| `preferences` | `preferences.md` | Agent | `mauto memory add --kind preferences` | Yes |
+
+### `run-history` — machine-owned
+
+`run-history.md` is written by the CLI, not the agent. When you call `mauto result finalize`, the typed **observations** in the result file — `regression`, `flakiness`, and `state_context` — are folded into a **bounded, rolling per-scenario aggregate**. Old entries age out so the file stays small and useful rather than growing without limit.
+
+Because it is machine-owned, `run-history` is **not a valid target** for `memory add` or `memory forget`. Trying to author it by hand would fight the harvester; let `result finalize` maintain it.
+
+!!! note "Harvesting never fails a finalize"
+    Memory harvesting on `result finalize` is best-effort. If a memory write fails, it never fails an otherwise-successful finalize — the problem folds into the envelope's `hint` instead.
+
+### `app-knowledge` — agent-authored
+
+`app-knowledge.md` holds durable facts the agent learns about *your app*: how a particular screen behaves, which flows are fragile, naming conventions, and other observations worth carrying forward. The agent records these with `mauto memory add --kind app-knowledge "<text>"`.
+
+### `preferences` — agent-authored
+
+`preferences.md` captures standing preferences about how you want tests authored and run — style choices, defaults, and conventions the agent should honor going forward. The agent records these with `mauto memory add --kind preferences "<text>"`.
+
+Agent-authored entries (both kinds) are marked `[asserted]`, exact-match de-duped so the same fact is not stored twice, and written under a lock (see [Durability](#durability)).
+
+## The Verbs
+
+Three verbs manage memory. See the [CLI Verbs reference](../reference/cli-verbs.md) for the full surface.
+
+| Verb | Purpose |
+|---|---|
+| `mauto memory show [--kind <kind>] [--scenario <id>]` | Read memory back (all kinds, or filter by kind / scenario) |
+| `mauto memory add <text> --kind <app-knowledge\|preferences>` | Record an agent-authored entry |
+| `mauto memory forget --kind <app-knowledge\|preferences> --match <substr>` | Remove agent-authored entries containing a substring |
+
+!!! note "`memory show` prints raw markdown"
+    Like `guide`, `schema`, and `bootstrap`, `mauto memory show` prints the **raw markdown** verbatim on success — **not** the uniform JSON envelope. This is deliberate: the agent injects that text straight into its context. `memory add` and `memory forget` return the normal `{ok,data,error,hint,schema_version}` envelope.
+
+`memory add` and `memory forget` accept only `app-knowledge` and `preferences` — the two agent-authored kinds. `run-history` is read-only from the agent's side; you can inspect it with `mauto memory show --kind run-history` but you cannot author or forget it.
+
+## Durability
+
+Memory files are read-modify-written safely so concurrent sessions and interrupted writes never corrupt them:
+
+- **Advisory lock** — every read-modify-write goes through a lock at `mobile-automator/.session/memory.lock`.
+- **Atomic writes** — updates are written atomically, so a file is never left half-written.
+- **`.corrupt.<ts>` sidecars** — if a memory file is found unreadable, it is preserved as a `.corrupt.<timestamp>` sidecar rather than discarded, so nothing is silently lost.
+
+## How the Agent Uses Memory
+
+```mermaid
+graph LR
+    A["Agent starts<br/>generate / execute"] -->|reads| B["mauto memory show"]
+    B --> C["Agent does the work<br/>drives mauto verbs"]
+    C -->|learns durable fact| D["mauto memory add<br/>app-knowledge / preferences"]
+    C -->|execute only| E["mauto result finalize"]
+    E -->|auto-harvests observations| F["run-history.md"]
+
+    style A fill:#1a1a2e,stroke:#10B981,color:#fff
+    style B fill:#1a1a2e,stroke:#10B981,color:#fff
+    style C fill:#1a1a2e,stroke:#10B981,color:#fff
+    style D fill:#1a1a2e,stroke:#10B981,color:#fff
+    style E fill:#1a1a2e,stroke:#10B981,color:#fff
+    style F fill:#1a1a2e,stroke:#10B981,color:#fff
+```
+
+The [Generate guide](../guides/generate.md) and [Execute guide](../guides/execute.md) both instruct the agent to consult memory before starting and to record durable app-knowledge or preferences it discovers. On the execute side, `run-history` is maintained for you: each `result finalize` harvests the run's observations into the rolling per-scenario aggregate.
+
+## Next Steps
+
+- [How Skills Work](skills.md) — where memory reads and writes fit into the generate/execute workflows
+- [CLI Verbs reference](../reference/cli-verbs.md) — full `memory` verb surface and flags
+- [Executor Guide](../guides/execute.md) — how observations become run-history

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -93,51 +93,72 @@ Convert natural language descriptions into structured test scenarios (JSON follo
 
 The agent, following `mauto guide generate`:
 
-1. Parses user intent
-2. Identifies the test flow (sequence of user actions)
-3. Resolves elements with `mauto elements` (which wraps mobile-mcp → device)
-4. Maps to test actions (tap, type, wait, etc.)
-5. Adds contextual assertions
-6. Includes retry logic for async operations
-7. Validates the JSON with `mauto validate <file>` and saves it
+1. **Consults memory** with `mauto memory show` for prior app-knowledge and preferences learned in earlier sessions
+2. Parses user intent
+3. Identifies the test flow (sequence of user actions)
+4. Resolves elements with `mauto elements` (which wraps mobile-mcp → device)
+5. Maps to test actions (tap, type, wait, etc.)
+6. Adds contextual assertions
+7. Includes retry logic for async operations
+8. Validates the JSON with `mauto validate <file>` and saves it
+9. **Records durable knowledge** it learned about the app or your conventions with `mauto memory add --kind <app-knowledge|preferences>`
+
+See [Cross-Session Memory](memory.md) for how these reads and writes persist across sessions.
 
 ### Output
 
 ```json
 {
+  "$schema_version": "2.1",
   "scenario_id": "login_flow",
-  "schema_version": "2.1",
+  "name": "Login Flow",
+  "description": "Log in with a valid email and password and land on the home screen",
+  "platform": "android",
+  "app_package": "com.example.app",
   "mode": "platform-aware",
   "tags": ["authentication", "critical"],
-  "actions": [
+  "metadata": {
+    "app_version": "1.0.0",
+    "environment": "staging"
+  },
+  "steps": [
     {
-      "step_id": "launch_app",
-      "action_type": "launch_app",
+      "id": "launch_app",
+      "action": "launch_app",
       "description": "Launch the application"
     },
     {
-      "step_id": "wait_for_login_screen",
-      "action_type": "wait_for_element",
-      "element_description": "Login button",
-      "timeout_seconds": 10
+      "id": "wait_for_login_screen",
+      "action": "wait_for_element",
+      "description": "Wait for the login screen to appear",
+      "target": "Login button"
     },
     {
-      "step_id": "tap_email_field",
-      "action_type": "tap",
-      "element_description": "Email input field"
+      "id": "tap_email_field",
+      "action": "tap",
+      "description": "Focus the email input field",
+      "target": "Email input field"
     },
     {
-      "step_id": "type_email",
-      "action_type": "type",
-      "text": "test@example.com"
+      "id": "type_email",
+      "action": "type",
+      "description": "Enter the email address",
+      "target": "Email input field",
+      "value": "test@example.com"
+    },
+    {
+      "id": "wait_for_home",
+      "action": "wait_for_element",
+      "description": "Wait for the home screen to load",
+      "target": "Home screen content"
     }
-    // ... more actions
   ],
   "assertions": [
     {
-      "assertion_id": "home_screen_visible",
-      "action_step_id": "wait_for_home",
-      "assertion_type": "element_exists",
+      "id": "home_screen_visible",
+      "after_step": "wait_for_home",
+      "type": "element_exists",
+      "description": "The home screen is shown after login",
       "element_description": "Home screen content"
     }
   ]
@@ -169,14 +190,18 @@ Replay test scenarios on a connected device and report detailed results with obs
 
 The agent, following `mauto guide execute`:
 
-1. Parses the scenario JSON
-2. For each action:
+1. **Consults memory** with `mauto memory show --scenario <id>` for prior run-history, app-knowledge, and preferences — for example, known flaky steps to watch
+2. Parses the scenario JSON
+3. For each action:
    - Drives a `mauto` verb (`tap`, `type`, `swipe`, `screenshot`, …) which wraps mobile-mcp → device
    - Reads the `{ok,data,error,hint,schema_version}` envelope
-3. For each assertion:
+4. For each assertion:
    - Runs `mauto assert` for mechanical checks, or judges visually for vision assertions
    - Records the result via `mauto result add-step`
-4. Calls `mauto result finalize` to write the report
+5. Calls `mauto result finalize` to write the report — this **auto-harvests** the run's typed observations (regression / flakiness / state_context) into `run-history` memory
+6. **Records durable knowledge** it learned during the run with `mauto memory add --kind <app-knowledge|preferences>`
+
+See [Cross-Session Memory](memory.md) for how run-history is harvested and how agent-authored entries persist.
 
 ### Output
 
@@ -184,7 +209,7 @@ The agent, following `mauto guide execute`:
 {
   "run_id": "login_flow_20250227_143022",
   "scenario_id": "login_flow",
-  "schema_version": "2.1",
+  "schema_version": "2.0",
   "status": "passed",
   "duration_seconds": 15.3,
   "steps_executed": [
@@ -393,18 +418,28 @@ Capture values during test execution for later verification:
 
 ```json
 {
-  "steps": {
-    "capture_user_id": {
-      "type": "capture_value",
-      "element": "user_id_display",
-      "capture_to": "user_id"
-    },
-    "verify_balance": {
-      "type": "element_text",
-      "element": "balance_display",
-      "condition": "user_id matches variable user_id"
+  "variables": {
+    "user_id": { "type": "string", "description": "The displayed user ID" }
+  },
+  "steps": [
+    {
+      "id": "capture_user_id",
+      "action": "capture_value",
+      "target": "user_id_display",
+      "capture_to": "user_id",
+      "description": "Capture the displayed user ID"
     }
-  }
+  ],
+  "assertions": [
+    {
+      "id": "verify_balance",
+      "after_step": "capture_user_id",
+      "type": "value_matches_variable",
+      "element_description": "balance_display",
+      "variable_name": "user_id",
+      "description": "Balance display matches the captured user ID"
+    }
+  ]
 }
 ```
 
@@ -419,19 +454,24 @@ Execute steps conditionally based on previous results:
 
 ```json
 {
-  "steps": {
-    "attempt_login": { "type": "tap", "element": "login_button" },
-    "check_error": {
-      "type": "element_exists",
-      "element": "error_message",
-      "optional": true
+  "steps": [
+    {
+      "id": "attempt_login",
+      "action": "tap",
+      "target": "login_button",
+      "description": "Tap the login button"
     },
-    "retry_if_error": {
-      "type": "tap",
-      "element": "retry_button",
-      "condition": "error_message is visible"
+    {
+      "id": "retry_if_error",
+      "action": "tap",
+      "target": "retry_button",
+      "description": "Tap retry only if an error is showing",
+      "condition": {
+        "type": "element_visible",
+        "element_description": "error_message"
+      }
     }
-  }
+  ]
 }
 ```
 
@@ -446,17 +486,19 @@ Configure how steps retry on failure:
 
 ```json
 {
-  "steps": {
-    "wait_for_data": {
-      "type": "wait_for_element",
-      "element": "data_list",
+  "steps": [
+    {
+      "id": "wait_for_data",
+      "action": "wait_for_element",
+      "target": "data_list",
+      "description": "Wait for the data list to load",
+      "on_failure": "retry",
       "retry_policy": {
-        "max_retries": 3,
-        "wait_between_retries_ms": 1000,
-        "backoff_factor": 1.5
+        "max_attempts": 3,
+        "backoff_ms": 1000
       }
     }
-  }
+  ]
 }
 ```
 

--- a/docs/concepts/three-tier-design.md
+++ b/docs/concepts/three-tier-design.md
@@ -79,12 +79,13 @@ Provide a deterministic, host-agnostic surface. Each verb performs one mechanica
 
 ### Verb groups
 
-- **Device actions:** `elements`, `tap`, `type <text>`, `swipe`, `press <button>`, `screenshot <path>`
+- **Device actions:** `elements`, `tap`, `type <text>`, `swipe`, `press <button>`, `screenshot <path>`, `long-press`, `double-tap`, `launch <appId>`, `install <path>`, `uninstall <appId>`, `open-url <url>`, `orientation <portrait|landscape>`
 - **Author & verify:** `validate <file>`, `assert <type>`, `result add-step`, `result finalize`
 - **Workspace:** `setup`, `config get <key>`, `config set <key> <value>`
 - **Reasoning:** `guide <topic>`, `bootstrap`, `schema <name>`
 - **Agent integration:** `init --agent <host>`, `mcp`
 - **Device session:** `session start|status|end`; `devices`, `devices use <id>`, `devices clear`
+- **Memory:** `memory show`, `memory add`, `memory forget` — the cross-session learning subsystem (see [Memory](memory.md) and the [CLI Verbs reference](../reference/cli-verbs.md))
 
 ### Why a deterministic CLI?
 
@@ -212,6 +213,10 @@ To extend the CLI:
 ### Adding a New Engine Primitive
 
 mobile-mcp is pinned outside this project. To pick up a newer engine, bump the `@mobilenext/mobile-mcp` pin in `package.json`; `mauto` verbs resolve it from `node_modules` at runtime.
+
+### The Memory Subsystem
+
+Cross-session learning lives in `src/memory/`, backed by the `mobile-automator/memory/` store. It is **auto-harvested on `mauto result finalize`** — typed observations fold into a bounded per-scenario `run-history` — and **agent-authored** via `mauto memory add` / `mauto memory forget` for durable app-knowledge and preferences. This lets the agent get smarter about *this* app over time. See [Memory](memory.md).
 
 ## Next Steps
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,6 +85,7 @@ mobile-automator/
 │   │   └── <topic>.invariants.md #   placeholder-free, OS-free skill core
 │   ├── schemas/                 # scenario_schema.json (v2.1), result_schema.json
 │   ├── device/                  # mobile-mcp wrapper (one persistent session daemon)
+│   ├── memory/                  # cross-session memory (run-history, app-knowledge, preferences)
 │   └── init/ setup/ config/ …   # host adapters, workspace scaffold, config
 ├── CLAUDE.md                    # developer guide (architecture, workflows)
 ├── README.md                    # user-facing docs
@@ -106,6 +107,13 @@ The contract is: **agent (the brain) → `mauto` verbs → mobile-mcp engine →
 3. **Schemas** (`src/schemas/*.json`)
    - Define the test scenario format (scenario schema 2.1) and the test result format.
    - Enforced by `mauto validate <file>`.
+
+4. **Cross-session memory** (`src/memory/`)
+   - Persists what the agent learns about an app across runs in `mobile-automator/memory/`.
+   - `run-history.md` is machine-owned (auto-harvested on `result finalize`); `app-knowledge.md`
+     and `preferences.md` are agent-authored via `mauto memory add`/`memory forget`.
+   - Read-modify-writes go through an advisory lock plus atomic writes. See the
+     [memory concept doc](concepts/memory.md) for the full model.
 
 ---
 
@@ -393,7 +401,7 @@ Closes #123
   "properties": {
     "$schema_version": {
       "type": "string",
-      "enum": ["2.1"],
+      "enum": ["2.0", "2.1"],
       "description": "Schema version identifier"
     },
     "new_field": {
@@ -683,5 +691,4 @@ We're here to help make contributing as smooth as possible!
 Thank you for contributing to mobile-automator! 🎉
 
 [Back to Docs →](index.md)
-</content>
-</invoke>
+

--- a/docs/examples/android.md
+++ b/docs/examples/android.md
@@ -6,6 +6,8 @@ description: "Android test scenario examples - login flow, RecyclerView scrollin
 
 Complete test scenario examples for Android applications. Each example demonstrates key patterns and best practices.
 
+All scenarios below use scenario schema **2.1** (the current version — additive over 2.0, adding the `mode` metadata field and the four platform-agnostic semantic actions). Existing 2.0 scenarios remain valid. Every example on this page validates with `mauto validate <file>`.
+
 ## Table of Contents
 
 1. [Login Flow](#login-flow) — Email validation, loading states, error handling
@@ -32,7 +34,7 @@ A realistic login scenario demonstrating email validation, password entry, loadi
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "android_login_happy_path",
   "name": "Login with Valid Credentials",
   "description": "User successfully logs in with valid email and password, completes loading, and accesses dashboard",
@@ -44,110 +46,39 @@ A realistic login scenario demonstrating email validation, password entry, loadi
   },
   "tags": ["authentication", "login", "happy-path"],
   "variables": {
-    "user_email": {
-      "type": "string",
-      "value": "testuser@example.com"
-    },
-    "user_password": {
-      "type": "string",
-      "value": "SecurePassword123!"
-    },
     "dashboard_title": {
-      "type": "string"
+      "type": "string",
+      "description": "Title text captured from the dashboard screen after login"
     }
   },
   "preconditions": {
-    "setup_actions": [
+    "app_state": "logged_out",
+    "device_actions": [
       {
-        "type": "clear_app_data",
-        "description": "Clear app cache to ensure fresh login state"
+        "action": "clear_app_data",
+        "target_package": "com.example.app",
+        "description": "Clear app cache to ensure a fresh login state"
       }
     ],
-    "device_state": "Clean login screen required"
+    "notes": ["A clean login screen is required before the scenario starts"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch the app to login screen"
-    },
-    "verify_login_screen": {
-      "type": "wait_for_element",
-      "element": "email_input",
-      "timeout_seconds": 5,
-      "description": "Wait for login screen to appear"
-    },
-    "tap_email_field": {
-      "type": "tap",
-      "element": "email_input",
-      "description": "Tap on email input field"
-    },
-    "enter_email": {
-      "type": "type",
-      "element": "email_input",
-      "text": "testuser@example.com",
-      "clear_before": true,
-      "description": "Enter test user email address"
-    },
-    "tap_password_field": {
-      "type": "tap",
-      "element": "password_input",
-      "description": "Tap on password input field"
-    },
-    "enter_password": {
-      "type": "type",
-      "element": "password_input",
-      "text": "SecurePassword123!",
-      "clear_before": true,
-      "description": "Enter user password"
-    },
-    "tap_login_button": {
-      "type": "tap",
-      "element": "login_button",
-      "description": "Tap login button to submit form"
-    },
-    "wait_for_loading": {
-      "type": "wait_for_loading_complete",
-      "timeout_seconds": 10,
-      "description": "Wait for loading animation to complete"
-    },
-    "verify_dashboard_reached": {
-      "type": "wait_for_element",
-      "element": "dashboard_title",
-      "timeout_seconds": 5,
-      "description": "Verify dashboard screen is displayed"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the app to the login screen", "target": "com.example.app" },
+    { "id": "verify_login_screen", "action": "wait_for_element", "description": "Wait for the login screen to appear", "target": "email input field", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "tap_email_field", "action": "tap", "description": "Tap on the email input field", "target": "email input field" },
+    { "id": "enter_email", "action": "type", "description": "Enter the test user email address", "target": "email input field", "value": "testuser@example.com" },
+    { "id": "tap_password_field", "action": "tap", "description": "Tap on the password input field", "target": "password input field" },
+    { "id": "enter_password", "action": "type", "description": "Enter the user password", "target": "password input field", "value": "SecurePassword123!" },
+    { "id": "tap_login_button", "action": "tap", "description": "Tap the login button to submit the form", "target": "login button" },
+    { "id": "wait_for_loading", "action": "wait_for_loading_complete", "description": "Wait for the loading animation to complete", "wait_config": { "type": "loading_complete", "indicator": "spinner", "timeout_ms": 10000 } },
+    { "id": "verify_dashboard_reached", "action": "wait_for_element", "description": "Verify the dashboard screen is displayed", "target": "dashboard screen title", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } }
+  ],
   "assertions": [
-    {
-      "id": "email_field_visible",
-      "description": "Email input field is visible on login screen",
-      "type": "element_exists",
-      "element": "email_input"
-    },
-    {
-      "id": "password_field_visible",
-      "description": "Password input field is visible on login screen",
-      "type": "element_exists",
-      "element": "password_input"
-    },
-    {
-      "id": "login_button_clickable",
-      "description": "Login button is visible and accessible",
-      "type": "element_visible",
-      "element": "login_button"
-    },
-    {
-      "id": "dashboard_screen_reached",
-      "description": "Dashboard screen is displayed after login",
-      "type": "screen_title",
-      "expected_text": "Dashboard"
-    },
-    {
-      "id": "no_error_message",
-      "description": "No error message displayed during login",
-      "type": "element_not_exists",
-      "element": "error_message_view"
-    }
+    { "id": "email_field_visible", "after_step": "verify_login_screen", "type": "element_exists", "description": "Email input field is visible on the login screen", "element_description": "email input field" },
+    { "id": "password_field_visible", "after_step": "verify_login_screen", "type": "element_exists", "description": "Password input field is visible on the login screen", "element_description": "password input field" },
+    { "id": "login_button_clickable", "after_step": "verify_login_screen", "type": "element_visible", "description": "Login button is visible and accessible", "element_description": "login button", "expected_visible": true },
+    { "id": "dashboard_screen_reached", "after_step": "verify_dashboard_reached", "type": "screen_title", "description": "Dashboard screen is displayed after login", "expected_text": "Dashboard" },
+    { "id": "no_error_message", "after_step": "verify_dashboard_reached", "type": "element_not_exists", "description": "No error message displayed during login", "element_description": "error message banner" }
   ]
 }
 ```
@@ -166,7 +97,7 @@ A realistic login scenario demonstrating email validation, password entry, loadi
 - Change email/password credentials for different test accounts
 - Modify timeout values based on network speed
 - Add additional assertions for custom dashboard elements
-- Use variables to parameterize credentials
+- Capture dynamic values (like the dashboard title) into declared `variables`
 
 ---
 
@@ -186,108 +117,35 @@ Demonstrates handling of RecyclerView/ListViews, scrolling to elements, and sele
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "android_list_scrolling",
   "name": "Navigate List and Select Item",
   "description": "User scrolls through a product list and selects an item to view details",
   "platform": "android",
   "app_package": "com.example.shop",
-  "metadata": {
-    "app_version": "2.1.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "2.1.0", "environment": "staging" },
   "tags": ["navigation", "list", "scrolling"],
   "variables": {
-    "selected_product": {
-      "type": "string",
-      "value": "Premium Widget"
-    },
-    "product_price": {
-      "type": "string"
-    }
+    "product_price": { "type": "string", "description": "Price text captured from the product detail screen" }
   },
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "launch_app"
-      }
-    ],
-    "device_state": "Logged in and on products list screen"
+    "app_state": "logged_in",
+    "notes": ["User is logged in and on the products list screen"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch shopping app"
-    },
-    "wait_for_product_list": {
-      "type": "wait_for_element",
-      "element": "products_recycler_view",
-      "timeout_seconds": 5,
-      "description": "Wait for products list to load"
-    },
-    "verify_list_not_empty": {
-      "type": "list_is_empty",
-      "element": "products_recycler_view",
-      "expected": false,
-      "description": "Verify list contains items"
-    },
-    "scroll_to_premium_widget": {
-      "type": "scroll_to_element",
-      "element": "products_recycler_view",
-      "target_element": "product_item_premium_widget",
-      "timeout_seconds": 10,
-      "description": "Scroll down to find Premium Widget product"
-    },
-    "verify_item_visible": {
-      "type": "element_visible",
-      "element": "product_item_premium_widget",
-      "description": "Verify Premium Widget is visible on screen"
-    },
-    "tap_product_item": {
-      "type": "tap",
-      "element": "product_item_premium_widget",
-      "description": "Tap on Premium Widget item"
-    },
-    "wait_for_detail_screen": {
-      "type": "wait_for_element",
-      "element": "product_detail_title",
-      "timeout_seconds": 5,
-      "description": "Wait for product detail screen to load"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the shopping app", "target": "com.example.shop" },
+    { "id": "wait_for_product_list", "action": "wait_for_element", "description": "Wait for the products list to load", "target": "products list", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "scroll_to_premium_widget", "action": "scroll_to_element", "description": "Scroll down to find the Premium Widget product", "target": "Premium Widget product row", "value": "down" },
+    { "id": "tap_product_item", "action": "tap", "description": "Tap on the Premium Widget item", "target": "Premium Widget product row" },
+    { "id": "wait_for_detail_screen", "action": "wait_for_element", "description": "Wait for the product detail screen to load", "target": "product detail title", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "capture_price", "action": "capture_value", "description": "Capture the product price from the detail screen", "target": "product detail price", "capture_to": "product_price" }
+  ],
   "assertions": [
-    {
-      "id": "list_displayed",
-      "description": "Products list is displayed",
-      "type": "element_exists",
-      "element": "products_recycler_view"
-    },
-    {
-      "id": "list_has_items",
-      "description": "Products list contains items",
-      "type": "list_is_empty",
-      "element": "products_recycler_view",
-      "expected": false
-    },
-    {
-      "id": "product_item_found",
-      "description": "Premium Widget product item is found",
-      "type": "element_exists",
-      "element": "product_item_premium_widget"
-    },
-    {
-      "id": "detail_screen_loaded",
-      "description": "Product detail screen displays correct product",
-      "type": "element_text",
-      "element": "product_detail_title",
-      "expected_text": "Premium Widget"
-    },
-    {
-      "id": "price_displayed",
-      "description": "Product price is displayed on detail screen",
-      "type": "element_exists",
-      "element": "product_detail_price"
-    }
+    { "id": "list_displayed", "after_step": "wait_for_product_list", "type": "element_exists", "description": "Products list is displayed", "element_description": "products list" },
+    { "id": "list_has_items", "after_step": "wait_for_product_list", "type": "list_item_count", "description": "Products list contains at least one item", "element_description": "products list", "operator": ">", "expected_count": 0 },
+    { "id": "product_item_found", "after_step": "scroll_to_premium_widget", "type": "element_exists", "description": "Premium Widget product item is found", "element_description": "Premium Widget product row" },
+    { "id": "detail_screen_loaded", "after_step": "wait_for_detail_screen", "type": "element_text", "description": "Product detail screen displays the correct product", "element_description": "product detail title", "expected_value": "Premium Widget" },
+    { "id": "price_displayed", "after_step": "capture_price", "type": "element_exists", "description": "Product price is displayed on the detail screen", "element_description": "product detail price" }
   ]
 }
 ```
@@ -325,101 +183,39 @@ Demonstrates handling Android runtime permission dialogs and permission-dependen
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "android_camera_permission_request",
   "name": "Request Camera Permission",
-  "description": "User grants camera permission to enable photo capture feature",
+  "description": "User grants camera permission to enable the photo capture feature",
   "platform": "android",
   "app_package": "com.example.photoapp",
-  "metadata": {
-    "app_version": "3.0.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "3.0.0", "environment": "staging" },
   "tags": ["permissions", "camera", "system-dialog"],
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "clear_app_data",
-        "description": "Clear app to reset permission state"
-      }
+    "app_state": "fresh_install",
+    "device_actions": [
+      { "action": "clear_app_data", "target_package": "com.example.photoapp", "description": "Clear app data to reset the permission state" }
     ],
-    "device_state": "Camera permission not yet granted"
+    "notes": ["Camera permission has not yet been granted"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch photo app"
-    },
-    "wait_for_home_screen": {
-      "type": "wait_for_element",
-      "element": "home_screen_title",
-      "timeout_seconds": 5,
-      "description": "Wait for home screen to load"
-    },
-    "tap_camera_button": {
-      "type": "tap",
-      "element": "camera_button",
-      "description": "Tap camera button to trigger permission request"
-    },
-    "wait_for_permission_dialog": {
-      "type": "wait_for_element",
-      "element": "permission_dialog_title",
-      "timeout_seconds": 3,
-      "description": "Wait for Android permission dialog to appear"
-    },
-    "verify_dialog_message": {
-      "type": "wait_for_element",
-      "element": "permission_message_text",
-      "timeout_seconds": 2,
-      "description": "Verify permission request message is displayed"
-    },
-    "tap_allow_button": {
-      "type": "tap",
-      "element": "permission_allow_button",
-      "description": "Tap Allow button in permission dialog"
-    },
-    "wait_for_camera_feature": {
-      "type": "wait_for_element",
-      "element": "camera_preview",
-      "timeout_seconds": 5,
-      "description": "Wait for camera preview to load after permission granted"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the photo app", "target": "com.example.photoapp" },
+    { "id": "wait_for_home_screen", "action": "wait_for_element", "description": "Wait for the home screen to load", "target": "home screen title", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "tap_camera_button", "action": "tap", "description": "Tap the camera button to trigger the permission request", "target": "camera button" },
+    { "id": "wait_for_permission_dialog", "action": "wait_for_element", "description": "Wait for the system permission dialog to appear", "target": "camera permission dialog", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "grant_camera_permission", "action": "grant_permission", "description": "Grant the camera permission on the system dialog", "permission_name": "camera" },
+    { "id": "wait_for_camera_feature", "action": "wait_for_element", "description": "Wait for the camera preview to load after the permission is granted", "target": "camera preview", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } }
+  ],
   "assertions": [
-    {
-      "id": "permission_dialog_shown",
-      "description": "Android camera permission dialog is displayed",
-      "type": "permission_dialog_shown",
-      "permission_type": "android.permission.CAMERA"
-    },
-    {
-      "id": "dialog_title_correct",
-      "description": "Permission dialog shows correct title",
-      "type": "element_text",
-      "element": "permission_dialog_title",
-      "expected_text": "Allow photo app to access your camera?"
-    },
-    {
-      "id": "allow_button_visible",
-      "description": "Allow button is visible in permission dialog",
-      "type": "element_visible",
-      "element": "permission_allow_button"
-    },
-    {
-      "id": "camera_available_after_grant",
-      "description": "Camera preview is available after permission granted",
-      "type": "element_exists",
-      "element": "camera_preview"
-    },
-    {
-      "id": "no_error_shown",
-      "description": "No error message displayed after granting permission",
-      "type": "element_not_exists",
-      "element": "error_toast"
-    }
+    { "id": "permission_dialog_shown", "after_step": "wait_for_permission_dialog", "type": "permission_dialog_shown", "description": "System camera permission dialog is displayed", "permission_name": "camera" },
+    { "id": "allow_button_visible", "after_step": "wait_for_permission_dialog", "type": "element_visible", "description": "Allow button is visible in the permission dialog", "element_description": "Allow button", "expected_visible": true },
+    { "id": "camera_available_after_grant", "after_step": "wait_for_camera_feature", "type": "element_exists", "description": "Camera preview is available after the permission is granted", "element_description": "camera preview" },
+    { "id": "no_error_shown", "after_step": "wait_for_camera_feature", "type": "element_not_exists", "description": "No error toast displayed after granting permission", "element_description": "error toast" }
   ]
 }
 ```
+
+> **Semantic action:** This scenario uses the `grant_permission` action, one of the four platform-agnostic semantic actions (`press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`). In a `platform-agnostic` scenario these resolve to the correct per-platform mechanics at replay time — the same step works on Android and iOS. Swap it for `deny_permission` to exercise the rejection flow.
 
 ### What This Tests
 
@@ -431,9 +227,9 @@ Demonstrates handling Android runtime permission dialogs and permission-dependen
 
 ### Adaptation Tips
 
-- Change permission type (CAMERA, LOCATION, CONTACTS, etc.)
+- Change the permission name (`camera`, `location`, `contacts`, etc.)
 - Adjust timeout based on device and network
-- Add deny button testing for rejection flow
+- Swap `grant_permission` for `deny_permission` to test the rejection flow
 - Include feature-specific assertions
 
 ---
@@ -454,123 +250,39 @@ Demonstrates verification of toast messages during user interactions.
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "android_toast_verification",
   "name": "Verify Toast Notifications",
-  "description": "User performs action that triggers success toast message",
+  "description": "User performs an action that triggers a success toast message",
   "platform": "android",
   "app_package": "com.example.notes",
-  "metadata": {
-    "app_version": "1.5.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "1.5.0", "environment": "staging" },
   "tags": ["notifications", "toast", "feedback"],
   "variables": {
-    "note_title": {
-      "type": "string",
-      "value": "Test Note"
-    }
+    "note_title": { "type": "string", "description": "Title used for the note created during the test", "value": "Test Note" }
   },
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "launch_app"
-      }
-    ],
-    "device_state": "Logged in on notes list screen"
+    "app_state": "logged_in",
+    "notes": ["User is logged in on the notes list screen"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch notes application"
-    },
-    "wait_for_notes_list": {
-      "type": "wait_for_element",
-      "element": "notes_list",
-      "timeout_seconds": 5,
-      "description": "Wait for notes list to display"
-    },
-    "tap_create_note_button": {
-      "type": "tap",
-      "element": "create_note_button",
-      "description": "Tap create new note button"
-    },
-    "wait_for_note_form": {
-      "type": "wait_for_element",
-      "element": "note_title_input",
-      "timeout_seconds": 3,
-      "description": "Wait for note creation form"
-    },
-    "enter_note_title": {
-      "type": "type",
-      "element": "note_title_input",
-      "text": "Test Note",
-      "clear_before": true,
-      "description": "Enter note title"
-    },
-    "tap_note_content": {
-      "type": "tap",
-      "element": "note_content_input",
-      "description": "Tap on note content field"
-    },
-    "enter_note_content": {
-      "type": "type",
-      "element": "note_content_input",
-      "text": "This is a test note created during automated testing.",
-      "clear_before": true,
-      "description": "Enter note content"
-    },
-    "tap_save_button": {
-      "type": "tap",
-      "element": "save_note_button",
-      "description": "Tap save button"
-    },
-    "wait_for_toast": {
-      "type": "toast_visible",
-      "message": "Note saved successfully",
-      "timeout_seconds": 3,
-      "description": "Wait for success toast to appear"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the notes application", "target": "com.example.notes" },
+    { "id": "wait_for_notes_list", "action": "wait_for_element", "description": "Wait for the notes list to display", "target": "notes list", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "tap_create_note_button", "action": "tap", "description": "Tap the create new note button", "target": "create note button" },
+    { "id": "wait_for_note_form", "action": "wait_for_element", "description": "Wait for the note creation form", "target": "note title input", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "enter_note_title", "action": "type", "description": "Enter the note title", "target": "note title input", "value": "Test Note" },
+    { "id": "tap_note_content", "action": "tap", "description": "Tap on the note content field", "target": "note content input" },
+    { "id": "enter_note_content", "action": "type", "description": "Enter the note content", "target": "note content input", "value": "This is a test note created during automated testing." },
+    { "id": "tap_save_button", "action": "tap", "description": "Tap the save button", "target": "save note button" },
+    { "id": "wait_for_toast", "action": "wait_for_element", "description": "Wait for the success toast to appear", "target": "success toast", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } }
+  ],
   "assertions": [
-    {
-      "id": "create_button_visible",
-      "description": "Create note button is visible",
-      "type": "element_visible",
-      "element": "create_note_button"
-    },
-    {
-      "id": "form_displayed",
-      "description": "Note creation form is displayed",
-      "type": "element_exists",
-      "element": "note_title_input"
-    },
-    {
-      "id": "title_entered",
-      "description": "Note title is entered correctly",
-      "type": "element_text",
-      "element": "note_title_input",
-      "expected_text": "Test Note"
-    },
-    {
-      "id": "content_entered",
-      "description": "Note content is entered correctly",
-      "type": "text_contains",
-      "element": "note_content_input",
-      "expected_substring": "test note created"
-    },
-    {
-      "id": "success_toast_shown",
-      "description": "Success toast message is displayed",
-      "type": "toast_visible",
-      "message": "Note saved successfully"
-    },
-    {
-      "id": "back_to_list",
-      "description": "User returns to notes list after save",
-      "type": "element_exists",
-      "element": "notes_list"
-    }
+    { "id": "create_button_visible", "after_step": "wait_for_notes_list", "type": "element_visible", "description": "Create note button is visible", "element_description": "create note button", "expected_visible": true },
+    { "id": "form_displayed", "after_step": "wait_for_note_form", "type": "element_exists", "description": "Note creation form is displayed", "element_description": "note title input" },
+    { "id": "title_entered", "after_step": "enter_note_title", "type": "element_text", "description": "Note title is entered correctly", "element_description": "note title input", "expected_value": "Test Note" },
+    { "id": "content_entered", "after_step": "enter_note_content", "type": "text_contains", "description": "Note content includes the expected text", "element_description": "note content input", "expected_substring": "test note created" },
+    { "id": "success_toast_shown", "after_step": "wait_for_toast", "type": "toast_visible", "description": "Success toast message is displayed", "expected_text": "Note saved successfully" },
+    { "id": "back_to_list", "after_step": "wait_for_toast", "type": "element_exists", "description": "User returns to the notes list after save", "element_description": "notes list" }
   ]
 }
 ```
@@ -609,112 +321,36 @@ Demonstrates verification of error states, network errors, and validation error 
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "android_error_handling",
   "name": "Handle Login Validation Error",
-  "description": "User enters invalid email and sees validation error message",
+  "description": "User enters an invalid email and sees a validation error message",
   "platform": "android",
   "app_package": "com.example.app",
-  "metadata": {
-    "app_version": "1.2.3",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "1.2.3", "environment": "staging" },
   "tags": ["validation", "error-handling", "forms"],
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "clear_app_data",
-        "description": "Clear app data for clean state"
-      }
+    "app_state": "logged_out",
+    "device_actions": [
+      { "action": "clear_app_data", "target_package": "com.example.app", "description": "Clear app data for a clean state" }
     ],
-    "device_state": "On login screen"
+    "notes": ["Start on the login screen"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch application"
-    },
-    "wait_for_login_screen": {
-      "type": "wait_for_element",
-      "element": "email_input",
-      "timeout_seconds": 5,
-      "description": "Wait for login screen to load"
-    },
-    "tap_email_field": {
-      "type": "tap",
-      "element": "email_input",
-      "description": "Tap email input field"
-    },
-    "enter_invalid_email": {
-      "type": "type",
-      "element": "email_input",
-      "text": "invalid.email",
-      "clear_before": true,
-      "description": "Enter invalid email format"
-    },
-    "tap_password_field": {
-      "type": "tap",
-      "element": "password_input",
-      "description": "Tap password field to trigger validation"
-    },
-    "wait_for_error_message": {
-      "type": "wait_for_element",
-      "element": "email_error_message",
-      "timeout_seconds": 2,
-      "description": "Wait for email validation error to appear"
-    },
-    "verify_error_displayed": {
-      "type": "element_visible",
-      "element": "email_error_message",
-      "description": "Verify error message is visible"
-    },
-    "verify_login_button_disabled": {
-      "type": "element_state",
-      "element": "login_button",
-      "expected_state": "disabled",
-      "description": "Verify login button is disabled due to validation error"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the application", "target": "com.example.app" },
+    { "id": "wait_for_login_screen", "action": "wait_for_element", "description": "Wait for the login screen to load", "target": "email input field", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "tap_email_field", "action": "tap", "description": "Tap the email input field", "target": "email input field" },
+    { "id": "enter_invalid_email", "action": "type", "description": "Enter an invalid email format", "target": "email input field", "value": "invalid.email" },
+    { "id": "tap_password_field", "action": "tap", "description": "Tap the password field to trigger validation", "target": "password input field" },
+    { "id": "wait_for_error_message", "action": "wait_for_element", "description": "Wait for the email validation error to appear", "target": "email error message", "wait_config": { "type": "element_visible", "timeout_ms": 2000 } }
+  ],
   "assertions": [
-    {
-      "id": "login_screen_ready",
-      "description": "Login screen is displayed",
-      "type": "element_exists",
-      "element": "email_input"
-    },
-    {
-      "id": "invalid_email_entered",
-      "description": "Invalid email is entered in field",
-      "type": "element_text",
-      "element": "email_input",
-      "expected_text": "invalid.email"
-    },
-    {
-      "id": "error_message_displayed",
-      "description": "Email validation error message is shown",
-      "type": "element_exists",
-      "element": "email_error_message"
-    },
-    {
-      "id": "error_text_correct",
-      "description": "Error message contains correct validation text",
-      "type": "element_text",
-      "element": "email_error_message",
-      "expected_text": "Please enter a valid email address"
-    },
-    {
-      "id": "login_button_disabled",
-      "description": "Login button is disabled when validation fails",
-      "type": "element_state",
-      "element": "login_button",
-      "expected_state": "disabled"
-    },
-    {
-      "id": "error_icon_visible",
-      "description": "Error icon is shown next to email field",
-      "type": "element_exists",
-      "element": "email_error_icon"
-    }
+    { "id": "login_screen_ready", "after_step": "wait_for_login_screen", "type": "element_exists", "description": "Login screen is displayed", "element_description": "email input field" },
+    { "id": "invalid_email_entered", "after_step": "enter_invalid_email", "type": "element_text", "description": "Invalid email is entered in the field", "element_description": "email input field", "expected_value": "invalid.email" },
+    { "id": "error_message_displayed", "after_step": "wait_for_error_message", "type": "element_exists", "description": "Email validation error message is shown", "element_description": "email error message" },
+    { "id": "error_text_correct", "after_step": "wait_for_error_message", "type": "element_text", "description": "Error message contains the correct validation text", "element_description": "email error message", "expected_value": "Please enter a valid email address" },
+    { "id": "login_button_disabled", "after_step": "wait_for_error_message", "type": "element_state", "description": "Login button is disabled when validation fails", "element_description": "login button", "state_property": "disabled" },
+    { "id": "error_icon_visible", "after_step": "wait_for_error_message", "type": "element_exists", "description": "Error icon is shown next to the email field", "element_description": "email error icon" }
   ]
 }
 ```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -31,6 +31,8 @@ Our examples cover a wide range of mobile testing scenarios that you'll encounte
 
 Mobile testing involves unique challenges compared to web testing. Mobile apps must handle diverse device sizes, orientations, network conditions, and user interactions. Our examples show you how to write tests that account for these variables. By studying these scenarios, you'll learn how to write clear, maintainable test scenarios using the JSON schema, structure steps logically to match actual user behavior patterns, create assertions that verify functionality without being brittle, handle asynchronous operations like network requests and animations, and account for platform-specific behavior differences.
 
+All examples on this site use scenario schema **2.1** — the current version, additive over 2.0 (it adds the `mode` metadata field and the four platform-agnostic semantic actions `press_back`, `dismiss_keyboard`, `grant_permission`, and `deny_permission`). Existing 2.0 scenarios remain valid. The examples below are organized by platform, but if you author in `platform-agnostic` mode a single scenario can run on both Android and iOS by using those semantic actions in place of OS-specific gestures.
+
 ## How to Use These Examples
 
 The most effective way to learn Mobile Automator is by studying and adapting these examples:

--- a/docs/examples/ios.md
+++ b/docs/examples/ios.md
@@ -6,6 +6,8 @@ description: "iOS test scenario examples - Face ID authentication, tab bar navig
 
 Complete test scenario examples for iOS applications. Each example demonstrates iOS-specific patterns and best practices.
 
+All scenarios below use scenario schema **2.1** (the current version — additive over 2.0, adding the `mode` metadata field and the four platform-agnostic semantic actions). Existing 2.0 scenarios remain valid. Every example on this page validates with `mauto validate <file>`.
+
 ## Table of Contents
 
 1. [Login with Biometric Fallback](#login-with-biometric-fallback) — Face ID with password fallback
@@ -32,141 +34,41 @@ Demonstrates handling biometric authentication with Face ID and fallback to pass
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "ios_login_biometric_fallback",
   "name": "Login with Face ID and Password Fallback",
-  "description": "User authenticates with Face ID, and falls back to password entry if biometric fails",
+  "description": "User authenticates with Face ID and falls back to password entry if biometric fails",
   "platform": "ios",
   "app_package": "com.example.app",
-  "metadata": {
-    "app_version": "2.1.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "2.1.0", "environment": "staging" },
   "tags": ["authentication", "biometric", "face-id", "ios"],
   "variables": {
-    "test_password": {
-      "type": "string",
-      "value": "SecurePassword123!"
-    },
-    "dashboard_loaded": {
-      "type": "boolean"
-    }
+    "test_password": { "type": "string", "description": "Password used for the fallback authentication path", "value": "SecurePassword123!" }
   },
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "clear_app_data",
-        "description": "Clear app keychain and defaults"
-      }
-    ],
-    "device_state": "On login screen with biometric enrolled"
+    "app_state": "logged_out",
+    "notes": ["Start on the login screen with a biometric identity enrolled"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch authentication enabled app"
-    },
-    "wait_for_login_screen": {
-      "type": "wait_for_element",
-      "element": "login_view_title",
-      "timeout_seconds": 5,
-      "description": "Wait for login screen to display"
-    },
-    "verify_biometric_button": {
-      "type": "element_visible",
-      "element": "biometric_auth_button",
-      "description": "Verify Face ID button is visible"
-    },
-    "tap_biometric_button": {
-      "type": "tap",
-      "element": "biometric_auth_button",
-      "description": "Tap Face ID authentication button"
-    },
-    "wait_for_biometric_prompt": {
-      "type": "wait_for_element",
-      "element": "biometric_system_prompt",
-      "timeout_seconds": 3,
-      "description": "Wait for system biometric prompt"
-    },
-    "deny_biometric": {
-      "type": "tap",
-      "element": "biometric_cancel_button",
-      "description": "Tap cancel on biometric prompt to trigger fallback"
-    },
-    "wait_for_fallback": {
-      "type": "wait_for_element",
-      "element": "password_input",
-      "timeout_seconds": 3,
-      "description": "Wait for password input field to appear"
-    },
-    "tap_password_field": {
-      "type": "tap",
-      "element": "password_input",
-      "description": "Tap password input field"
-    },
-    "enter_password": {
-      "type": "type",
-      "element": "password_input",
-      "text": "SecurePassword123!",
-      "clear_before": true,
-      "description": "Enter password for fallback authentication"
-    },
-    "tap_login_button": {
-      "type": "tap",
-      "element": "login_button",
-      "description": "Tap login button"
-    },
-    "wait_for_dashboard": {
-      "type": "wait_for_element",
-      "element": "dashboard_title",
-      "timeout_seconds": 5,
-      "description": "Wait for dashboard to load after password login"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the authentication-enabled app", "target": "com.example.app" },
+    { "id": "wait_for_login_screen", "action": "wait_for_element", "description": "Wait for the login screen to display", "target": "login screen title", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "tap_biometric_button", "action": "tap", "description": "Tap the Face ID authentication button", "target": "Face ID button" },
+    { "id": "wait_for_biometric_prompt", "action": "wait_for_element", "description": "Wait for the system biometric prompt", "target": "system biometric prompt", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "cancel_biometric", "action": "tap", "description": "Tap cancel on the biometric prompt to trigger the fallback", "target": "biometric prompt cancel button" },
+    { "id": "wait_for_fallback", "action": "wait_for_element", "description": "Wait for the password input field to appear", "target": "password input field", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "tap_password_field", "action": "tap", "description": "Tap the password input field", "target": "password input field" },
+    { "id": "enter_password", "action": "type", "description": "Enter the password for fallback authentication", "target": "password input field", "value": "SecurePassword123!" },
+    { "id": "tap_login_button", "action": "tap", "description": "Tap the login button", "target": "login button" },
+    { "id": "wait_for_dashboard", "action": "wait_for_element", "description": "Wait for the dashboard to load after password login", "target": "dashboard title", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } }
+  ],
   "assertions": [
-    {
-      "id": "login_screen_loaded",
-      "description": "Login screen is displayed",
-      "type": "element_exists",
-      "element": "login_view_title"
-    },
-    {
-      "id": "biometric_button_available",
-      "description": "Face ID button is available and visible",
-      "type": "element_visible",
-      "element": "biometric_auth_button"
-    },
-    {
-      "id": "password_field_shown_after_cancel",
-      "description": "Password input field appears after biometric cancel",
-      "type": "element_exists",
-      "element": "password_input"
-    },
-    {
-      "id": "password_entered",
-      "description": "Password is entered in field",
-      "type": "element_text",
-      "element": "password_input",
-      "expected_text": "SecurePassword123!"
-    },
-    {
-      "id": "login_button_enabled",
-      "description": "Login button is enabled when password entered",
-      "type": "element_visible",
-      "element": "login_button"
-    },
-    {
-      "id": "dashboard_accessible",
-      "description": "Dashboard is displayed after fallback login",
-      "type": "screen_title",
-      "expected_text": "Dashboard"
-    },
-    {
-      "id": "no_error_on_fallback",
-      "description": "No error message on successful fallback",
-      "type": "element_not_exists",
-      "element": "error_message"
-    }
+    { "id": "login_screen_loaded", "after_step": "wait_for_login_screen", "type": "element_exists", "description": "Login screen is displayed", "element_description": "login screen title" },
+    { "id": "biometric_button_available", "after_step": "wait_for_login_screen", "type": "element_visible", "description": "Face ID button is available and visible", "element_description": "Face ID button", "expected_visible": true },
+    { "id": "password_field_shown_after_cancel", "after_step": "wait_for_fallback", "type": "element_exists", "description": "Password input field appears after biometric cancel", "element_description": "password input field" },
+    { "id": "password_entered", "after_step": "enter_password", "type": "element_text", "description": "Password is entered in the field", "element_description": "password input field", "expected_value": "SecurePassword123!" },
+    { "id": "login_button_enabled", "after_step": "enter_password", "type": "element_state", "description": "Login button is enabled when the password is entered", "element_description": "login button", "state_property": "enabled" },
+    { "id": "dashboard_accessible", "after_step": "wait_for_dashboard", "type": "screen_title", "description": "Dashboard is displayed after fallback login", "expected_text": "Dashboard" },
+    { "id": "no_error_on_fallback", "after_step": "wait_for_dashboard", "type": "element_not_exists", "description": "No error message on successful fallback", "element_description": "error message banner" }
   ]
 }
 ```
@@ -206,170 +108,43 @@ Demonstrates tab bar navigation, tab switching, and state persistence across tab
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "ios_tabbar_navigation",
   "name": "Navigate Between Tabs and Verify State",
-  "description": "User switches between tab bar tabs and verifies correct content loads for each tab",
+  "description": "User switches between tab bar tabs and verifies the correct content loads for each tab",
   "platform": "ios",
   "app_package": "com.example.shop",
-  "metadata": {
-    "app_version": "1.8.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "1.8.0", "environment": "staging" },
   "tags": ["navigation", "tabbar", "ios", "ui"],
   "variables": {
-    "current_tab": {
-      "type": "string"
-    },
-    "cart_item_count": {
-      "type": "string"
-    }
+    "cart_item_count": { "type": "string", "description": "Item count captured from the cart tab badge" }
   },
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "launch_app"
-      }
-    ],
-    "device_state": "Logged in on home tab"
+    "app_state": "logged_in",
+    "notes": ["User is logged in on the home tab"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch shopping application"
-    },
-    "wait_for_home_tab": {
-      "type": "wait_for_element",
-      "element": "home_tab_content",
-      "timeout_seconds": 5,
-      "description": "Wait for home tab content to load"
-    },
-    "verify_home_tab_active": {
-      "type": "element_visible",
-      "element": "home_tab_icon_active",
-      "description": "Verify home tab is selected (active state)"
-    },
-    "tap_search_tab": {
-      "type": "tap",
-      "element": "search_tab",
-      "description": "Tap on search tab"
-    },
-    "wait_for_search_content": {
-      "type": "wait_for_element",
-      "element": "search_bar",
-      "timeout_seconds": 3,
-      "description": "Wait for search tab content to load"
-    },
-    "verify_search_tab_active": {
-      "type": "element_visible",
-      "element": "search_tab_icon_active",
-      "description": "Verify search tab is now active"
-    },
-    "tap_cart_tab": {
-      "type": "tap",
-      "element": "cart_tab",
-      "description": "Tap on cart tab"
-    },
-    "wait_for_cart_content": {
-      "type": "wait_for_element",
-      "element": "cart_items_list",
-      "timeout_seconds": 3,
-      "description": "Wait for cart tab to load"
-    },
-    "capture_cart_count": {
-      "type": "capture_value",
-      "element": "cart_badge_count",
-      "capture_to": "cart_item_count",
-      "description": "Capture cart item count from badge"
-    },
-    "verify_cart_tab_active": {
-      "type": "element_visible",
-      "element": "cart_tab_icon_active",
-      "description": "Verify cart tab is selected"
-    },
-    "tap_account_tab": {
-      "type": "tap",
-      "element": "account_tab",
-      "description": "Tap on account/profile tab"
-    },
-    "wait_for_account_content": {
-      "type": "wait_for_element",
-      "element": "account_header",
-      "timeout_seconds": 3,
-      "description": "Wait for account tab to load"
-    },
-    "verify_account_tab_active": {
-      "type": "element_visible",
-      "element": "account_tab_icon_active",
-      "description": "Verify account tab is selected"
-    },
-    "tap_home_tab_again": {
-      "type": "tap",
-      "element": "home_tab",
-      "description": "Return to home tab"
-    },
-    "wait_for_home_content_reload": {
-      "type": "wait_for_element",
-      "element": "home_tab_content",
-      "timeout_seconds": 3,
-      "description": "Wait for home tab content to reload"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the shopping application", "target": "com.example.shop" },
+    { "id": "wait_for_home_tab", "action": "wait_for_element", "description": "Wait for the home tab content to load", "target": "home tab content", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "tap_search_tab", "action": "tap", "description": "Tap on the search tab", "target": "search tab" },
+    { "id": "wait_for_search_content", "action": "wait_for_element", "description": "Wait for the search tab content to load", "target": "search bar", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "tap_cart_tab", "action": "tap", "description": "Tap on the cart tab", "target": "cart tab" },
+    { "id": "wait_for_cart_content", "action": "wait_for_element", "description": "Wait for the cart tab to load", "target": "cart items list", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "capture_cart_count", "action": "capture_value", "description": "Capture the cart item count from the badge", "target": "cart badge count", "capture_to": "cart_item_count" },
+    { "id": "tap_account_tab", "action": "tap", "description": "Tap on the account/profile tab", "target": "account tab" },
+    { "id": "wait_for_account_content", "action": "wait_for_element", "description": "Wait for the account tab to load", "target": "account header", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "tap_home_tab_again", "action": "tap", "description": "Return to the home tab", "target": "home tab" },
+    { "id": "wait_for_home_content_reload", "action": "wait_for_element", "description": "Wait for the home tab content to reload", "target": "home tab content", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } }
+  ],
   "assertions": [
-    {
-      "id": "tabbar_visible",
-      "description": "Tab bar is visible at bottom of screen",
-      "type": "element_exists",
-      "element": "bottom_tab_bar"
-    },
-    {
-      "id": "home_tab_loads",
-      "description": "Home tab content displays correctly",
-      "type": "element_exists",
-      "element": "home_tab_content"
-    },
-    {
-      "id": "search_tab_loads",
-      "description": "Search tab content loads with search bar",
-      "type": "element_exists",
-      "element": "search_bar"
-    },
-    {
-      "id": "search_tab_active",
-      "description": "Search tab icon shows active state",
-      "type": "element_exists",
-      "element": "search_tab_icon_active"
-    },
-    {
-      "id": "cart_tab_loads",
-      "description": "Cart tab displays items list",
-      "type": "element_exists",
-      "element": "cart_items_list"
-    },
-    {
-      "id": "cart_badge_visible",
-      "description": "Cart badge displays item count",
-      "type": "element_exists",
-      "element": "cart_badge_count"
-    },
-    {
-      "id": "account_tab_loads",
-      "description": "Account tab displays user profile header",
-      "type": "element_exists",
-      "element": "account_header"
-    },
-    {
-      "id": "home_tab_persists",
-      "description": "Home tab state is maintained after returning",
-      "type": "element_exists",
-      "element": "home_tab_content"
-    },
-    {
-      "id": "no_tab_errors",
-      "description": "No error messages shown during tab switching",
-      "type": "element_not_exists",
-      "element": "error_alert"
-    }
+    { "id": "tabbar_visible", "after_step": "wait_for_home_tab", "type": "element_exists", "description": "Tab bar is visible at the bottom of the screen", "element_description": "bottom tab bar" },
+    { "id": "home_tab_loads", "after_step": "wait_for_home_tab", "type": "element_exists", "description": "Home tab content displays correctly", "element_description": "home tab content" },
+    { "id": "search_tab_loads", "after_step": "wait_for_search_content", "type": "element_exists", "description": "Search tab content loads with the search bar", "element_description": "search bar" },
+    { "id": "cart_tab_loads", "after_step": "wait_for_cart_content", "type": "element_exists", "description": "Cart tab displays the items list", "element_description": "cart items list" },
+    { "id": "cart_badge_visible", "after_step": "capture_cart_count", "type": "element_exists", "description": "Cart badge displays the item count", "element_description": "cart badge count" },
+    { "id": "account_tab_loads", "after_step": "wait_for_account_content", "type": "element_exists", "description": "Account tab displays the user profile header", "element_description": "account header" },
+    { "id": "home_tab_persists", "after_step": "wait_for_home_content_reload", "type": "element_exists", "description": "Home tab state is maintained after returning", "element_description": "home tab content" },
+    { "id": "no_tab_errors", "after_step": "wait_for_home_content_reload", "type": "element_not_exists", "description": "No error messages shown during tab switching", "element_description": "error alert" }
   ]
 }
 ```
@@ -410,135 +185,42 @@ Demonstrates gesture-based screen dismissal using iOS swipe-to-pop navigation ge
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "ios_swipeback_dismissal",
   "name": "Dismiss Screen with Swipe Gesture",
-  "description": "User swipes back to dismiss a detail screen and return to list",
+  "description": "User swipes back to dismiss a detail screen and return to the list",
   "platform": "ios",
   "app_package": "com.example.articles",
-  "metadata": {
-    "app_version": "1.3.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "1.3.0", "environment": "staging" },
   "tags": ["gestures", "navigation", "ios", "swipe"],
   "variables": {
-    "selected_article": {
-      "type": "string",
-      "value": "iOS Development Guide"
-    }
+    "selected_article": { "type": "string", "description": "Title of the article opened during the test", "value": "iOS Development Guide" }
   },
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "launch_app"
-      }
-    ],
-    "device_state": "Logged in on articles list screen"
+    "app_state": "logged_in",
+    "notes": ["User is logged in on the articles list screen"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch articles app"
-    },
-    "wait_for_articles_list": {
-      "type": "wait_for_element",
-      "element": "articles_table_view",
-      "timeout_seconds": 5,
-      "description": "Wait for articles list to load"
-    },
-    "verify_article_visible": {
-      "type": "element_visible",
-      "element": "article_cell_ios_development",
-      "description": "Verify iOS Development article is visible"
-    },
-    "tap_article": {
-      "type": "tap",
-      "element": "article_cell_ios_development",
-      "description": "Tap on iOS Development article"
-    },
-    "wait_for_detail_screen": {
-      "type": "wait_for_element",
-      "element": "article_detail_title",
-      "timeout_seconds": 3,
-      "description": "Wait for article detail screen to load"
-    },
-    "verify_article_loaded": {
-      "type": "element_text",
-      "element": "article_detail_title",
-      "expected_text": "iOS Development Guide",
-      "description": "Verify correct article detail loaded"
-    },
-    "verify_back_button": {
-      "type": "element_visible",
-      "element": "back_button",
-      "description": "Verify back button is visible"
-    },
-    "swipe_back": {
-      "type": "swipe",
-      "direction": "left",
-      "location": "left_edge",
-      "distance": 200,
-      "description": "Swipe from left edge to dismiss detail screen"
-    },
-    "wait_for_list_return": {
-      "type": "wait_for_element",
-      "element": "articles_table_view",
-      "timeout_seconds": 2,
-      "description": "Wait for return to articles list after swipe"
-    },
-    "verify_list_restored": {
-      "type": "element_visible",
-      "element": "article_cell_ios_development",
-      "description": "Verify original article cell is still visible"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the articles app", "target": "com.example.articles" },
+    { "id": "wait_for_articles_list", "action": "wait_for_element", "description": "Wait for the articles list to load", "target": "articles list", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "tap_article", "action": "tap", "description": "Tap on the iOS Development article", "target": "iOS Development Guide article row" },
+    { "id": "wait_for_detail_screen", "action": "wait_for_element", "description": "Wait for the article detail screen to load", "target": "article detail title", "wait_config": { "type": "element_visible", "timeout_ms": 3000 } },
+    { "id": "swipe_back", "action": "swipe", "description": "Swipe from the left edge to the right to dismiss the detail screen", "target": "article detail screen", "value": "right" },
+    { "id": "wait_for_list_return", "action": "wait_for_element", "description": "Wait for the return to the articles list after the swipe", "target": "articles list", "wait_config": { "type": "element_visible", "timeout_ms": 2000 } }
+  ],
   "assertions": [
-    {
-      "id": "articles_list_visible",
-      "description": "Articles list is initially displayed",
-      "type": "element_exists",
-      "element": "articles_table_view"
-    },
-    {
-      "id": "article_cell_tappable",
-      "description": "Article cell is visible and tappable",
-      "type": "element_visible",
-      "element": "article_cell_ios_development"
-    },
-    {
-      "id": "detail_screen_pushed",
-      "description": "Detail screen displays correct article",
-      "type": "element_text",
-      "element": "article_detail_title",
-      "expected_text": "iOS Development Guide"
-    },
-    {
-      "id": "back_navigation_available",
-      "description": "Back button or swipe gesture available",
-      "type": "element_exists",
-      "element": "back_button"
-    },
-    {
-      "id": "swipe_gesture_responsive",
-      "description": "Swipe gesture responds to user interaction",
-      "type": "screen_title",
-      "expected_text": "Articles"
-    },
-    {
-      "id": "list_state_maintained",
-      "description": "List returns to same state after swipe",
-      "type": "element_exists",
-      "element": "articles_table_view"
-    },
-    {
-      "id": "no_animation_glitch",
-      "description": "Transition animation completes without errors",
-      "type": "element_not_exists",
-      "element": "error_overlay"
-    }
+    { "id": "articles_list_visible", "after_step": "wait_for_articles_list", "type": "element_exists", "description": "Articles list is initially displayed", "element_description": "articles list" },
+    { "id": "article_cell_tappable", "after_step": "wait_for_articles_list", "type": "element_visible", "description": "Article cell is visible and tappable", "element_description": "iOS Development Guide article row", "expected_visible": true },
+    { "id": "detail_screen_pushed", "after_step": "wait_for_detail_screen", "type": "element_text", "description": "Detail screen displays the correct article", "element_description": "article detail title", "expected_value": "iOS Development Guide" },
+    { "id": "back_navigation_available", "after_step": "wait_for_detail_screen", "type": "element_exists", "description": "Back button or swipe gesture is available", "element_description": "back button" },
+    { "id": "swipe_returns_to_list", "after_step": "wait_for_list_return", "type": "screen_title", "description": "Swipe gesture returns the user to the articles screen", "expected_text": "Articles" },
+    { "id": "list_state_maintained", "after_step": "wait_for_list_return", "type": "element_exists", "description": "List returns to the same state after the swipe", "element_description": "articles list" },
+    { "id": "no_animation_glitch", "after_step": "wait_for_list_return", "type": "element_not_exists", "description": "Transition completes without an error overlay", "element_description": "error overlay" }
   ]
 }
 ```
+
+> **Cross-platform tip:** This example targets iOS with a raw left-to-right swipe. In a `platform-agnostic` scenario you would instead use the `press_back` semantic action, which resolves to a left-edge pop swipe on iOS and the BACK button on Android — one step, both platforms.
 
 ### What This Tests
 
@@ -575,137 +257,41 @@ Demonstrates UIAlertController handling, including different button actions and 
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "ios_alert_confirmation",
   "name": "Handle Alert Dialog and Confirm Action",
-  "description": "User sees confirmation alert and taps to confirm destructive action",
+  "description": "User sees a confirmation alert and taps to confirm a destructive action",
   "platform": "ios",
   "app_package": "com.example.todo",
-  "metadata": {
-    "app_version": "2.0.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "2.0.0", "environment": "staging" },
   "tags": ["alerts", "dialogs", "ios", "confirmation"],
   "variables": {
-    "todo_item": {
-      "type": "string",
-      "value": "Complete project setup"
-    }
+    "todo_item": { "type": "string", "description": "Title of the todo item targeted for deletion", "value": "Complete project setup" }
   },
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "launch_app"
-      }
-    ],
-    "device_state": "On todo list with items"
+    "app_state": "logged_in",
+    "notes": ["Start on the todo list with at least one item"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch todo app"
-    },
-    "wait_for_todo_list": {
-      "type": "wait_for_element",
-      "element": "todos_table_view",
-      "timeout_seconds": 5,
-      "description": "Wait for todo list to load"
-    },
-    "find_todo_item": {
-      "type": "scroll_to_element",
-      "element": "todos_table_view",
-      "target_element": "todo_cell_setup",
-      "timeout_seconds": 5,
-      "description": "Scroll to find specific todo item"
-    },
-    "long_press_todo": {
-      "type": "long_press",
-      "element": "todo_cell_setup",
-      "duration": 1000,
-      "description": "Long press on todo item to show options menu"
-    },
-    "wait_for_action_sheet": {
-      "type": "wait_for_element",
-      "element": "action_sheet_title",
-      "timeout_seconds": 2,
-      "description": "Wait for action sheet to appear"
-    },
-    "tap_delete_option": {
-      "type": "tap",
-      "element": "action_sheet_delete_button",
-      "description": "Tap delete option in action sheet"
-    },
-    "wait_for_confirmation_alert": {
-      "type": "wait_for_element",
-      "element": "confirmation_alert_title",
-      "timeout_seconds": 2,
-      "description": "Wait for delete confirmation alert"
-    },
-    "verify_alert_message": {
-      "type": "alert_text",
-      "message": "Are you sure you want to delete this item?",
-      "description": "Verify confirmation message text"
-    },
-    "tap_confirm_delete": {
-      "type": "tap",
-      "element": "alert_delete_button",
-      "description": "Tap confirm button to delete item"
-    },
-    "wait_for_deletion": {
-      "type": "wait_for_element_gone",
-      "element": "todo_cell_setup",
-      "timeout_seconds": 2,
-      "description": "Wait for item to be removed from list"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the todo app", "target": "com.example.todo" },
+    { "id": "wait_for_todo_list", "action": "wait_for_element", "description": "Wait for the todo list to load", "target": "todos list", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "find_todo_item", "action": "scroll_to_element", "description": "Scroll to find the specific todo item", "target": "Complete project setup todo row", "value": "down" },
+    { "id": "long_press_todo", "action": "long_press", "description": "Long press on the todo item to show the options menu", "target": "Complete project setup todo row" },
+    { "id": "wait_for_action_sheet", "action": "wait_for_element", "description": "Wait for the action sheet to appear", "target": "action sheet", "wait_config": { "type": "element_visible", "timeout_ms": 2000 } },
+    { "id": "tap_delete_option", "action": "tap", "description": "Tap the delete option in the action sheet", "target": "action sheet delete button" },
+    { "id": "wait_for_confirmation_alert", "action": "wait_for_element", "description": "Wait for the delete confirmation alert", "target": "confirmation alert", "wait_config": { "type": "element_visible", "timeout_ms": 2000 } },
+    { "id": "tap_confirm_delete", "action": "tap", "description": "Tap the confirm button to delete the item", "target": "alert delete button" },
+    { "id": "wait_for_deletion", "action": "wait_for_element_gone", "description": "Wait for the item to be removed from the list", "target": "Complete project setup todo row", "wait_config": { "type": "element_gone", "timeout_ms": 2000 } }
+  ],
   "assertions": [
-    {
-      "id": "list_displayed",
-      "description": "Todo list is displayed",
-      "type": "element_exists",
-      "element": "todos_table_view"
-    },
-    {
-      "id": "item_found",
-      "description": "Todo item is visible in list",
-      "type": "element_exists",
-      "element": "todo_cell_setup"
-    },
-    {
-      "id": "action_sheet_shown",
-      "description": "Action sheet appears after long press",
-      "type": "element_exists",
-      "element": "action_sheet_title"
-    },
-    {
-      "id": "delete_option_available",
-      "description": "Delete option is visible in action sheet",
-      "type": "element_visible",
-      "element": "action_sheet_delete_button"
-    },
-    {
-      "id": "alert_presented",
-      "description": "Confirmation alert is presented",
-      "type": "alert_present"
-    },
-    {
-      "id": "alert_message_correct",
-      "description": "Alert message is correct",
-      "type": "alert_text",
-      "message": "Are you sure you want to delete this item?"
-    },
-    {
-      "id": "delete_confirmed",
-      "description": "Item is deleted after confirmation",
-      "type": "element_not_exists",
-      "element": "todo_cell_setup"
-    },
-    {
-      "id": "no_errors",
-      "description": "No error messages displayed",
-      "type": "element_not_exists",
-      "element": "error_alert"
-    }
+    { "id": "list_displayed", "after_step": "wait_for_todo_list", "type": "element_exists", "description": "Todo list is displayed", "element_description": "todos list" },
+    { "id": "item_found", "after_step": "find_todo_item", "type": "element_exists", "description": "Todo item is visible in the list", "element_description": "Complete project setup todo row" },
+    { "id": "action_sheet_shown", "after_step": "wait_for_action_sheet", "type": "element_exists", "description": "Action sheet appears after the long press", "element_description": "action sheet" },
+    { "id": "delete_option_available", "after_step": "wait_for_action_sheet", "type": "element_visible", "description": "Delete option is visible in the action sheet", "element_description": "action sheet delete button", "expected_visible": true },
+    { "id": "alert_presented", "after_step": "wait_for_confirmation_alert", "type": "alert_present", "description": "Confirmation alert is presented" },
+    { "id": "alert_message_correct", "after_step": "wait_for_confirmation_alert", "type": "alert_text", "description": "Alert message is correct", "expected_text": "Are you sure you want to delete this item?" },
+    { "id": "delete_confirmed", "after_step": "wait_for_deletion", "type": "element_not_exists", "description": "Item is deleted after confirmation", "element_description": "Complete project setup todo row" },
+    { "id": "no_errors", "after_step": "wait_for_deletion", "type": "element_not_exists", "description": "No error messages displayed", "element_description": "error alert" }
   ]
 }
 ```
@@ -745,137 +331,43 @@ Demonstrates handling background tasks and silent notifications during app usage
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "ios_background_sync",
   "name": "Handle Background Sync and Data Update",
-  "description": "App syncs data in background and user sees updated content on return to foreground",
+  "description": "App syncs data in the background and the user sees updated content on return to the foreground",
   "platform": "ios",
   "app_package": "com.example.messages",
-  "metadata": {
-    "app_version": "3.1.0",
-    "environment": "staging"
-  },
+  "metadata": { "app_version": "3.1.0", "environment": "staging" },
   "tags": ["background", "sync", "notifications", "ios"],
   "variables": {
-    "message_count_before": {
-      "type": "number"
-    },
-    "message_count_after": {
-      "type": "number"
-    },
-    "sync_timestamp": {
-      "type": "string"
-    }
+    "message_count_before": { "type": "number", "description": "Message count captured before backgrounding the app" },
+    "message_count_after": { "type": "number", "description": "Message count captured after the background sync" },
+    "sync_timestamp": { "type": "string", "description": "Last sync timestamp captured after returning to the foreground" }
   },
   "preconditions": {
-    "setup_actions": [
-      {
-        "type": "launch_app"
-      }
-    ],
-    "device_state": "Logged in on messages screen"
+    "app_state": "logged_in",
+    "notes": ["User is logged in on the messages screen"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app",
-      "description": "Launch messages app"
-    },
-    "wait_for_messages_load": {
-      "type": "wait_for_element",
-      "element": "messages_list",
-      "timeout_seconds": 5,
-      "description": "Wait for messages list to load"
-    },
-    "capture_initial_count": {
-      "type": "capture_value",
-      "element": "message_count_badge",
-      "capture_to": "message_count_before",
-      "description": "Capture initial message count"
-    },
-    "wait_for_sync_indicator": {
-      "type": "wait_for_element",
-      "element": "sync_indicator",
-      "timeout_seconds": 2,
-      "optional": true,
-      "description": "Wait for sync indicator if present"
-    },
-    "press_home_button": {
-      "type": "press_button",
-      "button": "HOME",
-      "description": "Press home button to background app"
-    },
-    "wait_background_time": {
-      "type": "wait_for_loading_complete",
-      "timeout_seconds": 5,
-      "description": "Allow time for background sync to occur"
-    },
-    "relaunch_app": {
-      "type": "launch_app",
-      "description": "Relaunch app from background"
-    },
-    "wait_for_list_reload": {
-      "type": "wait_for_element",
-      "element": "messages_list",
-      "timeout_seconds": 5,
-      "description": "Wait for messages list to load after relaunch"
-    },
-    "capture_updated_count": {
-      "type": "capture_value",
-      "element": "message_count_badge",
-      "capture_to": "message_count_after",
-      "description": "Capture updated message count"
-    },
-    "capture_sync_time": {
-      "type": "capture_value",
-      "element": "last_sync_timestamp",
-      "capture_to": "sync_timestamp",
-      "description": "Capture last sync timestamp"
-    }
-  },
+  "steps": [
+    { "id": "launch_app", "action": "launch_app", "description": "Launch the messages app", "target": "com.example.messages" },
+    { "id": "wait_for_messages_load", "action": "wait_for_element", "description": "Wait for the messages list to load", "target": "messages list", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "capture_initial_count", "action": "capture_value", "description": "Capture the initial message count", "target": "message count badge", "capture_to": "message_count_before" },
+    { "id": "wait_for_sync_indicator", "action": "wait_for_element", "description": "Wait for the sync indicator if it is present", "target": "sync indicator", "optional": true, "wait_config": { "type": "element_visible", "timeout_ms": 2000 } },
+    { "id": "press_home_button", "action": "press_button", "description": "Press the home button to background the app", "value": "HOME" },
+    { "id": "wait_background_time", "action": "wait_for_loading_complete", "description": "Allow time for the background sync to occur", "wait_config": { "type": "loading_complete", "timeout_ms": 5000 } },
+    { "id": "relaunch_app", "action": "launch_app", "description": "Relaunch the app from the background", "target": "com.example.messages" },
+    { "id": "wait_for_list_reload", "action": "wait_for_element", "description": "Wait for the messages list to load after relaunch", "target": "messages list", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } },
+    { "id": "capture_updated_count", "action": "capture_value", "description": "Capture the updated message count", "target": "message count badge", "capture_to": "message_count_after" },
+    { "id": "capture_sync_time", "action": "capture_value", "description": "Capture the last sync timestamp", "target": "last sync timestamp", "capture_to": "sync_timestamp" }
+  ],
   "assertions": [
-    {
-      "id": "messages_load_initially",
-      "description": "Messages list loads on app launch",
-      "type": "element_exists",
-      "element": "messages_list"
-    },
-    {
-      "id": "message_count_visible",
-      "description": "Message count badge is displayed",
-      "type": "element_exists",
-      "element": "message_count_badge"
-    },
-    {
-      "id": "app_returns_from_background",
-      "description": "App returns from background state",
-      "type": "element_exists",
-      "element": "messages_list"
-    },
-    {
-      "id": "list_reloaded",
-      "description": "Messages list is reloaded after returning from background",
-      "type": "element_exists",
-      "element": "messages_list"
-    },
-    {
-      "id": "sync_occurred",
-      "description": "Background sync occurred (timestamp updated)",
-      "type": "element_exists",
-      "element": "last_sync_timestamp"
-    },
-    {
-      "id": "content_updated",
-      "description": "New messages appear after sync",
-      "type": "value_matches_variable",
-      "element": "message_count_badge",
-      "variable": "message_count_after"
-    },
-    {
-      "id": "no_sync_error",
-      "description": "No error message during sync",
-      "type": "element_not_exists",
-      "element": "sync_error_banner"
-    }
+    { "id": "messages_load_initially", "after_step": "wait_for_messages_load", "type": "element_exists", "description": "Messages list loads on app launch", "element_description": "messages list" },
+    { "id": "message_count_visible", "after_step": "capture_initial_count", "type": "element_exists", "description": "Message count badge is displayed", "element_description": "message count badge" },
+    { "id": "app_returns_from_background", "after_step": "wait_for_list_reload", "type": "element_exists", "description": "App returns from the background state", "element_description": "messages list" },
+    { "id": "list_reloaded", "after_step": "wait_for_list_reload", "type": "element_exists", "description": "Messages list is reloaded after returning from the background", "element_description": "messages list" },
+    { "id": "sync_occurred", "after_step": "capture_sync_time", "type": "element_exists", "description": "Background sync occurred (timestamp updated)", "element_description": "last sync timestamp" },
+    { "id": "content_updated", "after_step": "capture_updated_count", "type": "value_matches_variable", "description": "New message count matches the captured post-sync value", "element_description": "message count badge", "variable_name": "message_count_after" },
+    { "id": "no_sync_error", "after_step": "wait_for_list_reload", "type": "element_not_exists", "description": "No error message during sync", "element_description": "sync error banner" }
   ]
 }
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -92,6 +92,31 @@ The chosen mode is stored as `mode` in `mobile-automator/config.json` (read it b
 
 **Answer:** Every test scenario JSON file includes a `$schema_version` field (currently `"2.1"`) as its first field. This enables version detection for schema evolution. All scenarios must include this field.
 
+### Does the agent remember anything between sessions?
+
+**Answer:** Yes. mobile-automator keeps a small **cross-session memory** under `mobile-automator/memory/`, so the agent gets smarter about *your* app over time instead of re-discovering the same quirks on every run. There are three kinds:
+
+- **`run-history`** (`run-history.md`) — **machine-owned**. Auto-harvested on `mauto result finalize`: typed observations (regression / flakiness / state context) are folded into a bounded rolling per-scenario summary. You don't edit this by hand.
+- **`app-knowledge`** (`app-knowledge.md`) — **agent-authored** durable facts about the app (selectors, conventions, gotchas).
+- **`preferences`** (`preferences.md`) — **agent-authored** testing preferences.
+
+Inspect memory (prints raw markdown, not the JSON envelope):
+
+```bash
+mauto memory show                              # everything
+mauto memory show --kind app-knowledge         # one kind
+mauto memory show --kind run-history --scenario login_happy_path
+```
+
+Add or remove agent-authored entries (only `app-knowledge` and `preferences` are writable — `run-history` is not):
+
+```bash
+mauto memory add "Login button is labeled 'Sign in', not 'Log in'" --kind app-knowledge
+mauto memory forget --kind app-knowledge --match "Sign in"
+```
+
+Entries are exact-match de-duped and written under an advisory lock with atomic writes, so concurrent runs won't corrupt the files. The generate and execute workflows consult memory before work and save durable knowledge they learn.
+
 ### Can I use mobile-automator with my existing tests?
 
 **Answer:** Partially. If you have:
@@ -261,20 +286,24 @@ In **platform-aware** mode, generate a scenario on each platform separately and 
   "variables": {
     "test_email": {
       "type": "string",
+      "description": "Email used to log in",
       "value": "user@example.com"
     },
     "test_password": {
       "type": "string",
+      "description": "Password used to log in",
       "value": "SecurePassword123"
     }
   },
-  "steps": {
-    "enter_email": {
-      "type": "type",
-      "element": "email_input",
-      "text": "{{test_email}}"
+  "steps": [
+    {
+      "id": "enter_email",
+      "action": "type",
+      "target": "email_input",
+      "value": "{{test_email}}",
+      "description": "Type the test email into the email field"
     }
-  }
+  ]
 }
 ```
 
@@ -308,11 +337,15 @@ Results saved to: `mobile-automator/results/<run_id>.json`
 1. **Add explicit wait** — Insert a wait step before the action:
    ```json
    {
-     "wait_for_element": {
-       "type": "wait_for_element",
-       "element": "button_id",
-       "timeout_seconds": 5
-     }
+     "steps": [
+       {
+         "id": "wait_for_button",
+         "action": "wait_for_element",
+         "target": "button_id",
+         "description": "Wait for the button to appear",
+         "wait_config": { "type": "element_visible", "timeout_ms": 5000 }
+       }
+     ]
    }
    ```
 
@@ -322,10 +355,15 @@ Results saved to: `mobile-automator/results/<run_id>.json`
 5. **Add screenshot assertion** — Debug what's actually on screen:
    ```json
    {
-     "verify_screen": {
-       "type": "screenshot_match",
-       "reference_file": "expected_screen.png"
-     }
+     "assertions": [
+       {
+         "id": "verify_screen",
+         "after_step": "wait_for_button",
+         "type": "screenshot_match",
+         "reference_screenshot": "expected_screen.png",
+         "description": "Screen matches the expected baseline"
+       }
+     ]
    }
    ```
 
@@ -334,17 +372,21 @@ Results saved to: `mobile-automator/results/<run_id>.json`
 **Cause:** Assertion condition wasn't met during test.
 
 **Solutions:**
-1. **Check assertion syntax** — Verify `expected_text`, `expected_exact`, `expected_substring`
+1. **Check assertion syntax** — Verify `expected_text`, `expected_value`, `expected_substring`
 2. **Verify actual app data** — Manually check what value is displayed
 3. **Handle dynamic content** — If value changes, use `text_contains` instead of `text_matches`
 4. **Add debug screenshot** — Insert a capture step to see actual state:
    ```json
    {
-     "capture_state": {
-       "type": "capture_value",
-       "element": "title",
-       "capture_to": "actual_title"
-     }
+     "steps": [
+       {
+         "id": "capture_state",
+         "action": "capture_value",
+         "target": "title",
+         "capture_to": "actual_title",
+         "description": "Capture the current title"
+       }
+     ]
    }
    ```
 
@@ -356,8 +398,10 @@ Results saved to: `mobile-automator/results/<run_id>.json`
 1. **Increase timeout** — Default is 10s, try 15-30s:
    ```json
    {
-     "type": "wait_for_loading_complete",
-     "timeout_seconds": 30
+     "id": "wait_for_loading",
+     "action": "wait_for_loading_complete",
+     "description": "Wait for loading to complete",
+     "wait_config": { "type": "loading_complete", "timeout_ms": 30000 }
    }
    ```
 
@@ -372,10 +416,14 @@ Results saved to: `mobile-automator/results/<run_id>.json`
 4. **Add intermediate waits** — Between rapid actions:
    ```json
    {
-     "wait_before_next": {
-       "type": "wait_for_loading_complete",
-       "timeout_seconds": 2
-     }
+     "steps": [
+       {
+         "id": "wait_before_next",
+         "action": "wait_for_loading_complete",
+         "description": "Brief wait before the next action",
+         "wait_config": { "type": "loading_complete", "timeout_ms": 2000 }
+       }
+     ]
    }
    ```
 
@@ -515,7 +563,7 @@ jobs:
 
 **Answer:** Test execution speed depends on app, network, and device:
 
-1. **Reduce waits** — Use shorter timeouts for fast-responding apps (e.g., `"timeout_seconds": 3` instead of 10)
+1. **Reduce waits** — Use shorter wait timeouts for fast-responding apps (e.g., `wait_config.timeout_ms` of `3000` instead of `10000`)
 2. **Remove unnecessary assertions** — Only assert critical checks
 3. **Optimize element selection** — Use unique, visible targets
 4. **Test on faster device** — High-end device > low-end device
@@ -546,8 +594,8 @@ jobs:
    ```json
    {
      "preconditions": {
-       "setup_actions": [
-         {"type": "clear_app_data"}
+       "device_actions": [
+         {"action": "clear_app_data"}
        ]
      }
    }
@@ -592,6 +640,28 @@ Pin a specific device once it appears:
 ```bash
 mauto devices use <id>     # mauto devices clear to unpin
 ```
+
+### Device state seems stuck or stale
+
+**Cause:** Device actions run through one long-lived session daemon (a persistent mobile-mcp process). If it wedged — verbs hang, target the wrong device, or return stale screen state — reset it.
+
+**Solutions:**
+```bash
+# Check whether the daemon is alive
+mauto session status        # -> { running: true|false }
+
+# Stop it (removes the socket/pidfile); it auto-restarts on the next device verb
+mauto session end
+
+# Optionally start a fresh one explicitly
+mauto session start
+
+# Re-confirm and re-pin the device
+mauto devices               # list connected devices/simulators
+mauto devices use <id>      # pin the intended one (mauto devices clear to unpin)
+```
+
+Device precedence is: explicit `--device <id>` > persisted selection (`mauto devices use`) > auto-selected lone device. If you have several devices attached and haven't pinned one, pin it to avoid the daemon acting on the wrong target.
 
 ### App Installation Failures
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -6,7 +6,7 @@ description: "Run your first mobile test in 5 minutes - from setup to test gener
 
 Get mobile-automator working in 5 minutes with a real test scenario.
 
-This quick start uses **Claude Code** as the example agent. For Cursor, swap `--agent claude` → `--agent cursor`. For any other agent, see [Using another agent](#using-another-agent).
+This quick start uses **Claude Code** as the example agent. For Cursor, swap `--agent claude` → `--agent cursor`. For any other agent, see [Using another agent](installation.md#using-another-agent).
 
 ## Prerequisites
 

--- a/docs/guides/execute.md
+++ b/docs/guides/execute.md
@@ -82,7 +82,7 @@ When you start execution, the agent verifies:
 
 ### Phase 1: Setup
 
-Before test execution begins:
+Before test execution begins, the agent reads cross-session memory (`mauto memory show`) to pull in prior run history, app-knowledge, and preferences — known flaky screens, waits, and conventions for this app inform how it runs and interprets the scenario.
 
 1. **Clear previous runs** (optional)
    - Ask: "Clear app data before test? (y/n)"
@@ -184,7 +184,7 @@ For each assertion in your scenario:
 {
   "type": "element_text",
   "element": "welcome_message",
-  "expected_exact": "Welcome back!",
+  "expected_text": "Welcome back!",
   "actual": "Welcome back!",
   "result": "passed"
 }
@@ -194,7 +194,7 @@ For each assertion in your scenario:
 {
   "type": "text_contains",
   "element": "error_message",
-  "expected_contains": "timeout",
+  "expected_substring": "timeout",
   "actual": "Network timeout occurred",
   "result": "passed"
 }
@@ -224,6 +224,10 @@ After all steps execute:
 4. **Create result file**
    - Saved to `mobile-automator/results/run_*.json`
    - Ready for analysis
+
+5. **Harvest memory** (automatic)
+   - On `result finalize`, the typed observations (regression / flakiness / state_context) are folded into a bounded rolling per-scenario aggregate in `mobile-automator/memory/run-history.md`, so future runs carry forward what earlier runs learned.
+   - This is best-effort: a memory-write failure never fails an otherwise-successful finalize — it is reported in the envelope `hint` instead.
 
 ---
 
@@ -323,7 +327,7 @@ After all steps execute:
       "severity": "medium",
       "message": "Step 4 failed initially (timeout), passed on retry after 2s wait",
       "affected_step": "wait_for_product_list",
-      "suggestion": "Add retry_policy or increase timeout_seconds"
+      "suggestion": "Add a retry_policy or increase the wait timeout (wait_config.timeout_ms)"
     },
     {
       "type": "regression",
@@ -387,11 +391,14 @@ If a step has a retry policy configured:
 
 ```json
 {
-  "type": "wait_for_element",
-  "element": "product_list",
+  "id": "wait_for_product_list",
+  "action": "wait_for_element",
+  "target": "product_list",
+  "description": "Wait for the product list to load",
+  "on_failure": "retry",
   "retry_policy": {
-    "max_retries": 3,
-    "wait_between_retries_ms": 2000
+    "max_attempts": 3,
+    "backoff_ms": 2000
   }
 }
 ```
@@ -432,12 +439,17 @@ For steps with timeouts (waits, element verification):
 
 **Customizing timeouts:**
 
-Edit scenario JSON:
+Edit scenario JSON (increase the wait timeout from the default 10s to 30s):
 ```json
 {
-  "type": "wait_for_element",
-  "element": "data_grid",
-  "timeout_seconds": 30  ← Increase from default 10s
+  "id": "wait_for_data_grid",
+  "action": "wait_for_element",
+  "target": "data_grid",
+  "description": "Wait for the data grid to load",
+  "wait_config": {
+    "type": "element_visible",
+    "timeout_ms": 30000
+  }
 }
 ```
 
@@ -482,22 +494,32 @@ mobile-automator/results/
 1. **Add explicit wait before action:**
    ```json
    {
-     "type": "wait_for_element",
-     "element": "target_element",
-     "timeout_seconds": 10
+     "id": "wait_for_target",
+     "action": "wait_for_element",
+     "target": "target_element",
+     "description": "Wait for the target element to appear",
+     "wait_config": {
+       "type": "element_visible",
+       "timeout_ms": 10000
+     }
    },
    {
-     "type": "tap",
-     "element": "target_element"
+     "id": "tap_target",
+     "action": "tap",
+     "target": "target_element",
+     "description": "Tap the target element"
    }
    ```
 
 2. **Add retry policy:**
    ```json
    {
-     "type": "tap",
-     "element": "target_element",
-     "retry_policy": {"max_retries": 3, "wait_between_retries_ms": 2000}
+     "id": "tap_target",
+     "action": "tap",
+     "target": "target_element",
+     "description": "Tap the target element, retrying on failure",
+     "on_failure": "retry",
+     "retry_policy": {"max_attempts": 3, "backoff_ms": 2000}
    }
    ```
 
@@ -515,14 +537,22 @@ mobile-automator/results/
 3. **Use text_contains instead of element_text** — More forgiving
 4. **Capture and compare variables** — For dynamic values:
    ```json
+   // step: capture the dynamic value
    {
-     "type": "capture_value",
-     "element": "dynamic_field",
-     "capture_to": "actual_value"
-   },
+     "id": "capture_dynamic_field",
+     "action": "capture_value",
+     "target": "dynamic_field",
+     "capture_to": "actual_value",
+     "description": "Capture the dynamic field value"
+   }
+   // assertion: compare a later element against the captured value
    {
+     "id": "check_dynamic_field",
+     "after_step": "capture_dynamic_field",
      "type": "value_matches_variable",
-     "variable": "actual_value"
+     "element_description": "dynamic_field",
+     "variable_name": "actual_value",
+     "description": "Field value matches the captured variable"
    }
    ```
 
@@ -534,8 +564,13 @@ mobile-automator/results/
 1. **Increase timeout:**
    ```json
    {
-     "type": "wait_for_loading_complete",
-     "timeout_seconds": 60  ← Increase from default
+     "id": "wait_for_loading",
+     "action": "wait_for_loading_complete",
+     "description": "Wait for loading to complete (increased from the default)",
+     "wait_config": {
+       "type": "loading_complete",
+       "timeout_ms": 60000
+     }
    }
    ```
 
@@ -546,19 +581,31 @@ mobile-automator/results/
 4. **Add intermediate waits** — Break long operations into steps:
    ```json
    {
-     "type": "wait_for_element",
-     "element": "loading_bar",
-     "timeout_seconds": 5
+     "id": "wait_for_loading_bar",
+     "action": "wait_for_element",
+     "target": "loading_bar",
+     "description": "Wait for the loading bar to appear",
+     "wait_config": {
+       "type": "element_visible",
+       "timeout_ms": 5000
+     }
    },
    {
-     "type": "wait_for_element",
-     "element": "loading_bar",
-     "optional": true  ← May disappear
+     "id": "loading_bar_optional",
+     "action": "wait_for_element",
+     "target": "loading_bar",
+     "description": "Loading bar may still be visible",
+     "optional": true
    },
    {
-     "type": "wait_for_element",
-     "element": "content",
-     "timeout_seconds": 10
+     "id": "wait_for_content",
+     "action": "wait_for_element",
+     "target": "content",
+     "description": "Wait for the content to load",
+     "wait_config": {
+       "type": "element_visible",
+       "timeout_ms": 10000
+     }
    }
    ```
 
@@ -570,12 +617,14 @@ mobile-automator/results/
 1. **Check result file** — `mobile-automator/results/run_*.json` shows which step caused crash
 2. **Review app logs** — use your platform's logging tools (Android logcat, Xcode debugger for iOS)
 3. **Check if known issue** — May be app bug, not test issue
-4. **Add preconditions** — Clear app data before test:
+4. **Add preconditions** — Start from a fresh state before the test:
    ```json
    {
      "preconditions": {
-       "clear_app_data": true,
-       "restart_app": true
+       "app_state": "fresh_install",
+       "device_actions": [
+         { "action": "clear_app_data", "target_package": "com.example.myapp" }
+       ]
      }
    }
    ```
@@ -665,9 +714,11 @@ mobile-automator/results/
 
 ```json
 {
+  "id": "assert_welcome",
+  "after_step": "login",
   "type": "element_text",
-  "element": "welcome_message",
-  "expected_exact": "Welcome back, John!",
+  "element_description": "welcome_message",
+  "expected_value": "Welcome back, John!",
   "description": "User is greeted by name after login"
 }
 ```
@@ -676,23 +727,33 @@ mobile-automator/results/
 
 ```json
 {
-  "type": "wait_for_loading_complete",
-  "retry_policy": {"max_retries": 3, "wait_between_retries_ms": 2000}
+  "id": "wait_for_loading",
+  "action": "wait_for_loading_complete",
+  "description": "Wait for loading to complete, retrying on failure",
+  "on_failure": "retry",
+  "retry_policy": {"max_attempts": 3, "backoff_ms": 2000}
 }
 ```
 
 ### ✅ DO: Capture Dynamic Values
 
 ```json
+// step: capture the order ID
 {
-  "type": "capture_value",
-  "element": "order_id",
-  "capture_to": "generated_order_id"
-},
+  "id": "capture_order_id",
+  "action": "capture_value",
+  "target": "order_id",
+  "capture_to": "generated_order_id",
+  "description": "Capture the generated order ID"
+}
+// assertion: confirmation text contains the captured order ID
 {
-  "type": "element_text",
-  "element": "confirmation_text",
-  "expected_contains": "Order captured_to {{generated_order_id}}"
+  "id": "confirm_order_id",
+  "after_step": "capture_order_id",
+  "type": "text_contains",
+  "element_description": "confirmation_text",
+  "expected_substring": "Order {{generated_order_id}}",
+  "description": "Confirmation text includes the captured order ID"
 }
 ```
 
@@ -701,14 +762,18 @@ mobile-automator/results/
 ```json
 // Bad
 {
-  "type": "wait_for_element",  // Uses hardcoded timeout
-  "element": "data",
-  "timeout_seconds": 3
+  "id": "wait_for_data",
+  "action": "wait_for_element",  // Uses a hardcoded timeout
+  "target": "data",
+  "description": "Wait for the data element",
+  "wait_config": { "type": "element_visible", "timeout_ms": 3000 }
 }
 
 // Good
 {
-  "type": "wait_for_loading_complete"  // Waits for actual loading
+  "id": "wait_for_loading",
+  "action": "wait_for_loading_complete",  // Waits for actual loading
+  "description": "Wait for loading to complete"
 }
 ```
 
@@ -717,14 +782,20 @@ mobile-automator/results/
 ```json
 // Bad
 {
+  "id": "assert_pixel_perfect",
+  "after_step": "load_screen",
   "type": "screenshot_match",
-  "reference": "pixel_perfect_baseline.png"  // Too strict
+  "reference_screenshot": "pixel_perfect_baseline.png",  // Too strict
+  "description": "Screen matches a pixel-perfect baseline"
 }
 
 // Good
 {
+  "id": "assert_success",
+  "after_step": "load_screen",
   "type": "element_exists",
-  "element": "success_message"  // Functional assertion
+  "element_description": "success_message",  // Functional assertion
+  "description": "Success message is present"
 }
 ```
 

--- a/docs/guides/generate.md
+++ b/docs/guides/generate.md
@@ -72,6 +72,21 @@ If app isn't installed, generator offers to build and install it.
 
 ## The Generation Workflow
 
+### Step 0: Consult cross-session memory
+
+Before authoring, the agent reads what it already knows about this app:
+
+```bash
+mauto memory show
+```
+
+This surfaces prior run history, app-knowledge, and preferences — so it can reuse known selectors, waits, and conventions instead of re-discovering them. As it learns durable facts during generation (a reliable element reference, a project convention, a flaky screen to guard), it records them for next time:
+
+```bash
+mauto memory add "Login screen shows a shimmer loader; wait for it to clear" --kind app-knowledge
+mauto memory add "Prefer semantic waits over fixed delays" --kind preferences
+```
+
 ### Step 1: Natural Language Input
 
 The generator prompts you to describe your test in plain English:
@@ -182,7 +197,7 @@ The generator creates a scenario JSON file with all information:
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "login_happy_path",
   "name": "User Login - Happy Path",
   "description": "User can log in with valid credentials and see home screen",
@@ -192,49 +207,59 @@ The generator creates a scenario JSON file with all information:
     "app_version": "1.2.3",
     "environment": "staging"
   },
-  "steps": {
-    "tap_login_button": {
-      "type": "tap",
-      "element": "login_button",
-      "coordinates": [200, 400]
+  "steps": [
+    {
+      "id": "tap_login_button",
+      "action": "tap",
+      "description": "Open the login form",
+      "target": "Login button"
     },
-    "enter_email": {
-      "type": "type",
-      "element": "email_field",
-      "text": "user@example.com"
+    {
+      "id": "enter_email",
+      "action": "type",
+      "description": "Enter the account email",
+      "target": "Email field",
+      "value": "user@example.com"
     },
-    "enter_password": {
-      "type": "type",
-      "element": "password_field",
-      "text": "password123"
+    {
+      "id": "enter_password",
+      "action": "type",
+      "description": "Enter the account password",
+      "target": "Password field",
+      "value": "password123"
     },
-    "tap_signin": {
-      "type": "tap",
-      "element": "signin_button"
+    {
+      "id": "tap_signin",
+      "action": "tap",
+      "description": "Submit the login form",
+      "target": "Sign in button"
     },
-    "wait_loading": {
-      "type": "wait_for_loading_complete",
-      "timeout_seconds": 10
-    },
-    "verify_welcome": {
-      "type": "element_text",
-      "element": "home_title",
-      "expected_exact": "Welcome back!"
+    {
+      "id": "wait_loading",
+      "action": "wait_for_loading_complete",
+      "description": "Wait for the login spinner to clear",
+      "wait_config": {
+        "type": "loading_complete",
+        "indicator": "spinner",
+        "timeout_ms": 10000
+      }
     }
-  },
+  ],
   "assertions": [
     {
       "id": "login_button_exists",
-      "description": "Login button is visible on startup",
+      "after_step": "tap_login_button",
       "type": "element_exists",
-      "element": "login_button"
+      "description": "Login button is visible on startup",
+      "element_description": "Login button"
     },
     {
       "id": "home_screen_title",
-      "description": "Home screen shows correct greeting",
+      "after_step": "wait_loading",
       "type": "element_text",
-      "element": "home_title",
-      "expected_exact": "Welcome back!"
+      "description": "Home screen shows correct greeting",
+      "element_description": "Home screen title",
+      "expected_text": "Welcome back!"
     }
   ]
 }
@@ -282,20 +307,29 @@ Generator creates:
       "description": "User ID from welcome message"
     }
   },
-  "steps": {
-    "capture_user_id": {
-      "type": "capture_value",
-      "element": "welcome_message",
+  "steps": [
+    {
+      "id": "capture_user_id",
+      "action": "capture_value",
+      "description": "Capture the user ID shown in the welcome message",
+      "target": "welcome_message",
       "capture_to": "user_id"
-    },
-    "verify_id_matches": {
-      "type": "value_matches_variable",
-      "element": "profile_id",
-      "variable": "user_id"
     }
-  }
+  ],
+  "assertions": [
+    {
+      "id": "id_matches",
+      "after_step": "capture_user_id",
+      "type": "value_matches_variable",
+      "description": "Verify the profile ID matches the captured user_id",
+      "element_description": "profile_id",
+      "variable_name": "user_id"
+    }
+  ]
 }
 ```
+
+Variables are captured by a `capture_value` **step** (via `capture_to`) and checked by a `value_matches_variable` **assertion** (via `variable_name`).
 
 ### Conditional Steps
 
@@ -311,20 +345,24 @@ For conditional branching (skip steps if condition not met):
 Generator creates:
 ```json
 {
-  "steps": {
-    "enter_email": {
-      "type": "type",
-      "element": "email_field",
-      "text": "user@example.com",
+  "steps": [
+    {
+      "id": "enter_email",
+      "action": "type",
+      "description": "Enter the email address when the field is present",
+      "target": "email_field",
+      "value": "user@example.com",
       "optional": true,
       "condition": {
-        "type": "element_exists",
-        "element": "email_field"
+        "type": "element_visible",
+        "element_description": "email_field"
       }
     }
-  }
+  ]
 }
 ```
+
+Condition `type` is one of `element_visible`, `variable_value`, `device_property`, or `previous_step_skipped` — pair it with `optional: true` so an unmet condition skips the step instead of failing it.
 
 ### Retry Policies
 
@@ -337,15 +375,23 @@ Wait for product list to load (retry up to 3 times if timeout)
 Generator creates:
 ```json
 {
-  "type": "wait_for_element",
-  "element": "product_list",
-  "timeout_seconds": 10,
+  "id": "wait_for_products",
+  "action": "wait_for_element",
+  "description": "Wait for the product list to load",
+  "target": "product_list",
+  "wait_config": {
+    "type": "element_visible",
+    "timeout_ms": 10000
+  },
+  "on_failure": "retry",
   "retry_policy": {
-    "max_retries": 3,
-    "wait_between_retries_ms": 2000
+    "max_attempts": 3,
+    "backoff_ms": 2000
   }
 }
 ```
+
+`retry_policy` applies only when `on_failure` is `"retry"`. `max_attempts` (2–5) counts the initial try plus retries; `backoff_ms` is the pause between attempts.
 
 ---
 
@@ -407,22 +453,25 @@ Bad:  "Wait 3 seconds"
 
 ### Schema Version
 
-All generated scenarios use the current schema:
+Scenarios carry a `$schema_version` field (note the leading `$`). Two values are valid:
+
 ```json
-{ "$schema_version": "2.0" }
+{ "$schema_version": "2.1" }
 ```
 
-The schema provides features like variables, retry policies, and comprehensive assertions.
+`2.0` is the baseline. **`2.1` is current and additive** — it adds the `mode` metadata field and the four platform-agnostic semantic actions (`press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`) without removing anything. Existing `2.0` scenarios remain valid, so there is no forced migration; new scenarios should use `2.1`.
+
+Either version provides features like variables, retry policies, and comprehensive assertions.
 
 ### Step IDs (Named Strings)
 
-The schema uses descriptive step IDs:
+`steps` is an ordered array; each step carries a descriptive `id` (plus `action` and `description`):
 ```json
-"steps": {
-  "tap_login": {...},
-  "enter_email": {...},
-  "wait_loading": {...}
-}
+"steps": [
+  { "id": "tap_login", "action": "tap", "description": "..." },
+  { "id": "enter_email", "action": "type", "description": "..." },
+  { "id": "wait_loading", "action": "wait_for_element", "description": "..." }
+]
 ```
 
 Benefits:
@@ -537,11 +586,14 @@ Generated JSON is fully editable. Common modifications:
 **Add retry policy:**
 ```json
 {
-  "type": "wait_for_element",
-  "element": "product_list",
+  "id": "wait_for_product_list",
+  "action": "wait_for_element",
+  "target": "product_list",
+  "description": "Wait for the product list to load",
+  "on_failure": "retry",
   "retry_policy": {
-    "max_retries": 3,
-    "wait_between_retries_ms": 2000
+    "max_attempts": 3,
+    "backoff_ms": 2000
   }
 }
 ```
@@ -549,8 +601,10 @@ Generated JSON is fully editable. Common modifications:
 **Make step optional:**
 ```json
 {
-  "type": "element_text",
-  "element": "newsletter_prompt",
+  "id": "dismiss_newsletter_prompt",
+  "action": "tap",
+  "target": "newsletter_prompt",
+  "description": "Dismiss the newsletter prompt if it appears",
   "optional": true
 }
 ```
@@ -558,11 +612,13 @@ Generated JSON is fully editable. Common modifications:
 **Add condition:**
 ```json
 {
-  "type": "tap",
-  "element": "premium_feature",
+  "id": "tap_premium_feature",
+  "action": "tap",
+  "target": "premium_feature",
+  "description": "Tap the premium feature when the premium badge is present",
   "condition": {
-    "type": "element_exists",
-    "element": "premium_badge"
+    "type": "element_visible",
+    "element_description": "premium_badge"
   }
 }
 ```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -44,11 +44,13 @@ The recommended approach to mobile testing with `mauto` follows this pattern:
 
 ## When to Use Each Stage
 
-**Setup** is your starting point. Run `mauto setup` once per mobile project to scaffold the `mobile-automator/` workspace (`scenarios/`, `screenshots/`, `results/`) and write `config.json`. Choose a mode with `--mode aware` (single-OS) or `--mode agnostic` (cross-platform). Then run `mauto devices` to confirm a device is reachable.
+**Setup** is your starting point. Run `mauto setup` once per mobile project to scaffold the `mobile-automator/` workspace (`scenarios/`, `screenshots/`, `results/`, `memory/`) and write `config.json`. Choose a mode with `--mode aware` (single-OS) or `--mode agnostic` (cross-platform). Then run `mauto devices` to confirm a device is reachable.
 
 **Generate** creates test scenarios from natural language. After setup, the agent reads `mauto guide generate` and drives the device through `mauto` verbs to describe test cases in plain English. It generates structured JSON scenarios, handling all the technical formatting so you can focus on what to test.
 
 **Execute** runs your test scenarios on connected devices. The agent reads `mauto guide execute`, performs pre-flight checks to ensure a device is ready, then runs each scenario step-by-step with AI vision-based assertions. Results capture not just pass/fail status, but also observations about flakiness, regressions, and execution context.
+
+Across all three stages, the agent draws on **cross-session memory** in `mobile-automator/memory/` — run history auto-harvested on `result finalize`, plus agent-authored app-knowledge and preferences (`mauto memory show` / `mauto memory add`) — so it gets smarter about your app over time.
 
 
 ## Next Steps

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -84,8 +84,11 @@ mobile-automator/
 ├── scenarios/      # generated test JSON files
 ├── screenshots/    # reference + execution screenshots
 ├── results/        # execution result reports
+├── memory/         # cross-session memory (run-history, app-knowledge, preferences)
 └── config.json     # project configuration (starter skeleton)
 ```
+
+Alongside `scenarios/`, `screenshots/`, and `results/`, setup also scaffolds a `memory/` subdirectory. This is where `mauto` keeps cross-session memory so your agent gets smarter about *this* app over time — run history auto-harvested on `result finalize`, plus agent-authored app-knowledge and preferences.
 
 The starter `config.json` written on first run:
 
@@ -281,5 +284,5 @@ See the [Generate Guide](generate.md) for next steps.
 ## See Also
 
 - [Generate Guide](generate.md) — Next step after setup
-- [Architecture: 3-Tier Design](../concepts/three-tier-design.md) — How setup fits in the overall system
+- [Architecture: Layered Architecture](../concepts/three-tier-design.md) — How setup fits in the overall system
 - [FAQ: Setup Issues](../faq.md#setup-installation)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Testing mobile apps manually is **tedious and error-prone**. Cross-platform test
 - **Platform-Agnostic by Default**: One scenario runs on Android and iOS, with OS gestures mapped to semantic actions
 - **Schema**: 14 action types, 27 assertion types, and advanced retry/condition logic
 - **Result Observations**: Captures flakiness, regressions, and state context for smarter debugging
+- **Cross-Session Memory**: The agent remembers app-knowledge, preferences, and run-history across sessions ([`mauto memory`](concepts/memory.md))
 - **Semantic Vision**: AI-powered visual assertions that tolerate cosmetic changes
 - **Portable Targets**: Visible text + role + coordinates, never brittle resource-ids
 
@@ -54,6 +55,8 @@ mauto setup                    # add --mode agnostic for cross-platform apps
 ```bash
 mauto devices                  # lists devices; mauto devices use <id> to pin one
 ```
+
+Device actions run through one persistent session daemon (`mauto session start|status|end`), so state stays warm across verbs. All device, workspace, memory, and session verbs — including the seven new device verbs in v0.21.0 — are catalogued in the [CLI Verbs reference](reference/cli-verbs.md).
 
 ### 4. Generate Tests
 
@@ -126,6 +129,8 @@ Because the contract is just verbs + JSON, **no agent is special** — any agent
 - **Platform Modes**: platform-aware (default) and platform-agnostic (`--mode agnostic`) with four semantic actions for cross-platform scenarios
 - **Schema**: 14 action types, 27 assertion types, advanced retry/condition logic
 - **Result Observations**: Captures flakiness, regressions, and execution context
+- **Cross-Session Memory**: The agent remembers app-knowledge, preferences, and run-history across sessions via [`mauto memory`](concepts/memory.md) — so it gets smarter about *your* app over time
+- **Persistent Device Session**: One warm mobile-mcp daemon behind `mauto session` and `mauto devices` keeps device state across verbs
 - **Built-in Schemas**: Scenario and result schemas available via `mauto schema scenario` / `mauto schema result`
 
 ## Next Steps

--- a/docs/reference/assertions.md
+++ b/docs/reference/assertions.md
@@ -6,6 +6,8 @@ description: "All 27 assertion types in mobile-automator - element state, text c
 
 mobile-automator supports 27 assertion types organized in 8 categories for comprehensive test verification.
 
+Every assertion object requires `id`, `after_step` (the step `id` it runs after), `type`, and `description`. Element-based assertions locate their target with `element_description` — a *semantic* description of the element, never a `resource-id` or OS-specific locator. The syntax snippets below show only the type-specific fields for brevity.
+
 ## Quick Reference Table
 
 | Category | Types | Count |
@@ -30,7 +32,7 @@ Verify element is present in UI.
 ```json
 {
   "type": "element_exists",
-  "element": "login_button"
+  "element_description": "Login button"
 }
 ```
 
@@ -51,7 +53,7 @@ Verify element is absent from UI.
 ```json
 {
   "type": "element_not_exists",
-  "element": "loading_spinner"
+  "element_description": "Loading spinner"
 }
 ```
 
@@ -72,9 +74,12 @@ Verify element is visible to user.
 ```json
 {
   "type": "element_visible",
-  "element": "success_message"
+  "element_description": "Success message",
+  "expected_visible": true
 }
 ```
+
+`expected_visible` is a boolean: `true` = must be visible/showing, `false` = must be hidden/dismissed.
 
 **Example scenario usage:**
 ```
@@ -93,17 +98,18 @@ Check element state (enabled, disabled, focused, selected, etc.).
 ```json
 {
   "type": "element_state",
-  "element": "submit_button",
-  "state": "enabled"
+  "element_description": "Submit button",
+  "state_property": "enabled"
 }
 ```
 
-**Supported states:**
+**Supported `state_property` values:**
 - `enabled` — Element is interactive
 - `disabled` — Element is not interactive
-- `focused` — Element has focus (cursor in text field)
 - `selected` — Element is selected (checkbox, radio button)
-- `checked` — Same as selected for checkboxes
+- `not_selected` — Element is not selected
+- `focused` — Element has focus (cursor in text field)
+- `clickable` — Element is clickable
 
 **Example scenario usage:**
 ```
@@ -125,8 +131,8 @@ Verify exact text match.
 ```json
 {
   "type": "element_text",
-  "element": "welcome_label",
-  "expected_exact": "Welcome, John"
+  "element_description": "Welcome label",
+  "expected_value": "Welcome, John"
 }
 ```
 
@@ -147,8 +153,8 @@ Verify substring is present.
 ```json
 {
   "type": "text_contains",
-  "element": "message",
-  "expected_contains": "Success"
+  "element_description": "Status message",
+  "expected_substring": "Success"
 }
 ```
 
@@ -169,7 +175,7 @@ Verify field has any text.
 ```json
 {
   "type": "text_not_empty",
-  "element": "username_field"
+  "element_description": "Username field"
 }
 ```
 
@@ -190,8 +196,8 @@ Check placeholder/hint text.
 ```json
 {
   "type": "element_hint",
-  "element": "email_field",
-  "expected_exact": "Enter email address"
+  "element_description": "Email field",
+  "expected_text": "Enter email address"
 }
 ```
 
@@ -212,8 +218,8 @@ Verify text matches regex pattern.
 ```json
 {
   "type": "pattern_match",
-  "element": "error_code",
-  "expected_pattern": "^ERR_[0-9]{3}$"
+  "element_description": "Error code",
+  "pattern": "^ERR_[0-9]{3}$"
 }
 ```
 
@@ -240,7 +246,7 @@ Verify text changed since last check.
 ```json
 {
   "type": "text_changed",
-  "element": "counter"
+  "element_description": "Counter label"
 }
 ```
 
@@ -261,8 +267,8 @@ Verify accessibility content description.
 ```json
 {
   "type": "content_description",
-  "element": "profile_icon",
-  "expected_exact": "User profile picture"
+  "element_description": "Profile icon",
+  "expected_text": "User profile picture"
 }
 ```
 
@@ -277,7 +283,7 @@ Check the accessibility label of the button
 ## Count & Collections Assertions (3 types)
 
 ### element_count
-Count specific elements matching a selector.
+Count specific elements matching a description.
 
 **When to use:** Verify number of matching elements on screen (buttons, list items, tabs).
 
@@ -285,10 +291,13 @@ Count specific elements matching a selector.
 ```json
 {
   "type": "element_count",
-  "element": "list_item",
-  "expected_exact": 5
+  "element_description": "List item",
+  "operator": "==",
+  "expected_count": 5
 }
 ```
+
+`operator` is one of `==`, `!=`, `>=`, `<=`, `>`, `<` (default `==`).
 
 **Example scenario usage:**
 ```
@@ -307,8 +316,9 @@ Count items in a list view or collection.
 ```json
 {
   "type": "list_item_count",
-  "element": "messages_list",
-  "expected_exact": 3
+  "element_description": "Messages list",
+  "operator": "==",
+  "expected_count": 3
 }
 ```
 
@@ -329,7 +339,7 @@ Verify list has no items.
 ```json
 {
   "type": "list_is_empty",
-  "element": "search_results"
+  "element_description": "Search results list"
 }
 ```
 
@@ -352,9 +362,12 @@ Semantic visual comparison against a reference screenshot.
 ```json
 {
   "type": "screenshot_match",
-  "expected_image": "reference.png"
+  "reference_screenshot": "screenshots/login_flow/reference.png",
+  "tolerance": 0.9
 }
 ```
+
+`tolerance` ranges from `0.0` (any match) to `1.0` (pixel-perfect); default `0.9`.
 
 **Why AI-based comparison:** Tests are resilient to cosmetic changes (fonts, anti-aliasing, small positioning adjustments) while catching functional regressions (colors, layout, missing elements).
 
@@ -367,29 +380,29 @@ Check that the dashboard appears as expected
 ---
 
 ### visual_state
-Check visual appearance of element.
+Check the loading/data state of the screen or element.
 
-**When to use:** Verify element styling without needing a reference screenshot (highlighted, faded, etc.).
+**When to use:** Verify a screen or element is in a specific data state without needing a reference screenshot.
 
 **Syntax:**
 ```json
 {
   "type": "visual_state",
-  "element": "card",
-  "state": "highlighted"
+  "element_description": "Product list",
+  "expected_visual_state": "loaded"
 }
 ```
 
-**Common states:**
-- `highlighted` — Element has emphasis/highlight styling
-- `faded` — Element appears disabled or dimmed
-- `focused` — Element has focus indication
-- `active` — Element is in active state
+**Supported `expected_visual_state` values:**
+- `loaded` — Content finished loading
+- `loading` — Content still loading
+- `empty` — Empty / no-data state
+- `error` — Error state
 
 **Example scenario usage:**
 ```
-Verify the selected tab is highlighted
-Check that the disabled button appears faded
+Verify the product list finished loading
+Check that the feed shows the empty state
 ```
 
 ---
@@ -403,7 +416,7 @@ Verify element is completely visible (not clipped).
 ```json
 {
   "type": "element_fully_visible",
-  "element": "button"
+  "element_description": "Confirmation button"
 }
 ```
 
@@ -424,10 +437,12 @@ Check text or element color.
 ```json
 {
   "type": "color_style",
-  "element": "error_text",
-  "expected_color": "#FF0000"
+  "element_description": "Error text",
+  "color_hex": "#FF0000"
 }
 ```
+
+`color_hex` is a 3- or 6-digit hex value (e.g., `#0057FF`).
 
 **Example scenario usage:**
 ```
@@ -448,7 +463,7 @@ Verify screen/activity name.
 ```json
 {
   "type": "screen_title",
-  "expected_exact": "Login"
+  "expected_text": "Login"
 }
 ```
 
@@ -489,7 +504,7 @@ Verify alert message text.
 ```json
 {
   "type": "alert_text",
-  "expected_exact": "Are you sure?"
+  "expected_text": "Are you sure?"
 }
 ```
 
@@ -510,7 +525,7 @@ Check toast notification is visible.
 ```json
 {
   "type": "toast_visible",
-  "expected_contains": "Saved"
+  "expected_text": "Saved"
 }
 ```
 
@@ -530,9 +545,12 @@ Verify soft keyboard is open.
 **Syntax:**
 ```json
 {
-  "type": "keyboard_visible"
+  "type": "keyboard_visible",
+  "expected_visible": true
 }
 ```
+
+`expected_visible` is a boolean: `true` = keyboard must be showing, `false` = keyboard must be dismissed.
 
 **Example scenario usage:**
 ```
@@ -553,8 +571,8 @@ Check accessibility label on element.
 ```json
 {
   "type": "has_accessibility_label",
-  "element": "close_button",
-  "expected_exact": "Close dialog"
+  "element_description": "Close button",
+  "label_value": "Close dialog"
 }
 ```
 
@@ -577,8 +595,8 @@ Compare captured value to variable.
 ```json
 {
   "type": "value_matches_variable",
-  "expected_variable": "captured_email",
-  "element": "email_field"
+  "element_description": "Email field",
+  "variable_name": "captured_email"
 }
 ```
 
@@ -606,7 +624,7 @@ Check permission prompt (iOS/Android).
 ```json
 {
   "type": "permission_dialog_shown",
-  "expected_permission": "Camera"
+  "permission_name": "camera"
 }
 ```
 
@@ -626,9 +644,12 @@ Check if dark mode is enabled.
 **Syntax:**
 ```json
 {
-  "type": "dark_mode_active"
+  "type": "dark_mode_active",
+  "expected_theme": "dark"
 }
 ```
+
+`expected_theme` is `dark` or `light`.
 
 **Example scenario usage:**
 ```
@@ -642,28 +663,52 @@ Check that the app switched to dark theme
 
 ### In JSON Format
 
-Add assertions as named steps in your test scenario:
+Assertions live in the scenario's top-level `assertions` array. Each one names the step it runs after via `after_step`:
 
 ```json
 {
-  "schema_version": "2.0",
-  "id": "test_001",
-  "steps": {
-    "tap_login": { "type": "tap", "element": "login_button" },
-    "verify_welcome": {
-      "type": "element_text",
-      "element": "welcome_message",
-      "expected_exact": "Welcome, John"
-    },
-    "verify_enabled": {
-      "type": "element_state",
-      "element": "logout_button",
-      "state": "enabled"
-    }
+  "$schema_version": "2.1",
+  "scenario_id": "assertion_examples",
+  "name": "Assertion Examples",
+  "description": "Demonstrates how assertions reference a step and check the resulting UI state",
+  "platform": "android",
+  "app_package": "com.example.app",
+  "metadata": {
+    "app_version": "1.0.0",
+    "environment": "staging"
   },
+  "steps": [
+    {
+      "id": "tap_login",
+      "action": "tap",
+      "description": "Tap the login button",
+      "target": "Login button"
+    },
+    {
+      "id": "wait_for_home",
+      "action": "wait_for_element",
+      "description": "Wait for the home screen to load",
+      "target": "Welcome message",
+      "wait_config": { "type": "element_visible", "timeout_ms": 5000 }
+    }
+  ],
   "assertions": [
-    { "id": "welcome_check", "step": "verify_welcome" },
-    { "id": "button_check", "step": "verify_enabled" }
+    {
+      "id": "welcome_check",
+      "after_step": "wait_for_home",
+      "type": "element_text",
+      "description": "Welcome message greets the user by name",
+      "element_description": "Welcome message",
+      "expected_value": "Welcome, John"
+    },
+    {
+      "id": "logout_enabled_check",
+      "after_step": "wait_for_home",
+      "type": "element_state",
+      "description": "Logout button is enabled",
+      "element_description": "Logout button",
+      "state_property": "enabled"
+    }
   ]
 }
 ```
@@ -697,7 +742,7 @@ The generator automatically converts these to appropriate assertion types.
 ```
 Element 'login_button' not found on screen
 ```
-**Troubleshoot:** Button may be off-screen, hidden, or using different ID
+**Troubleshoot:** Button may be off-screen, hidden, or described differently
 
 ### Failed: element_text
 ```

--- a/docs/reference/cli-verbs.md
+++ b/docs/reference/cli-verbs.md
@@ -1,0 +1,174 @@
+---
+description: "Complete reference for every mauto CLI verb - device actions, authoring, workspace, reasoning, agent integration, device session, and cross-session memory - with the uniform JSON envelope and exit codes."
+---
+
+# CLI Verbs Reference
+
+`mauto` is a host-agnostic CLI for AI-driven mobile QA automation. Any AI coding agent drives a device through `mauto` verbs; the verbs wrap the internal [mobile-mcp engine](mcp-tools.md), which talks to the real device or emulator. The agent is the brain (it decides *what*); the verbs are the hands (they perform deterministic actions).
+
+This page catalogs every verb, grouped by category.
+
+## The uniform JSON envelope
+
+Every verb emits a single uniform JSON envelope on stdout so any agent can parse the outcome the same way:
+
+- **Success:** `{ "ok": true, "data": …, "schema_version": "2.1" }` (plus an optional `hint`).
+- **Failure:** `{ "ok": false, "error": { "kind": …, "message": … }, "hint": …, "schema_version": "2.1" }` (plus an optional `data`).
+
+The canonical shape is `{ok, data, error, hint, schema_version}`. The envelope `schema_version` is currently `2.1`.
+
+!!! note "The `--human` flag"
+    Every verb accepts a global `--human` flag (default off). With it, `mauto` renders a compact human-readable line instead of the JSON envelope. Leave it off when an agent is parsing output; turn it on for interactive terminal use.
+
+!!! warning "RAW-output exception"
+    Four verbs do **not** wrap their output in the envelope on success. `guide`, `schema`, `bootstrap`, and `memory show` print raw markdown/JSON verbatim, because the agent injects that text straight into its own context. (On failure they still emit the normal error envelope.)
+
+## Error kinds and exit codes
+
+The `error.kind` on a failure envelope maps to a process exit code:
+
+| Result | `error.kind` | Exit code |
+|--------|--------------|-----------|
+| Success | — | `0` |
+| Internal error | `internal` | `1` |
+| Partial success | `partial` | `1` |
+| Device / engine failure | `device` | `2` |
+| Invalid input | `invalid_input` | `3` |
+| Target not found | `target_not_found` | `4` |
+| Environment problem | `environment` | `5` |
+| Cancelled | `cancel` | `130` |
+
+---
+
+## Device action verbs
+
+These verbs drive the screen. Each accepts `--device <id>` to target a specific device.
+
+!!! note "`--device` precedence"
+    When resolving which device a verb runs against, the order is: explicit `--device <id>` **>** the persisted selection (`mauto devices use <id>`) **>** `null` (the engine auto-selects when exactly one device is connected).
+
+| Verb | Description |
+|------|-------------|
+| `mauto elements` | List the platform-agnostic UI elements currently on screen |
+| `mauto screenshot <path>` | Save a screenshot to `<path>` |
+| `mauto tap --at <x,y>` | Tap at absolute coordinates |
+| `mauto type <text>` | Type text into the focused element |
+| `mauto swipe --direction <up\|down\|left\|right>` | Swipe in a cardinal direction |
+| `mauto press <button>` | Press a hardware button (`BACK`, `HOME`, `ENTER`, …) or a semantic action |
+| `mauto long-press --at <x,y> [--duration <ms>]` | Long-press at coordinates **(new in 0.21.0)** |
+| `mauto double-tap --at <x,y>` | Double-tap at coordinates **(new in 0.21.0)** |
+| `mauto launch <appId>` | Launch an installed app by package/bundle id **(new in 0.21.0)** |
+| `mauto install <path>` | Install an app from a local `.apk` / `.app` / `.ipa` **(new in 0.21.0)** |
+| `mauto uninstall <appId>` | Uninstall an app by id **(new in 0.21.0)** |
+| `mauto open-url <url>` | Open a URL (deep link or web) on the device **(new in 0.21.0)** |
+| `mauto orientation <portrait\|landscape>` | Set device orientation **(new in 0.21.0)** |
+
+!!! tip "New in v0.21.0"
+    Seven device verbs were added in **v0.21.0**: `long-press`, `double-tap`, `launch`, `install`, `uninstall`, `open-url`, and `orientation`.
+
+### Semantic actions (platform-agnostic mode)
+
+In platform-agnostic mode, `mauto press` also resolves four **semantic actions** to per-platform mechanics at replay time:
+
+- `press_back`
+- `dismiss_keyboard`
+- `grant_permission`
+- `deny_permission`
+
+An unresolvable semantic action fails honestly with a `device` error rather than a silent no-op. Hardware buttons (`BACK` / `HOME` / `ENTER`) keep their passthrough behavior.
+
+---
+
+## Author & verify verbs
+
+Used to author scenario JSON, evaluate assertions, and assemble result files.
+
+| Verb | Description |
+|------|-------------|
+| `mauto validate <file>` | Validate a scenario JSON file against the [scenario schema](schema.md) |
+| `mauto assert <type> [--target --expected --operator --count --pattern --variable --device]` | Evaluate an assertion; mechanical types are decided by the CLI, visual types are deferred to the agent |
+| `mauto result add-step --run-id --step-id --status [--scenario-id --attempts]` | Append a step result to a run |
+| `mauto result finalize --run-id [--scenario-id --status --duration]` | Assemble the final [result file](result-schema.md) and auto-harvest memory |
+
+!!! note "`result finalize` and memory"
+    On finalize, `mauto` auto-harvests typed observations into cross-session memory. This is best-effort: a memory failure never fails an otherwise-successful finalize — it folds into the envelope `hint` instead. See [Cross-Session Memory](../concepts/memory.md).
+
+---
+
+## Workspace verbs
+
+Scaffold and configure the `mobile-automator/` workspace.
+
+| Verb | Description |
+|------|-------------|
+| `mauto setup [--mode aware\|agnostic]` | Scaffold `mobile-automator/` (subdirs `scenarios/`, `screenshots/`, `results/`, `memory/`) and write `config.json` |
+| `mauto config get <key>` | Read a config value by dotted path |
+| `mauto config set <key> <value>` | Write a config value by dotted path |
+
+The mode is chosen at setup and stored as `mode` in `config.json`: `--mode aware` → `platform-aware` (single-OS / OS-specific UI tests); `--mode agnostic` → `platform-agnostic` (one scenario runs across platforms such as Flutter / RN / KMP / CMP). Configs predating the field are treated as `platform-aware`.
+
+---
+
+## Reasoning verbs
+
+The agent pulls reasoning on demand. These verbs **print raw content on success** (see the RAW-output exception above), because the agent injects the text into its context.
+
+| Verb | Description |
+|------|-------------|
+| `mauto guide <topic>` | Print the workflow guide for a topic: `generate`, `execute`, or `setup` |
+| `mauto schema <name>` | Print a schema: `scenario` or `result` |
+| `mauto bootstrap` | Print the verb map and non-negotiable invariants |
+
+---
+
+## Agent integration verbs
+
+Wire `mauto` into a host AI agent.
+
+| Verb | Description |
+|------|-------------|
+| `mauto init --agent <claude\|cursor\|gemini\|copilot\|agents\|all>` | Install native Agent Skills (and host-specific slash-commands / rules / MCP entries) for the chosen host |
+| `mauto mcp` | Run the MCP prompts server (stdio) that exposes the workflows as prompts |
+
+All five hosts get native Agent Skills (one per workflow topic: generate / execute / setup). Claude and Cursor additionally get slash-commands / project rules plus a `mauto` MCP server entry (`{ "command": "mauto", "args": ["mcp"] }`). `init --agent all` continues on error and returns one envelope with a per-agent ok/failed map in `data.agents[]`.
+
+---
+
+## Device session verbs
+
+Device verbs are backed by a single persistent mobile-mcp session daemon. These verbs manage that daemon and the device selection.
+
+| Verb | Description |
+|------|-------------|
+| `mauto session start [--device <id>] [--idle <ms>]` | Start the persistent session daemon (idempotent; returns `already_running: true` if alive) |
+| `mauto session status` | Report `{ running: bool }` |
+| `mauto session end` | Stop the daemon and remove the socket / pidfile |
+| `mauto devices` | List connected devices/simulators (id / name / platform / state) |
+| `mauto devices use <id>` | Validate the id against the live list, then persist the selection |
+| `mauto devices clear` | Remove the persisted selection |
+
+---
+
+## Memory verbs
+
+Cross-session memory lives in `mobile-automator/memory/`. There are three kinds across three files; only `app-knowledge` and `preferences` are agent-authored. See [Cross-Session Memory](../concepts/memory.md) for the full model.
+
+| Verb | Description |
+|------|-------------|
+| `mauto memory show [--kind <run-history\|app-knowledge\|preferences>] [--scenario <id>]` | Print memory as raw markdown (RAW-output verb) |
+| `mauto memory add <text> --kind <app-knowledge\|preferences>` | Record an agent-authored entry |
+| `mauto memory forget --kind <app-knowledge\|preferences> --match <substr>` | Remove agent-authored entries containing `<substr>` |
+
+!!! note "run-history is machine-owned"
+    `run-history` is auto-harvested on `result finalize` and is **not** a valid target for `memory add` / `memory forget`. Only `app-knowledge` and `preferences` are agent-authored.
+
+---
+
+## Related references
+
+- [Test Scenario Schema](schema.md) — action and assertion structure that `validate` checks
+- [Test Result Schema](result-schema.md) — the file `result finalize` assembles
+- [Cross-Session Memory](../concepts/memory.md) — how memory verbs and auto-harvesting work
+- [Internal Engine (mobile-mcp)](mcp-tools.md) — the primitives `mauto` verbs wrap
+
+[← Back to Reference Index](index.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,12 @@ Complete reference for all schemas, assertion types, and automation tools used b
 - [20+ MCP Tools](mcp-tools.md) — Device control, screenshots, element inspection
 - [Result Schema](result-schema.md) — Understanding test execution results
 
+### For Agent Operators
+
+**Drive and extend mobile-automator:**
+- [CLI Verbs](cli-verbs.md) — Every `mauto` verb and its JSON envelope
+- [Memory](../concepts/memory.md) — Cross-session learning (run-history, app-knowledge, preferences)
+
 ### For Schema Developers
 
 **Extend mobile-automator:**
@@ -58,14 +64,18 @@ The default schema for test scenarios. Defines structure for steps, assertions, 
 **Schema structure:**
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "login_flow",
-  "steps": {
-    "tap_login": { "type": "tap", "element": "button" },
-    "verify_success": { "type": "element_exists", "element": "welcome" }
-  },
+  "name": "Login Flow",
+  "description": "Verify the user can log in and reach the dashboard",
+  "platform": "android",
+  "app_package": "com.example.app",
+  "metadata": { "app_version": "1.0.0", "environment": "staging" },
+  "steps": [
+    { "id": "tap_login", "action": "tap", "description": "Tap the login button", "target": "Login button" }
+  ],
   "assertions": [
-    { "id": "logged_in", "type": "screen_title", "expected_exact": "Dashboard" }
+    { "id": "logged_in", "after_step": "tap_login", "type": "screen_title", "description": "The dashboard screen is shown", "expected_text": "Dashboard" }
   ]
 }
 ```
@@ -131,6 +141,22 @@ Low-level device automation primitives for screen interaction, app management, a
 - `mauto swipe` → `mobile_swipe_on_screen` — Scroll or swipe
 
 **[View all engine tools →](mcp-tools.md)**
+
+---
+
+### CLI Verbs
+
+The full `mauto` verb surface — device actions, authoring, workspace, reasoning, agent integration, device session, and memory — each emitting the uniform `{ok, data, error, hint, schema_version}` envelope.
+
+**[CLI Verbs Reference →](cli-verbs.md)**
+
+---
+
+### Memory
+
+How mobile-automator learns across sessions: the auto-harvested `run-history` plus agent-authored `app-knowledge` and `preferences`, stored under `mobile-automator/memory/`.
+
+**[Memory Concept →](../concepts/memory.md)**
 
 ---
 
@@ -234,12 +260,19 @@ Low-level device automation primitives for screen interaction, app management, a
 
 ## Schema Versioning
 
-### Current (2.0)
+Scenario files and result files version themselves independently, with **different field names**:
 
-- **Identifier:** `"$schema_version": "2.0"`
+### Scenario schema — `$schema_version` (note the `$`)
+
+- **Identifier:** `"$schema_version"`, which accepts `"2.0"` or `"2.1"` (default `"2.0"`)
+- **2.1 is current** and additive over 2.0 — it adds the `mode` metadata field and four platform-agnostic semantic actions (`press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`). Existing `"2.0"` scenarios remain valid; new scenarios should use `"2.1"`.
 - **Step IDs:** String snake_case (`tap_login`, `verify_message`)
-- **Features:** Variables, retry policies, conditions, sub-steps, observations
-- **Status:** Fully supported and recommended for new scenarios
+- **Features:** Variables, retry policies, conditions, sub-steps
+
+### Result schema — `schema_version` (no `$`)
+
+- **Identifier:** `"schema_version"`, which is always `"2.0"` (the only valid value for result files)
+- This is intentional — result files stay at `2.0` even when the scenario that produced them uses `$schema_version` `2.1`.
 
 ---
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -68,11 +68,11 @@ Returns all connected devices and simulators (iOS and Android).
 - Choose target device for test execution
 - Verify device connectivity
 
-**Example:**
+**Example call:**
 ```json
 {
-  "type": "wait_for_element",
-  "description": "Get list of connected devices"
+  "tool": "mobile_list_available_devices",
+  "parameters": {}
 }
 ```
 
@@ -104,10 +104,14 @@ Launch an app on the specified device.
 - Relaunch app after crash
 - Test app startup sequence
 
-**Example:**
+**Example call:**
 ```json
 {
-  "type": "launch_app"
+  "tool": "mobile_launch_app",
+  "parameters": {
+    "device": "emulator-5554",
+    "packageName": "com.example.app"
+  }
 }
 ```
 

--- a/docs/reference/result-schema.md
+++ b/docs/reference/result-schema.md
@@ -17,6 +17,11 @@ A test result is a comprehensive record of a single scenario execution, capturin
 
 Results are stored as JSON files in `mobile-automator/results/` with the naming pattern `run_YYYYMMDD_HHMMSS.json`.
 
+!!! note "Result files version differently from scenario files"
+    Result files carry `schema_version` (no leading `$`), and its only valid value is `"2.0"`. This is deliberate and **not** a mistake: *scenario* files use `$schema_version` (with the `$`), which accepts `"2.0"` **or** `"2.1"`, while *result* files stay at `schema_version: "2.0"`. A result produced from a `$schema_version: "2.1"` scenario still reports `schema_version: "2.0"`.
+
+When you run `mauto result finalize`, the result file is assembled and its typed `observations` (regression, flakiness, state context) are auto-harvested into cross-session [memory](../concepts/memory.md) — a best-effort step that never fails an otherwise-successful finalize.
+
 ## Schema Structure
 
 The result schema defines a single JSON object at the root level with required and optional fields:
@@ -42,7 +47,7 @@ Run Result
 |-------|------|----------|-------------|
 | `run_id` | string | Yes | Unique run identifier in format `run_YYYYMMDD_HHMMSS`. Example: `run_20260227_145230` |
 | `scenario_id` | string | Yes | ID of the scenario that was executed |
-| `schema_version` | string | No | Version of the scenario schema: "2.0". |
+| `schema_version` | string | No | Result-file schema version. Always `"2.0"` (the only valid value). Distinct from a scenario's `$schema_version`, which may be `"2.0"` or `"2.1"`. |
 | `status` | string | Yes | Overall result status: `"passed"`, `"failed"`, or `"error"` |
 | `metadata` | object | Yes | Execution context including device, app version, environment, timestamp |
 | `total_assertions` | integer | Yes | Total count of assertions in the execution |

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -17,14 +17,14 @@ The scenario schema defines the format for mobile test scenarios:
 - **Conditional execution** — Optional steps, conditional branching, retry policies
 - **Structured preconditions** — Setup actions and device state requirements
 
-**Schema version identifier:** All scenarios MUST have `"$schema_version": "2.0"` as the first field.
+**Schema version identifier:** Every scenario carries a `$schema_version` field (note the leading `$`). It accepts `"2.0"` or `"2.1"` and defaults to `"2.0"`. **2.1 is the current version** and is purely additive over 2.0 — it adds the `mode` metadata field and four platform-agnostic semantic actions (`press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`). Existing `"2.0"` scenarios remain valid; new scenarios should use `"2.1"`.
 
 ## Schema Structure Overview
 
 ```
 Test Scenario
 ├─ Metadata
-│  ├─ $schema_version (required: "2.0")
+│  ├─ $schema_version (required: "2.0" or "2.1")
 │  ├─ scenario_id (required: snake_case)
 │  ├─ name (required: human-readable)
 │  ├─ description (required: what it tests)
@@ -37,7 +37,7 @@ Test Scenario
 │  ├─ variables (optional: variable definitions)
 │  └─ preconditions (optional: setup actions)
 ├─ Execution
-│  ├─ steps (required: test actions)
+│  ├─ steps (required: ordered array of test actions)
 │  └─ assertions (required: verification rules)
 └─ Execution Metadata (runtime-only, in result schema)
 ```
@@ -48,7 +48,7 @@ Test Scenario
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `$schema_version` | string | **YES** | Must be exactly `"2.0"` |
+| `$schema_version` | string | **YES** | Accepts `"2.0"` or `"2.1"` (default `"2.0"`). `"2.1"` is current. |
 | `scenario_id` | string | **YES** | Unique identifier in snake_case (e.g., `login_happy_path`) |
 | `name` | string | **YES** | Human-readable scenario title |
 | `description` | string | **YES** | What this scenario tests and business value |
@@ -56,93 +56,99 @@ Test Scenario
 | `app_package` | string | **YES** | Android package name or iOS bundle identifier |
 | `metadata` | object | **YES** | Design-time metadata with `app_version` and `environment` |
 | `tags` | array | No | Categorization tags for filtering (max 10 tags, max 20 chars each) |
-| `variables` | object | No | Variable declarations for capture_value steps |
+| `variables` | object | No | Variable declarations for `capture_value` steps |
 | `preconditions` | object | No | Setup requirements and device actions before test |
-| `steps` | object | **YES** | Named test steps (key = step_id, value = action definition) |
+| `steps` | array | **YES** | Ordered array of step objects (each with `id`, `action`, `description`) |
 | `assertions` | array | **YES** | Array of assertion checks |
 
 ### Example Minimal Scenario
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "login_happy_path",
   "name": "User Login - Happy Path",
-  "description": "Verify user can log in with valid credentials and access dashboard",
+  "description": "Verify user can log in with valid credentials and access the dashboard",
   "platform": "android",
   "app_package": "com.example.app",
   "metadata": {
     "app_version": "1.2.3",
     "environment": "staging"
   },
-  "steps": {
-    "tap_login_button": {
-      "type": "tap",
-      "element": "login_button"
+  "steps": [
+    {
+      "id": "tap_login_button",
+      "action": "tap",
+      "description": "Tap the login button on the welcome screen",
+      "target": "Login button"
     },
-    "wait_for_form": {
-      "type": "wait_for_element",
-      "element": "email_field",
-      "timeout_seconds": 5
+    {
+      "id": "wait_for_form",
+      "action": "wait_for_element",
+      "description": "Wait for the email input field to appear",
+      "target": "Email input field",
+      "wait_config": { "type": "element_visible", "timeout_ms": 5000 }
     }
-  },
+  ],
   "assertions": [
     {
       "id": "login_form_visible",
-      "description": "Login form is displayed",
+      "after_step": "wait_for_form",
       "type": "element_exists",
-      "element": "email_field"
+      "description": "The login form is displayed",
+      "element_description": "Email input field"
     }
   ]
 }
 ```
 
-## Steps Object
+## Steps Array
 
-The `steps` object contains named test actions. Each key is the step ID (snake_case), and the value is an action definition.
+The `steps` field is an **ordered array** of step objects. Each object requires `id`, `action`, and `description`. The `target` field is a *semantic* description of the element (never a `resource-id` or OS-specific locator) — the agent resolves it to a tappable element at replay time.
 
 ### Step ID Format
 
 - Must be lowercase alphanumeric with underscores: `^[a-z][a-z0-9_]*$`
 - Examples: `tap_login`, `wait_for_home`, `type_email_address`
-- Max length: 50 characters
+- Unique within the scenario; used for screenshot naming and `after_step` references
 
 ### Action Types (14 total)
 
+Each step's `action` field is one of these values. In platform-agnostic (`mode: "platform-agnostic"`) scenarios you can additionally use the four semantic actions `press_back`, `dismiss_keyboard`, `grant_permission`, and `deny_permission`, which resolve to the right per-platform mechanics at replay time.
+
 #### 1. launch_app
-Launch the app on the device.
+Launch the app under test on the device.
 
 **Fields:**
-- `type` — `"launch_app"`
-- `app_package` (optional) — Override default package (rarely needed)
+- `action` — `"launch_app"`
 
 **Example:**
 ```json
 {
-  "launch_app_step": {
-    "type": "launch_app"
-  }
+  "id": "launch_app",
+  "action": "launch_app",
+  "description": "Launch the app under test"
 }
 ```
 
 ---
 
 #### 2. tap
-Tap/click on a UI element.
+Tap on a UI element.
 
 **Fields:**
-- `type` — `"tap"`
-- `element` — Element ID/locator to tap
+- `action` — `"tap"`
+- `target` — Semantic description of the element to tap
 - `optional` (optional) — If `true`, step continues even if element not found (default: `false`)
 - `retry_policy` (optional) — Retry configuration
 
 **Example:**
 ```json
 {
-  "tap_login_button": {
-    "type": "tap",
-    "element": "login_button"
-  }
+  "id": "tap_login_button",
+  "action": "tap",
+  "description": "Tap the login button",
+  "target": "Login button"
 }
 ```
 
@@ -152,18 +158,16 @@ Tap/click on a UI element.
 Long-press on a UI element.
 
 **Fields:**
-- `type` — `"long_press"`
-- `element` — Element to long-press
-- `duration_ms` (optional) — Press duration in milliseconds (default: 500)
+- `action` — `"long_press"`
+- `target` — Element to long-press
 
 **Example:**
 ```json
 {
-  "long_press_menu_item": {
-    "type": "long_press",
-    "element": "menu_item",
-    "duration_ms": 1000
-  }
+  "id": "long_press_menu_item",
+  "action": "long_press",
+  "description": "Long-press the list item to open the context menu",
+  "target": "First message in the list"
 }
 ```
 
@@ -173,37 +177,35 @@ Long-press on a UI element.
 Double-tap on a UI element.
 
 **Fields:**
-- `type` — `"double_tap"`
-- `element` — Element to double-tap
+- `action` — `"double_tap"`
+- `target` — Element to double-tap
 
 **Example:**
 ```json
 {
-  "double_tap_zoom": {
-    "type": "double_tap",
-    "element": "image"
-  }
+  "id": "double_tap_zoom",
+  "action": "double_tap",
+  "description": "Double-tap the image to zoom in",
+  "target": "Product image"
 }
 ```
 
 ---
 
 #### 5. type
-Type text into a focused input field.
+Type text into the currently focused input field.
 
 **Fields:**
-- `type` — `"type"`
-- `text` — Text to type
-- `clear_first` (optional) — Clear field before typing (default: `false`)
+- `action` — `"type"`
+- `value` — Text to type
 
 **Example:**
 ```json
 {
-  "enter_email": {
-    "type": "type",
-    "text": "user@example.com",
-    "clear_first": true
-  }
+  "id": "enter_email",
+  "action": "type",
+  "description": "Type the account email into the focused field",
+  "value": "user@example.com"
 }
 ```
 
@@ -213,18 +215,16 @@ Type text into a focused input field.
 Swipe/scroll in a direction.
 
 **Fields:**
-- `type` — `"swipe"`
-- `direction` — `up`, `down`, `left`, or `right`
-- `distance_pixels` (optional) — Distance in pixels (default: 400)
+- `action` — `"swipe"`
+- `value` — `up`, `down`, `left`, or `right`
 
 **Example:**
 ```json
 {
-  "scroll_down_page": {
-    "type": "swipe",
-    "direction": "down",
-    "distance_pixels": 500
-  }
+  "id": "scroll_down_page",
+  "action": "swipe",
+  "description": "Scroll down the page",
+  "value": "down"
 }
 ```
 
@@ -234,57 +234,54 @@ Swipe/scroll in a direction.
 Scroll until a specific element is visible.
 
 **Fields:**
-- `type` — `"scroll_to_element"`
-- `element` — Element to scroll to
-- `max_swipes` (optional) — Maximum scroll attempts (default: 10)
-- `direction` (optional) — `up` or `down` (default: `down`)
+- `action` — `"scroll_to_element"`
+- `target` — Element to scroll to
 
 **Example:**
 ```json
 {
-  "scroll_to_submit": {
-    "type": "scroll_to_element",
-    "element": "submit_button",
-    "direction": "down"
-  }
+  "id": "scroll_to_submit",
+  "action": "scroll_to_element",
+  "description": "Scroll until the submit button is on screen",
+  "target": "Submit button"
 }
 ```
 
 ---
 
 #### 8. press_button
-Press a device button.
+Press a hardware/virtual device button.
 
 **Fields:**
-- `type` — `"press_button"`
-- `button` — `BACK`, `HOME`, `VOLUME_UP`, `VOLUME_DOWN`, `ENTER`
+- `action` — `"press_button"`
+- `value` — `BACK`, `HOME`, or `ENTER`
 
 **Example:**
 ```json
 {
-  "press_back": {
-    "type": "press_button",
-    "button": "BACK"
-  }
+  "id": "press_back",
+  "action": "press_button",
+  "description": "Press the device back button",
+  "value": "BACK"
 }
 ```
 
 ---
 
 #### 9. open_url
-Open a URL in the default browser.
+Open a URL (deep link or web) on the device.
 
 **Fields:**
-- `type` — `"open_url"`
-- `url` — URL to open
+- `action` — `"open_url"`
+- `value` — URL to open
 
 **Example:**
 ```json
 {
-  "open_help_page": {
-    "type": "open_url",
-    "url": "https://help.example.com"
-  }
+  "id": "open_help_page",
+  "action": "open_url",
+  "description": "Open the help page in the browser",
+  "value": "https://help.example.com"
 }
 ```
 
@@ -294,18 +291,18 @@ Open a URL in the default browser.
 Wait until an element appears on screen.
 
 **Fields:**
-- `type` — `"wait_for_element"`
-- `element` — Element to wait for
-- `timeout_seconds` (optional) — Max wait time (default: 10)
+- `action` — `"wait_for_element"`
+- `target` — Element to wait for
+- `wait_config` — `{ "type": "element_visible", "timeout_ms": <1000–60000> }`
 
 **Example:**
 ```json
 {
-  "wait_for_dashboard": {
-    "type": "wait_for_element",
-    "element": "dashboard_content",
-    "timeout_seconds": 15
-  }
+  "id": "wait_for_dashboard",
+  "action": "wait_for_element",
+  "description": "Wait for the dashboard content to appear",
+  "target": "Dashboard content",
+  "wait_config": { "type": "element_visible", "timeout_ms": 15000 }
 }
 ```
 
@@ -315,18 +312,18 @@ Wait until an element appears on screen.
 Wait until an element disappears from screen.
 
 **Fields:**
-- `type` — `"wait_for_element_gone"`
-- `element` — Element to wait for disappearance
-- `timeout_seconds` (optional) — Max wait time (default: 10)
+- `action` — `"wait_for_element_gone"`
+- `target` — Element to wait for disappearance
+- `wait_config` — `{ "type": "element_gone", "timeout_ms": <1000–60000> }`
 
 **Example:**
 ```json
 {
-  "wait_for_loading_done": {
-    "type": "wait_for_element_gone",
-    "element": "loading_spinner",
-    "timeout_seconds": 20
-  }
+  "id": "wait_for_loading_done",
+  "action": "wait_for_element_gone",
+  "description": "Wait for the loading spinner to disappear",
+  "target": "Loading spinner",
+  "wait_config": { "type": "element_gone", "timeout_ms": 20000 }
 }
 ```
 
@@ -336,57 +333,56 @@ Wait until an element disappears from screen.
 Wait until loading indicators disappear.
 
 **Fields:**
-- `type` — `"wait_for_loading_complete"`
-- `timeout_seconds` (optional) — Max wait time (default: 10)
+- `action` — `"wait_for_loading_complete"`
+- `wait_config` — `{ "type": "loading_complete", "indicator": "any", "timeout_ms": <1000–60000> }`
 
-**Note:** Automatically detects project-specific loading indicators from `mobile-automator/config.json`
+**Note:** `indicator` may be `shimmer`, `spinner`, `progress_bar`, `skeleton`, or `any` (default `any`).
 
 **Example:**
 ```json
 {
-  "wait_for_data_load": {
-    "type": "wait_for_loading_complete",
-    "timeout_seconds": 30
-  }
+  "id": "wait_for_data_load",
+  "action": "wait_for_loading_complete",
+  "description": "Wait for the feed to finish loading",
+  "wait_config": { "type": "loading_complete", "indicator": "any", "timeout_ms": 30000 }
 }
 ```
 
 ---
 
 #### 13. capture_value
-Extract text/value from an element and store in a variable.
+Extract text/value from an element and store it in a variable.
 
 **Fields:**
-- `type` — `"capture_value"`
-- `element` — Element to extract from
-- `capture_to` — Variable name to store value (must be declared in `variables` section)
+- `action` — `"capture_value"`
+- `target` — Element to extract from
+- `capture_to` — Variable name to store the value in (must be declared in the `variables` block)
 
 **Example:**
 ```json
 {
-  "capture_order_id": {
-    "type": "capture_value",
-    "element": "order_confirmation_code",
-    "capture_to": "order_id"
-  }
+  "id": "capture_order_id",
+  "action": "capture_value",
+  "description": "Capture the order confirmation code",
+  "target": "Order confirmation code",
+  "capture_to": "order_id"
 }
 ```
 
 ---
 
 #### 14. clear_app_data
-Clear app data and cache (precondition action).
+Clear app data and cache (setup action).
 
 **Fields:**
-- `type` — `"clear_app_data"`
-- `app_package` (optional) — Package to clear (default: primary app)
+- `action` — `"clear_app_data"`
 
 **Example:**
 ```json
 {
-  "reset_app": {
-    "type": "clear_app_data"
-  }
+  "id": "reset_app",
+  "action": "clear_app_data",
+  "description": "Clear app data to start from a clean state"
 }
 ```
 
@@ -394,95 +390,110 @@ Clear app data and cache (precondition action).
 
 ### Step Field Options
 
-Additional fields that can be added to any step:
+Additional optional fields that can be added to any step object:
 
 #### optional
-If `true`, step continues even if it fails. Default: `false`
+If `true`, failure to find or interact with the target is silently ignored and execution continues. Default: `false`
 
 ```json
 {
-  "optional_feature_check": {
-    "type": "tap",
-    "element": "optional_button",
-    "optional": true
-  }
+  "id": "optional_feature_check",
+  "action": "tap",
+  "description": "Dismiss the promo banner if it appears",
+  "target": "Promo banner close button",
+  "optional": true
 }
 ```
 
 #### retry_policy
-Configure automatic retry behavior for flaky steps.
+Configure automatic retry behavior. Only applies when `on_failure` is `"retry"`.
 
 ```json
 {
-  "flaky_element_step": {
-    "type": "wait_for_element",
-    "element": "sometimes_slow_element",
-    "retry_policy": {
-      "max_retries": 3,
-      "backoff_ms": 500,
-      "backoff_multiplier": 1.5
-    }
+  "id": "flaky_element_step",
+  "action": "wait_for_element",
+  "description": "Wait for the sometimes-slow element",
+  "target": "Slow-loading widget",
+  "wait_config": { "type": "element_visible", "timeout_ms": 10000 },
+  "on_failure": "retry",
+  "retry_policy": {
+    "max_attempts": 3,
+    "backoff_ms": 500
   }
 }
 ```
+
+- `max_attempts` — Total attempts including the first (integer, 2–5)
+- `backoff_ms` — Milliseconds to wait between attempts (default `1000`)
 
 #### condition
-Execute step only if condition is true. Reference variables: `"${{variable_name}}"`
+Execute the step only if the condition object evaluates to true; otherwise the step is skipped.
 
 ```json
 {
-  "conditionally_submit": {
-    "type": "tap",
-    "element": "submit_button",
-    "condition": "${{user_role}} == 'admin'"
+  "id": "conditionally_submit",
+  "action": "tap",
+  "description": "Submit only when running on Android",
+  "target": "Submit button",
+  "condition": {
+    "type": "device_property",
+    "property": "platform",
+    "operator": "==",
+    "value": "android"
   }
 }
 ```
 
+Condition `type` is one of `device_property`, `previous_step_skipped`, `variable_value`, or `element_visible`.
+
 #### on_failure
-Action to take if step fails: `"skip_remaining"`, `"retry"`, `"capture_screenshot"`, `"continue"`
+What to do when the step fails: `"fail"` (default), `"skip"`, or `"retry"`.
 
 ```json
 {
-  "critical_step": {
-    "type": "tap",
-    "element": "critical_button",
-    "on_failure": "capture_screenshot"
-  }
+  "id": "critical_step",
+  "action": "tap",
+  "description": "Tap the critical confirm button",
+  "target": "Confirm button",
+  "on_failure": "fail"
 }
 ```
 
 #### sub_steps
-Nested steps within a parent step (useful for complex interactions).
+A nested sub-flow (array of step objects) to execute when this step's `condition` is met. After the sub-steps complete, execution resumes at the next top-level step.
 
 ```json
 {
-  "complex_flow": {
-    "type": "tap",
-    "element": "menu",
-    "sub_steps": [
-      { "tap_submenu": { "type": "tap", "element": "submenu_item" } },
-      { "verify_result": { "type": "wait_for_element", "element": "result" } }
-    ]
-  }
+  "id": "complex_flow",
+  "action": "tap",
+  "description": "Open the menu, then run the nested flow",
+  "target": "Menu button",
+  "sub_steps": [
+    { "id": "tap_submenu", "action": "tap", "description": "Open the submenu", "target": "Settings submenu" },
+    { "id": "verify_result", "action": "wait_for_element", "description": "Wait for the settings panel", "target": "Settings panel", "wait_config": { "type": "element_visible", "timeout_ms": 5000 } }
+  ]
 }
 ```
 
 #### wait_config
-Configure wait behavior within a step.
+Configuration for wait-type actions (`wait_for_element`, `wait_for_element_gone`, `wait_for_loading_complete`).
 
 ```json
 {
-  "step_with_custom_wait": {
-    "type": "tap",
-    "element": "button",
-    "wait_config": {
-      "implicit_wait_ms": 1000,
-      "explicit_timeout_seconds": 5
-    }
+  "id": "wait_step",
+  "action": "wait_for_element",
+  "description": "Wait for the confirmation banner",
+  "target": "Confirmation banner",
+  "wait_config": {
+    "type": "element_visible",
+    "timeout_ms": 5000
   }
 }
 ```
+
+- `type` — `element_visible`, `element_gone`, or `loading_complete`
+- `timeout_ms` — Maximum wait in milliseconds (1000–60000)
+- `indicator` (loading only) — `shimmer`, `spinner`, `progress_bar`, `skeleton`, or `any`
 
 ---
 
@@ -533,8 +544,11 @@ Define setup requirements and device state before test execution.
 | Field | Type | Description |
 |-------|------|-------------|
 | `app_state` | string | Required app state: `fresh_install`, `logged_in`, `logged_out`, `any` |
-| `device_actions` | array | Setup actions to perform (clear data, install app, etc.) |
-| `device_properties` | object | Required device properties (network, location, orientation) |
+| `device_actions` | array | Automated setup actions to perform before the scenario starts |
+| `device_properties` | object | Required device properties (network, location_services, orientation) |
+| `notes` | array | Human-readable notes about preconditions that cannot be automated |
+
+Each `device_actions` item has an `action` (`clear_app_data`, `uninstall_app`, `install_app`, `enable_wifi`, `disable_wifi`, `set_orientation`) plus optional `target_package`, `value`, and `description`.
 
 **Example:**
 ```json
@@ -544,6 +558,7 @@ Define setup requirements and device state before test execution.
     "device_actions": [
       {
         "action": "clear_app_data",
+        "target_package": "com.example.app",
         "description": "Clear any cached login data"
       }
     ],
@@ -551,7 +566,8 @@ Define setup requirements and device state before test execution.
       "network": "wifi",
       "location_services": "enabled",
       "orientation": "portrait"
-    }
+    },
+    "notes": ["A valid test account must exist in the staging environment"]
   }
 }
 ```
@@ -560,17 +576,18 @@ Define setup requirements and device state before test execution.
 
 ## Assertions Array
 
-Define verification rules that must pass for the test to succeed.
+Define verification rules that must pass for the test to succeed. Each assertion requires `id`, `after_step`, `type`, and `description`.
 
 **Fields:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `id` | string | **YES** | Unique assertion ID in snake_case |
-| `description` | string | **YES** | Human-readable assertion description |
+| `after_step` | string | **YES** | The `id` of the step after which this assertion runs |
 | `type` | string | **YES** | Assertion type (one of 27 types) |
-| `element` | string | Depends | Element to assert (required for most types) |
-| Additional fields | varies | Depends | Type-specific fields (e.g., `expected_exact`, `expected_contains`) |
+| `description` | string | **YES** | Human-readable assertion description |
+| `element_description` | string | Depends | Semantic description of the element to check (for element-based types) |
+| Type-specific fields | varies | Depends | e.g., `expected_value`, `expected_substring`, `expected_count`, `expected_text`, `pattern` |
 
 **Example:**
 ```json
@@ -578,29 +595,32 @@ Define verification rules that must pass for the test to succeed.
   "assertions": [
     {
       "id": "welcome_message",
-      "description": "Welcome message displays user's name",
+      "after_step": "wait_for_home",
       "type": "element_text",
-      "element": "welcome_label",
-      "expected_exact": "Welcome, John Doe"
+      "description": "Welcome message displays the user's name",
+      "element_description": "Welcome label",
+      "expected_value": "Welcome, John Doe"
     },
     {
       "id": "dashboard_visible",
-      "description": "Dashboard content is fully visible",
+      "after_step": "wait_for_home",
       "type": "element_fully_visible",
-      "element": "dashboard_content"
+      "description": "Dashboard content is fully visible",
+      "element_description": "Dashboard content"
     },
     {
       "id": "verification_code_format",
-      "description": "Verification code has correct format",
+      "after_step": "wait_for_home",
       "type": "pattern_match",
-      "element": "code_display",
-      "expected_pattern": "^[0-9]{6}$"
+      "description": "Verification code has the correct format",
+      "element_description": "Verification code display",
+      "pattern": "^[0-9]{6}$"
     }
   ]
 }
 ```
 
-**See [Assertion Types Reference](assertions.md) for complete documentation on all 27 assertion types.**
+**See [Assertion Types Reference](assertions.md) for complete documentation on all 27 assertion types and their type-specific fields.**
 
 ---
 
@@ -657,7 +677,7 @@ Categorization tags for filtering and organizing scenarios.
 
 ```json
 {
-  "$schema_version": "2.0",
+  "$schema_version": "2.1",
   "scenario_id": "login_with_2fa",
   "name": "Login with 2FA",
   "description": "Verify user can log in with email/password and complete two-factor authentication",
@@ -679,87 +699,119 @@ Categorization tags for filtering and organizing scenarios.
     "device_actions": [
       {
         "action": "clear_app_data",
+        "target_package": "com.example.app",
         "description": "Clear cached login data"
       }
-    ]
+    ],
+    "notes": ["A valid test account must exist in the staging environment"]
   },
-  "steps": {
-    "launch_app": {
-      "type": "launch_app"
+  "steps": [
+    {
+      "id": "launch_app",
+      "action": "launch_app",
+      "description": "Launch the app under test"
     },
-    "wait_for_login_screen": {
-      "type": "wait_for_element",
-      "element": "email_input",
-      "timeout_seconds": 10
+    {
+      "id": "wait_for_login_screen",
+      "action": "wait_for_element",
+      "description": "Wait for the login screen to load",
+      "target": "Email input field",
+      "wait_config": { "type": "element_visible", "timeout_ms": 10000 }
     },
-    "enter_email": {
-      "type": "type",
-      "text": "testuser@example.com"
+    {
+      "id": "tap_email_field",
+      "action": "tap",
+      "description": "Focus the email field",
+      "target": "Email input field"
     },
-    "enter_password": {
-      "type": "tap",
-      "element": "password_input"
+    {
+      "id": "enter_email",
+      "action": "type",
+      "description": "Type the test account email",
+      "value": "testuser@example.com"
     },
-    "type_password": {
-      "type": "type",
-      "text": "SecurePassword123!"
+    {
+      "id": "tap_password_field",
+      "action": "tap",
+      "description": "Focus the password field",
+      "target": "Password input field"
     },
-    "tap_login": {
-      "type": "tap",
-      "element": "login_button"
+    {
+      "id": "type_password",
+      "action": "type",
+      "description": "Type the test account password",
+      "value": "SecurePassword123!"
     },
-    "wait_for_2fa_prompt": {
-      "type": "wait_for_element",
-      "element": "2fa_code_input",
-      "timeout_seconds": 15,
-      "retry_policy": {
-        "max_retries": 2,
-        "backoff_ms": 1000
-      }
+    {
+      "id": "tap_login",
+      "action": "tap",
+      "description": "Submit the login form",
+      "target": "Login button"
     },
-    "enter_2fa_code": {
-      "type": "type",
-      "text": "123456"
+    {
+      "id": "wait_for_2fa_prompt",
+      "action": "wait_for_element",
+      "description": "Wait for the two-factor code prompt",
+      "target": "2FA code input field",
+      "wait_config": { "type": "element_visible", "timeout_ms": 15000 },
+      "on_failure": "retry",
+      "retry_policy": { "max_attempts": 3, "backoff_ms": 1000 }
     },
-    "tap_verify": {
-      "type": "tap",
-      "element": "verify_2fa_button"
+    {
+      "id": "enter_2fa_code",
+      "action": "type",
+      "description": "Type the two-factor authentication code",
+      "value": "123456"
     },
-    "wait_for_dashboard": {
-      "type": "wait_for_loading_complete",
-      "timeout_seconds": 20
+    {
+      "id": "tap_verify",
+      "action": "tap",
+      "description": "Confirm the 2FA code",
+      "target": "Verify button"
     },
-    "capture_auth_token": {
-      "type": "capture_value",
-      "element": "auth_header_token",
+    {
+      "id": "wait_for_dashboard",
+      "action": "wait_for_loading_complete",
+      "description": "Wait for the dashboard to finish loading",
+      "wait_config": { "type": "loading_complete", "timeout_ms": 20000 }
+    },
+    {
+      "id": "capture_auth_token",
+      "action": "capture_value",
+      "description": "Capture the auth token from the session badge",
+      "target": "Auth token badge",
       "capture_to": "auth_token"
     }
-  },
+  ],
   "assertions": [
     {
       "id": "login_success",
-      "description": "User successfully logged in and dashboard is visible",
+      "after_step": "wait_for_dashboard",
       "type": "element_exists",
-      "element": "dashboard_content"
+      "description": "User successfully logged in and the dashboard is visible",
+      "element_description": "Dashboard content"
     },
     {
       "id": "welcome_message",
-      "description": "Welcome message displays correct user",
+      "after_step": "wait_for_dashboard",
       "type": "text_contains",
-      "element": "welcome_label",
-      "expected_contains": "Welcome"
+      "description": "Welcome banner greets the user",
+      "element_description": "Welcome banner",
+      "expected_substring": "Welcome"
     },
     {
       "id": "auth_token_captured",
-      "description": "Authentication token was captured",
+      "after_step": "capture_auth_token",
       "type": "text_not_empty",
-      "element": "auth_header_token"
+      "description": "An auth token was captured",
+      "element_description": "Auth token badge"
     },
     {
       "id": "dashboard_fully_loaded",
-      "description": "Dashboard is fully visible",
+      "after_step": "wait_for_dashboard",
       "type": "element_fully_visible",
-      "element": "dashboard_content"
+      "description": "Dashboard content is fully visible",
+      "element_description": "Dashboard content"
     }
   ]
 }
@@ -770,13 +822,12 @@ Categorization tags for filtering and organizing scenarios.
 
 ## Validation Rules
 
-**schema_version:**
-- Must be exactly `"2.0"`
-- Required, must be first field
+**$schema_version:**
+- Accepts `"2.0"` or `"2.1"` (default `"2.0"`); `"2.1"` is current and additive
+- Required
 
 **scenario_id:**
 - Format: `^[a-z][a-z0-9_]*$`
-- Max 50 characters
 - Unique within project
 
 **platform:**
@@ -788,14 +839,18 @@ Categorization tags for filtering and organizing scenarios.
 - Must be valid for target platform
 
 **Steps:**
+- `steps` is an array; each item requires `id`, `action`, and `description`
 - All step IDs must follow format: `^[a-z][a-z0-9_]*$`
-- Step IDs must be unique within scenario
-- All referenced elements must be valid locators
+- Step IDs must be unique within the scenario
+- `target` values are semantic element descriptions, never `resource-id` / OS locators
 
 **Assertions:**
+- Each assertion requires `id`, `after_step`, `type`, and `description`
+- `after_step` must reference a valid step `id`
 - All assertion IDs must be unique
 - `type` must be one of 27 supported types
-- Type-specific fields must be present
+
+Validate a scenario file at any time with `mauto validate <file>`, which returns the uniform envelope with `data.valid`.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: mobile-automator
-site_description: Intelligent mobile QA automation for Gemini CLI - auto-detect mobile app architecture, generate test scenarios, and execute with AI-powered assertions
+site_description: Intelligent mobile QA automation for any AI coding agent via the mauto CLI - auto-generate test scenarios and execute them with AI-powered assertions on real devices and emulators
 site_url: https://sh3lan93.github.io/mobile-automator/
 repo_url: https://github.com/sh3lan93/mobile-automator
 repo_name: sh3lan93/mobile-automator
@@ -75,8 +75,9 @@ nav:
   - Core Concepts:
       - Core Concepts: concepts/index.md
       - Architecture: concepts/architecture.md
-      - 3-Tier Design: concepts/three-tier-design.md
+      - Layered Architecture: concepts/three-tier-design.md
       - How Skills Work: concepts/skills.md
+      - Cross-Session Memory: concepts/memory.md
   - Guides:
       - Command Guides: guides/index.md
       - Setup Command: guides/setup.md
@@ -84,10 +85,11 @@ nav:
       - Execute Command: guides/execute.md
   - Reference:
       - Reference: reference/index.md
+      - CLI Verbs: reference/cli-verbs.md
       - Assertion Types: reference/assertions.md
       - Test Scenario Schema: reference/schema.md
       - Test Result Schema: reference/result-schema.md
-      - MCP Tools: reference/mcp-tools.md
+      - Internal Engine (mobile-mcp): reference/mcp-tools.md
   - Examples:
       - Example Scenarios: examples/index.md
       - Android Examples: examples/android.md


### PR DESCRIPTION
## What & why

The published docs site had drifted well behind the code. The big Gemini-extension → `mauto` CLI sweep landed in v0.21.0 (PR #124), but three things that shipped **in the same release** never made it onto the site, and the scenario-schema pages had accumulated field-name drift. This PR brings the site current with **v0.21.0**.

### New pages
- **`reference/cli-verbs.md`** — a single catalog of every `mauto` verb (device, author/verify, workspace, reasoning, agent-integration, session, memory), the uniform JSON envelope, `--human`, the RAW-output exception, and the error-kind → exit-code table.
- **`concepts/memory.md`** — the cross-session memory subsystem: `run-history` (machine-owned, auto-harvested on `result finalize`), agent-authored `app-knowledge`/`preferences`, the `mauto memory` verbs, and durability (lock + atomic writes + `.corrupt` sidecars).

### Feature coverage added
- **Memory** woven into home, concepts, the generate/execute guides, FAQ, and contributing.
- **Seven v0.21.0 device verbs** (`long-press`, `double-tap`, `launch`, `install`, `uninstall`, `open-url`, `orientation`) added to the verb listings.
- **Persistent device session** (`mauto session` / `mauto devices`) documented on home + FAQ.

### Correctness fixes (schema drift)
Docs disagreed with `src/schemas/scenario_schema.json` on both field names and version semantics. Corrected against the real schema:
- `steps` is an **array** of `{id, action, description}` (was shown as an object keyed by name in several fragments).
- Assertion fields: `expected_exact`/`expected_contains` → `expected_value`/`expected_substring`; preconditions `setup_actions` → `device_actions`; retry `max_retries`/`wait_between_retries_ms` → `max_attempts`/`backoff_ms`; `timeout_seconds` → `wait_config.timeout_ms`.
- **Version messaging**: scenario `$schema_version` accepts `"2.0"` or `"2.1"` (2.1 is current & additive — adds `mode` + semantic actions); result `schema_version` stays `const "2.0"` (clarified, **not** bumped — result-file `step_id`/`assertion_id` are legitimate and were left intact).
- All 10 Android/iOS example scenarios rewritten to be schema-valid.

### Misc
- `mkdocs.yml` `site_description` rewritten off "for Gemini CLI" to host-agnostic; nav "3-Tier Design" → "Layered Architecture", "MCP Tools" → "Internal Engine (mobile-mcp)".
- Removed stray `</content></invoke>` tags in `contributing.md`; repointed a broken `#using-another-agent` anchor in `quick-start.md`.

## Test plan
- ✅ **Every complete scenario JSON block validates** — a sweep extracts all 16 complete-scenario blocks from the docs and runs `mauto validate`: 16/16 `ok:true`.
- ✅ **`mkdocs build --strict`** exits 0 (no broken internal links / nav issues).
- ✅ **Lint guards** (incl. `docs-no-stale-extension`): 84/84 pass.
- ✅ **Full suite**: 579/579 tests pass.
- ✅ Docs-only change — no `src/`/`bin/`/`package.json` edits, so the version-bump gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)