### PR TITLE
docs(site): fix SEO metadata, dead link & logo a11y from site audit

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,5 @@
 ---
+title: "Changelog & Release Notes"
 description: "Changelog for mobile-automator - version history, new features, breaking changes, and migration notes from v0.1.0 to latest."
 ---
 
@@ -224,7 +225,7 @@ Schema v1 is deprecated as of **2026-02-17**. The 12-month deprecation timeline:
 | Phase 2 | 2026-08-17 → 2027-01-17 | New v1 generation blocked; execution requires acknowledgment |
 | Phase 3 | 2027-01-17+ | Hard fail — v1 scenarios will not execute |
 
-Migrate existing scenarios with `/mobile-automator:migrate <scenario_id>`. See [MIGRATION.md](https://github.com/sh3lan93/mobile-automator/blob/main/MIGRATION.md) for the full guide.
+Migrate existing scenarios with `/mobile-automator:migrate <scenario_id>`. See [MIGRATION.md](https://github.com/sh3lan93/mobile-automator/blob/v0.1.1/MIGRATION.md) for the full guide.
 
 ---
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -1,5 +1,5 @@
 ---
-description: "How mobile-automator's cross-session memory works - the run-history, app-knowledge, and preferences kinds, the memory verbs, and how the agent gets smarter about your app over time."
+description: "How mobile-automator's cross-session memory works: the run-history, app-knowledge, and preferences kinds, plus the verbs that make the agent smarter over time."
 ---
 
 # Cross-Session Memory

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -1,5 +1,5 @@
 ---
-description: "How mobile-automator skills work - native Agent Skills installed per host by mauto init, guide content in src/guide/content, and placeholders filled at emit time."
+description: "How mobile-automator skills work: native Agent Skills installed per host by mauto init, with guide content and placeholders resolved at emit time."
 ---
 
 # How Skills Work

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Step-by-step guides for mobile-automator - setup, generate, and execute workflows with detailed walkthroughs."
+description: "Step-by-step guides for mobile-automator covering the setup, generate, and execute workflows, each with detailed walkthroughs and command examples."
 ---
 
 # Guides

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
-description: "Intelligent mobile QA automation for any AI coding agent. The host-agnostic mauto CLI drives a device to auto-generate test scenarios and execute them with AI-powered assertions."
+title: "AI-driven mobile QA automation"
+description: "Intelligent mobile QA automation for any AI coding agent. The host-agnostic mauto CLI auto-generates test scenarios and runs AI-powered assertions on devices."
 ---
 
 # mobile-automator

--- a/docs/overrides/partials/logo.html
+++ b/docs/overrides/partials/logo.html
@@ -1,0 +1,12 @@
+{#-
+  Override of Material's partials/logo.html.
+  Fixes two audit findings on the header brand image (present on every page):
+    - a11y/image-redundant-alt: default theme hardcodes alt="logo" (matches filename)
+    - images/dimensions + perf/cls-hints: no width/height -> layout shift
+  Descriptive alt (site name) + explicit 32x32 (Material header logo size) resolve both.
+-#}
+{% if config.theme.logo %}
+  <img src="{{ config.theme.logo | url }}" alt="{{ config.site_name }} logo" width="32" height="32">
+{% elif config.theme.icon.logo %}
+  {% include ".icons/" ~ config.theme.icon.logo ~ ".svg" %}
+{% endif %}

--- a/docs/reference/cli-verbs.md
+++ b/docs/reference/cli-verbs.md
@@ -1,5 +1,6 @@
 ---
-description: "Complete reference for every mauto CLI verb - device actions, authoring, workspace, reasoning, agent integration, device session, and cross-session memory - with the uniform JSON envelope and exit codes."
+title: "CLI Verbs Reference"
+description: "Complete reference for every mauto CLI verb - device actions, authoring, workspace, reasoning, sessions, and memory - with the uniform JSON envelope."
 ---
 
 # CLI Verbs Reference

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,4 +1,5 @@
 ---
+title: "Reference & Schemas"
 description: "Complete reference documentation for mobile-automator schemas, 27 assertion types, 14 action types, and MCP automation tools."
 ---
 


### PR DESCRIPTION
## What & why

A squirrelscan audit of the live docs site (https://sh3lan93.github.io/mobile-automator/) scored **36/100 (F)**. Most of that is host/theme-inherent (GitHub Pages security headers, trailing-slash 301s, Material theme ARIA widgets) and not fixable from docs source. This PR lands the **author-controllable** findings.

### Changes
- **Dead link (404):** changelog's `MIGRATION.md` link pointed at `blob/main/` (file was intentionally deleted in a later release). Re-pointed to `blob/v0.1.1/` — the tag where the file still exists (verified 200). Faithful to changelog-as-history.
- **Short `<title>`s (16–28 → 38–49 chars):** added `title:` frontmatter to home, reference index, changelog, and cli-verbs pages.
- **Off-length meta descriptions (109–203 → 146–159 chars):** tuned home, cli-verbs, guides index, memory, and skills into the 120–160 sweet spot.
- **Logo a11y/CLS (all pages):** overrode Material's `partials/logo.html` — the default hardcodes `alt="logo"` with no dimensions. Now `alt="mobile-automator logo" width="32" height="32"`, clearing the redundant-alt, images/dimensions, and CLS warnings site-wide.

### Out of scope (not fixable from docs source)
CSP/HSTS/X-Frame-Options headers, HTTP→HTTPS & trailing-slash 301s, ~100 Material-theme ARIA errors, and the domain-root `robots.txt` (belongs to a separate GitHub user-pages repo). Sitemap and subpath robots.txt already work (200).

## Test plan
- [x] `mkdocs build` passes
- [x] Rendered `<title>` tags verified (38–49 chars)
- [x] Rendered meta descriptions verified (146–159 chars)
- [x] Logo `<img>` renders with descriptive alt + 32×32 dimensions
- [x] `sitemap.xml` still auto-generates
- [ ] Re-audit live site after merge + Pages redeploy to confirm the delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)