### PR TITLE
fix(config): store config list keys as lists, not comma-joined strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.21.1]
 
 ### 🐛 Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Workspace config values are now typed.** `mauto config set environments "a,b"` stored the literal string `"a,b"` instead of a list, because `config set` had no idea what shape any key held — it opportunistically `JSON.parse`d and fell back to the raw string, while the setup guide told the agent to pass a comma-separated value. The same defect hit `protected_directories` and `business_critical_paths`, and the same untyped handler retyped scalars (`config set project_name 12345` stored a number). A new `src/schemas/config_schema.json` declares the type of every known key; `config set` now coerces the raw argument to the declared type (comma-separated *or* JSON array → list; string keys stay strings) and validates it per-key before writing, returning a `hint` pointing at the new `mauto schema config` verb on a violation. Configs written by earlier versions are healed on read and rewritten in healed form by the next write. Unknown keys stay writable — the schema types keys, it does not gate them. A structural guard (`tests/lint/config-schema.test.js`) holds the schema, the placeholder table, the scaffold skeleton, the shipped fixtures, and the setup guide prose in agreement. ([#136](https://github.com/sh3lan93/mobile-automator/issues/136))
+
+### ✨ Added
+
+- `mauto schema config` prints the workspace config schema, so an agent can pull the config contract the same way it pulls `mauto schema scenario`. ([#136](https://github.com/sh3lan93/mobile-automator/issues/136))
+
 ## [0.21.0]
 
 ### ♻️ Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ src/
   schemas/
     scenario_schema.json      # v2.1
     result_schema.json
+    config_schema.json
 mobile-automator/             # created in user's project by `mauto setup`
   config.json  scenarios/  screenshots/  results/  .session/
   memory/                      # cross-session memory (run-history.md)
@@ -55,7 +56,7 @@ All verbs emit `{ok,data,error,hint,schema_version}`; `--human` is an opt-in rea
 - **Device actions:** `elements`, `tap`, `type <text>`, `swipe`, `press <button>`, `screenshot <path>`
 - **Author & verify:** `validate <file>`, `assert <type>`, `result add-step`, `result finalize`
 - **Workspace:** `setup`, `config get <key>`, `config set <key> <value>`
-- **Reasoning** (agent pulls on demand): `guide <topic>` (topics: `generate`, `execute`, `setup`); `bootstrap` (verb map + invariants); `schema <name>` (names: `scenario`, `result`)
+- **Reasoning** (agent pulls on demand): `guide <topic>` (topics: `generate`, `execute`, `setup`); `bootstrap` (verb map + invariants); `schema <name>` (names: `scenario`, `result`, `config`)
 - **Agent integration:** `init --agent <claude|cursor|gemini|copilot|agents|all>` (installs native Agent Skills per host + writes slash-commands/rules + MCP entry for claude/cursor); `mcp` (runs an MCP prompts server exposing guide topics)
 - **Device session:** `session start|status|end`; `devices` (list); `devices use <id>`; `devices clear`
 - **Memory:** `memory show` (read), `memory add <text> --kind <app-knowledge|preferences>` / `memory forget --kind <k> --match <substr>` (agent-authored); run-history is auto-harvested on `result finalize`

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ mobile-automator/
 └── results/           # execution results
 ```
 
-Scenario and result schemas: `mauto schema scenario` / `mauto schema result`.
+Scenario, result, and config schemas: `mauto schema scenario` / `mauto schema result` / `mauto schema config`.
 
 ---
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -24,7 +24,7 @@ Any AI agent (Claude Code, Cursor, Gemini CLI, Copilot, and more) drives the wor
 
 - `mauto guide <generate|execute|setup>` — task-specific reasoning prose
 - `mauto bootstrap` — verb map + invariants
-- `mauto schema <scenario|result>` — the JSON schemas
+- `mauto schema <scenario|result|config>` — the JSON schemas
 
 `mauto init --agent <host>` installs native Agent Skills per host so the agent knows when to pull each guide.
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -43,7 +43,7 @@ Any AI host — Claude Code, Cursor, Gemini CLI, Copilot, and more — pulls rea
 - `mauto guide execute` — execute scenarios, collect results
 - `mauto guide setup` — workspace setup reasoning
 - `mauto bootstrap` — verb map + invariants
-- `mauto schema <scenario|result>` — the JSON schemas
+- `mauto schema <scenario|result|config>` — the JSON schemas
 
 `mauto init --agent <host>` installs native Agent Skills per host. In Claude Code these arrive as the hyphen slash-commands `/mobile-automator-generate` and `/mobile-automator-execute`.
 

--- a/docs/concepts/three-tier-design.md
+++ b/docs/concepts/three-tier-design.md
@@ -56,7 +56,7 @@ The agent is not pre-loaded with an always-on skill. It pulls task-specific reas
 - `mauto guide execute` — reasoning for running scenarios and collecting results
 - `mauto guide setup` — reasoning for workspace setup
 - `mauto bootstrap` — the verb map + invariants the agent must honor
-- `mauto schema <scenario|result>` — the JSON schemas
+- `mauto schema <scenario|result|config>` — the JSON schemas
 
 `mauto init --agent <host>` installs a thin native Agent Skill per host that knows *when* to pull each guide. In Claude Code these are the hyphen slash-commands `/mobile-automator-generate` and `/mobile-automator-execute`.
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -164,6 +164,8 @@ It scans build configuration for named environments (Gradle `productFlavors` × 
 mauto config set environments <env1,env2,...>
 ```
 
+> List keys (`environments`, `protected_directories`, `business_critical_paths`) accept either a comma-separated value or a JSON array; both are stored as a JSON list. Run `mauto schema config` to see the declared type of every key.
+
 ### App package inference
 
 It reads the application identifier from build files and persists it per platform:
@@ -189,7 +191,7 @@ The agent infers and persists the deeper context that makes generated tests proj
 | `loading_indicators` | Progress/spinner/shimmer/skeleton patterns to wait on |
 | `protected_directories` | Source dirs the tooling must never modify |
 
-Each is persisted with `mauto config set <key> <value>` (comma-separated values for list keys), confirming uncertain values with you first.
+Each is persisted with `mauto config set <key> <value>` (comma-separated values for list keys), which are stored as JSON lists, confirming uncertain values with you first.
 
 ### Confirm the config
 

--- a/docs/reference/cli-verbs.md
+++ b/docs/reference/cli-verbs.md
@@ -117,7 +117,7 @@ The agent pulls reasoning on demand. These verbs **print raw content on success*
 | Verb | Description |
 |------|-------------|
 | `mauto guide <topic>` | Print the workflow guide for a topic: `generate`, `execute`, or `setup` |
-| `mauto schema <name>` | Print a schema: `scenario` or `result` |
+| `mauto schema <name>` | Print a schema: `scenario`, `result`, or `config` |
 | `mauto bootstrap` | Print the verb map and non-negotiable invariants |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mobile-automator",
-  "version": "0.21.0-rc.11",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobile-automator",
-      "version": "0.21.0-rc.11",
+      "version": "0.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@mobilenext/mobile-mcp": "0.0.55",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {
@@ -25,7 +25,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "lint:guides": "jest tests/lint/guide-no-mcp-tool-leak.test.js tests/lint/guide-no-placeholder-leak.test.js tests/lint/guide-agnostic-no-os.test.js tests/lint/skill-invariants.test.js tests/lint/skill-no-placeholder-leak.test.js tests/lint/skill-frontmatter-valid.test.js",
+    "lint:guides": "jest tests/lint/guide-no-mcp-tool-leak.test.js tests/lint/guide-no-placeholder-leak.test.js tests/lint/guide-agnostic-no-os.test.js tests/lint/skill-invariants.test.js tests/lint/skill-no-placeholder-leak.test.js tests/lint/skill-frontmatter-valid.test.js tests/lint/config-schema.test.js",
     "lint:schema-additive": "jest tests/lint/schema-additive.test.js",
     "test:unit": "jest tests/unit",
     "test:integration": "jest tests/integration",

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,8 @@ const { MemoryStore } = require('./memory/store');
 const { FILES: MEMORY_FILES, AGENT_KINDS } = require('./memory/paths');
 const { validateEntryText, MAX_ENTRY_LEN } = require('./memory/entries');
 const configManager = require('./config/manager');
+const { coerceValue } = require('./config/coerce');
+const { validateAt } = require('./config/schema');
 const { scaffold } = require('./setup/scaffold');
 const guideEmitter = require('./guide/emitter');
 const { ADAPTERS } = require('./init/adapters');
@@ -531,12 +533,21 @@ function handleConfigGet({ projectRoot }, key) {
   return { envelope: ok({ key, value }), exitKind: 'ok' };
 }
 
+// Coerce the raw CLI string into the type config_schema.json declares for this
+// key, then validate that one key before writing. Per-key (not whole-document)
+// so unrelated pre-existing drift never blocks an otherwise-valid write.
 function handleConfigSet({ projectRoot }, key, rawValue) {
-  let value = rawValue;
-  try {
-    value = JSON.parse(rawValue);
-  } catch (_) {
-    // Not JSON — keep the literal string.
+  const value = coerceValue(key, rawValue);
+  const { valid, errors } = validateAt(key, value);
+  if (!valid) {
+    return {
+      envelope: fail(
+        'invalid_input',
+        `invalid value for config key "${key}": ${errors.join('; ')}`,
+        'Run `mauto schema config` to see the declared type for this key. List keys accept a comma-separated value or a JSON array.'
+      ),
+      exitKind: 'invalid_input',
+    };
   }
   configManager.set(projectRoot, key, value);
   return { envelope: ok({ key, value }), exitKind: 'ok' };

--- a/src/cli.js
+++ b/src/cli.js
@@ -576,7 +576,7 @@ function handleSchema({ emitter = guideEmitter } = {}, name) {
     raw = emitter.emitSchema(name);
   } catch (err) {
     return {
-      envelope: fail('invalid_input', `unknown schema "${name}"`, 'Names: scenario, result.'),
+      envelope: fail('invalid_input', `unknown schema "${name}"`, 'Names: scenario, result, config.'),
       exitKind: 'invalid_input',
     };
   }
@@ -1179,7 +1179,7 @@ function buildProgram(deps = {}) {
     .action(withEnvelope((key) => emit(handleConfigGet({ projectRoot }, key), humanFlag())));
   config
     .command('set <key> <value>')
-    .description('Set a dotted-path config value (JSON-parsed when possible)')
+    .description('Set a dotted-path config value (coerced to its declared type per `mauto schema config`)')
     .action(withEnvelope((key, value) => emit(handleConfigSet({ projectRoot }, key, value), humanFlag())));
 
   program
@@ -1189,7 +1189,7 @@ function buildProgram(deps = {}) {
 
   program
     .command('schema <name>')
-    .description('Print the RAW JSON schema (scenario|result)')
+    .description('Print the RAW JSON schema (scenario|result|config)')
     .action(withEnvelope((name) => emitMaybeRaw(handleSchema({}, name))));
 
   program

--- a/src/config/coerce.js
+++ b/src/config/coerce.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Normalizes config values into the types config_schema.json declares.
+//
+// Two entry points, one contract:
+//   coerceValue    — a raw CLI string on the way IN to `config set`.
+//   normalizeConfig — a config object on the way OUT of `manager.load()`,
+//                     healing values written before the schema existed (#136).
+//
+// The comma-splitting rule is what makes the setup guide's long-standing
+// `mauto config set environments <env1,env2,...>` prose correct instead of
+// silently producing a string.
+
+const { declaredTypesAt, LIST_KEY_PATHS } = require('./schema');
+
+function splitList(raw) {
+  return String(raw)
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function tryJson(raw) {
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch (_) {
+    return { ok: false };
+  }
+}
+
+function coerceValue(dottedKey, rawValue) {
+  const types = declaredTypesAt(dottedKey);
+
+  // Undeclared key: preserve the historical lenient behavior exactly.
+  if (types.length === 0) {
+    const parsed = tryJson(rawValue);
+    return parsed.ok ? parsed.value : rawValue;
+  }
+
+  if (types.includes('array')) {
+    const parsed = tryJson(rawValue);
+    if (parsed.ok && Array.isArray(parsed.value)) return parsed.value;
+    return splitList(rawValue);
+  }
+
+  if (types.includes('string')) {
+    // Never let JSON.parse retype a string key (a project literally named
+    // "12345" stays a string). `null` is honored only where the schema
+    // declares the key nullable — that is how the scaffold seeds "unset".
+    if (types.includes('null') && String(rawValue).trim() === 'null') return null;
+    return String(rawValue);
+  }
+
+  const parsed = tryJson(rawValue);
+  return parsed.ok ? parsed.value : rawValue;
+}
+
+function getPath(obj, parts) {
+  let cur = obj;
+  for (const part of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}
+
+function setPath(obj, parts, value) {
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (cur[parts[i]] == null || typeof cur[parts[i]] !== 'object') return;
+    cur = cur[parts[i]];
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+// Heals every declared list path that holds a string. Values that are already
+// arrays — or are neither string nor array — are left exactly as found; this
+// repairs the known drift, it does not guess at anything else.
+function normalizeConfig(cfg) {
+  if (cfg == null || typeof cfg !== 'object') return cfg;
+  const out = JSON.parse(JSON.stringify(cfg));
+  for (const listPath of LIST_KEY_PATHS) {
+    const parts = listPath.split('.');
+    const current = getPath(out, parts);
+    if (typeof current === 'string') {
+      setPath(out, parts, splitList(current));
+    }
+  }
+  return out;
+}
+
+module.exports = { coerceValue, normalizeConfig, splitList };

--- a/src/config/coerce.js
+++ b/src/config/coerce.js
@@ -29,6 +29,13 @@ function tryJson(raw) {
 }
 
 function coerceValue(dottedKey, rawValue) {
+  // A bare `null` argument always means JSON null, regardless of the key's
+  // declared type. It is `validateAt` — not this function — that decides
+  // whether the key is allowed to hold it: keys declared nullable accept it,
+  // everything else gets a loud invalid_input instead of silently storing the
+  // string "null" (see #136 fix-wave, Important 2).
+  if (String(rawValue).trim() === 'null') return null;
+
   const types = declaredTypesAt(dottedKey);
 
   // Undeclared key: preserve the historical lenient behavior exactly.
@@ -45,9 +52,7 @@ function coerceValue(dottedKey, rawValue) {
 
   if (types.includes('string')) {
     // Never let JSON.parse retype a string key (a project literally named
-    // "12345" stays a string). `null` is honored only where the schema
-    // declares the key nullable — that is how the scaffold seeds "unset".
-    if (types.includes('null') && String(rawValue).trim() === 'null') return null;
+    // "12345" stays a string).
     return String(rawValue);
   }
 

--- a/src/config/manager.js
+++ b/src/config/manager.js
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { normalizeConfig } = require('./coerce');
 
 function configDir(projectRoot) {
   return path.join(projectRoot, 'mobile-automator');
@@ -16,11 +17,14 @@ function configPath(projectRoot) {
   return path.join(configDir(projectRoot), 'config.json');
 }
 
-// Parsed config object, or null when the file is absent.
+// Parsed config object, or null when the file is absent. Values written before
+// the config schema existed are healed on the way out (a comma-joined list key
+// becomes a real array) — see #136. Since set() is load-mutate-write, the next
+// write persists the healed shape.
 function load(projectRoot) {
   const p = configPath(projectRoot);
   if (!fs.existsSync(p)) return null;
-  return JSON.parse(fs.readFileSync(p, 'utf8'));
+  return normalizeConfig(JSON.parse(fs.readFileSync(p, 'utf8')));
 }
 
 // Default to platform-aware for null/empty/legacy configs.

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -78,7 +78,15 @@ function validateAt(dottedKey, value) {
   const sub = subschemaAt(dottedKey);
   if (!sub) return { valid: true, errors: [] }; // undeclared key -> always allowed
   if (!compiled.has(dottedKey)) {
-    compiled.set(dottedKey, ajv.compile(sub));
+    // `sub` may be an object-typed node (e.g. "app", "knowledge") whose OWN
+    // top-level $ref was resolved by subschemaAt's final deref, but whose
+    // nested properties (e.g. app.ios_bundle_id) still carry an unresolved
+    // local `#/definitions/...` $ref. Compiling `sub` standalone would make
+    // that pointer resolve against `sub`'s own (definitions-less) root and
+    // throw "can't resolve reference". Carrying the root `definitions`
+    // alongside makes every local ref in this schema resolve correctly no
+    // matter how deep the compiled subschema sits.
+    compiled.set(dottedKey, ajv.compile({ ...sub, definitions: schema.definitions }));
   }
   const fn = compiled.get(dottedKey);
   const valid = fn(value);

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -100,7 +100,19 @@ function validateAt(dottedKey, value) {
   const fn = compiled.get(dottedKey);
   const valid = fn(value);
   if (valid) return { valid: true, errors: [] };
-  return { valid: false, errors: (fn.errors || []).map(formatError) };
+  // formatError prefixes a root-level error with "(root)" — meaningful for
+  // the scenario validator, whose messages otherwise carry no subject. Here
+  // the CLI message already names the key ("invalid value for config key
+  // ..."), so a bare "(root)" only duplicates it; strip that one case. A
+  // non-root instancePath (e.g. "/android_package" on an object-typed key
+  // like "app") still adds information the key name alone doesn't, so it is
+  // left as formatError produced it. Fixed here, not in format-error.js,
+  // because the scenario validator's messages depend on that prefix.
+  const errors = (fn.errors || []).map((err) => {
+    const msg = formatError(err);
+    return err.instancePath ? msg : msg.replace(/^\(root\)\s*/, '');
+  });
+  return { valid: false, errors };
 }
 
 module.exports = {

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -21,18 +21,27 @@ const CONFIG_SCHEMA_PATH = path.resolve(__dirname, '../schemas/config_schema.jso
 const schema = JSON.parse(fs.readFileSync(CONFIG_SCHEMA_PATH, 'utf8'));
 const ajv = new Ajv({ allErrors: true, strict: false });
 
-// Resolve a local `$ref` ("#/definitions/stringList") one hop. The config
-// schema only ever uses single-hop local refs; anything else is left as-is and
-// Ajv resolves it at validation time.
+// Resolve a local `$ref` ("#/definitions/stringList") to a fixpoint: a
+// resolved node may itself be another `$ref` (e.g. a `$ref` to a `$ref`), so
+// one hop is not enough to agree with Ajv, which resolves refs fully. A
+// visited-set cycle guard makes a self-referential or circular `$ref` a no-op
+// (return the last-seen node) instead of an infinite loop.
 function deref(node) {
-  if (!node || typeof node !== 'object' || typeof node.$ref !== 'string') return node;
-  const parts = node.$ref.replace(/^#\//, '').split('/');
-  let cur = schema;
-  for (const part of parts) {
-    if (cur == null) return node;
-    cur = cur[part];
+  const seen = new Set();
+  let cur = node;
+  while (cur && typeof cur === 'object' && typeof cur.$ref === 'string') {
+    if (seen.has(cur.$ref)) return cur; // circular $ref — bail with what we have
+    seen.add(cur.$ref);
+    const parts = cur.$ref.replace(/^#\//, '').split('/');
+    let target = schema;
+    for (const part of parts) {
+      if (target == null) return cur; // unresolvable pointer — leave as-is
+      target = target[part];
+    }
+    if (!target) return cur;
+    cur = target;
   }
-  return cur || node;
+  return cur;
 }
 
 // Walk `properties` down a dotted path. Undeclared path -> null.

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -1,0 +1,95 @@
+'use strict';
+
+// Type lookup + per-key validation for the workspace config.
+//
+// config_schema.json is the single source of truth for what shape each config
+// key holds. This module is the only reader of that fact: the coercion layer
+// asks it "what type is this key?" and the CLI asks it "is this value valid?".
+// Nothing else hard-codes a config key's type.
+//
+// Validation is deliberately PER-KEY, not whole-document: a config carrying
+// unrelated pre-existing drift must not block an unrelated `config set`.
+
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+
+const { formatError } = require('../schemas/format-error');
+
+const CONFIG_SCHEMA_PATH = path.resolve(__dirname, '../schemas/config_schema.json');
+
+const schema = JSON.parse(fs.readFileSync(CONFIG_SCHEMA_PATH, 'utf8'));
+const ajv = new Ajv({ allErrors: true, strict: false });
+
+// Resolve a local `$ref` ("#/definitions/stringList") one hop. The config
+// schema only ever uses single-hop local refs; anything else is left as-is and
+// Ajv resolves it at validation time.
+function deref(node) {
+  if (!node || typeof node !== 'object' || typeof node.$ref !== 'string') return node;
+  const parts = node.$ref.replace(/^#\//, '').split('/');
+  let cur = schema;
+  for (const part of parts) {
+    if (cur == null) return node;
+    cur = cur[part];
+  }
+  return cur || node;
+}
+
+// Walk `properties` down a dotted path. Undeclared path -> null.
+function subschemaAt(dottedKey) {
+  const parts = String(dottedKey).split('.');
+  let node = schema;
+  for (const part of parts) {
+    node = deref(node);
+    if (!node || !node.properties || !node.properties[part]) return null;
+    node = node.properties[part];
+  }
+  const resolved = deref(node);
+  return resolved || null;
+}
+
+function declaredTypesAt(dottedKey) {
+  const sub = subschemaAt(dottedKey);
+  if (!sub || sub.type === undefined) return [];
+  return Array.isArray(sub.type) ? [...sub.type] : [sub.type];
+}
+
+// Every array-typed dotted path in the schema, flat and nested. Drives both
+// read-side healing and the structural lint guard.
+function collectListPaths(node, prefix, out) {
+  const resolved = deref(node);
+  if (!resolved || !resolved.properties) return out;
+  for (const [name, child] of Object.entries(resolved.properties)) {
+    const childPath = prefix ? `${prefix}.${name}` : name;
+    const rc = deref(child);
+    if (!rc) continue;
+    if (rc.type === 'array') out.push(childPath);
+    else if (rc.type === 'object' || rc.properties) collectListPaths(rc, childPath, out);
+  }
+  return out;
+}
+
+const LIST_KEY_PATHS = collectListPaths(schema, '', []);
+
+// Compiled per-path validators, built lazily and cached.
+const compiled = new Map();
+
+function validateAt(dottedKey, value) {
+  const sub = subschemaAt(dottedKey);
+  if (!sub) return { valid: true, errors: [] }; // undeclared key -> always allowed
+  if (!compiled.has(dottedKey)) {
+    compiled.set(dottedKey, ajv.compile(sub));
+  }
+  const fn = compiled.get(dottedKey);
+  const valid = fn(value);
+  if (valid) return { valid: true, errors: [] };
+  return { valid: false, errors: (fn.errors || []).map(formatError) };
+}
+
+module.exports = {
+  CONFIG_SCHEMA_PATH,
+  subschemaAt,
+  declaredTypesAt,
+  LIST_KEY_PATHS,
+  validateAt,
+};

--- a/src/guide/content/setup.agnostic.md
+++ b/src/guide/content/setup.agnostic.md
@@ -12,7 +12,7 @@ Every analysis result is stored in the workspace config:
 mauto config set <key> <value>
 ```
 
-For list-valued keys, pass a comma-separated value. Confirm uncertain values with the user before persisting; when a value truly cannot be inferred, ask the user directly and persist their answer.
+For list-valued keys (`environments`, `protected_directories`, `business_critical_paths`), pass a comma-separated value — it is stored as a JSON list. A JSON array is accepted too. Run `mauto schema config` to see the declared type of any key. Confirm uncertain values with the user before persisting; when a value truly cannot be inferred, ask the user directly and persist their answer.
 
 ## 1. Project basics
 
@@ -22,7 +22,7 @@ For list-valued keys, pass a comma-separated value. Confirm uncertain values wit
 ## 2. Business knowledge
 
 - **Business domain** — read `README.md`, app-store description, or the app display name to infer a one-sentence domain description. If you cannot tell, ask the user. Persist: `mauto config set business_domain "<one sentence>"`.
-- **Business-critical paths** — identify the most important user flows (onboarding, login, checkout, payment, search, profile, …) from navigation/route definitions, screen/page definitions, and feature structure. Confirm the list with the user. Persist a comma-separated value: `mauto config set business_critical_paths "<onboarding, login, checkout>"`.
+- **Business-critical paths** — identify the most important user flows (onboarding, login, checkout, payment, search, profile, …) from navigation/route definitions, screen/page definitions, and feature structure. Confirm the list with the user. Persist a comma-separated value (stored as a list): `mauto config set business_critical_paths "<onboarding, login, checkout>"`.
 
 ## 3. Loading indicators (semantic descriptions)
 
@@ -36,7 +36,7 @@ Ask the user to describe it if you cannot infer it from the UI. Persist the desc
 
 ## 4. Protected directories
 
-List the source directories the QA tooling must NEVER modify (it operates on test artifacts, not source code). Auto-detect common source roots that exist in the project (e.g. `src/`, `lib/`, app/module source trees), confirm with the user, then persist a comma-separated value: `mauto config set protected_directories "<src/, lib/>"`.
+List the source directories the QA tooling must NEVER modify (it operates on test artifacts, not source code). Auto-detect common source roots that exist in the project (e.g. `src/`, `lib/`, app/module source trees), confirm with the user, then persist a comma-separated value (stored as a list): `mauto config set protected_directories "<src/, lib/>"`.
 
 ## 5. Environments (optional)
 

--- a/src/guide/content/setup.aware.md
+++ b/src/guide/content/setup.aware.md
@@ -12,7 +12,7 @@ Every analysis result is stored in the workspace config:
 mauto config set <key> <value>
 ```
 
-For list-valued keys (e.g. `protected_directories`), pass a comma-separated value. When a value is uncertain, confirm it with the user before persisting. When you truly cannot infer a value, ask the user directly and persist their answer.
+For list-valued keys (e.g. `protected_directories`), pass a comma-separated value. Run `mauto schema config` to see the declared type of any key. When a value is uncertain, confirm it with the user before persisting. When you truly cannot infer a value, ask the user directly and persist their answer.
 
 ## 1. Detect the platform
 

--- a/src/guide/content/setup.aware.md
+++ b/src/guide/content/setup.aware.md
@@ -46,6 +46,8 @@ Deduplicate the result. If none are found, default to `production, staging, deve
 mauto config set environments <env1,env2,...>
 ```
 
+The comma-separated value is stored as a JSON list.
+
 ## 3. Infer the app package
 
 Read the application identifier from the build files, scoped to the platform:
@@ -66,9 +68,9 @@ Infer each of the following from the codebase, confirm uncertain values with the
 - **Build command** — the default debug/development build command (e.g. `./gradlew assembleDemoDebug`, `flutter build apk --flavor demo`, `npx react-native run-android`, or `xcodebuild -scheme <scheme>`). Persist: `mauto config set build_command "<command>"`.
 - **Architecture** — infer from directory and class naming (`viewmodel/` → MVVM; `repository/`+`usecase/`+`domain/`+`data/` → Clean Architecture; `bloc/`/`cubit/` → BLoC; `reducer/`/`store/` → Redux/MVI; `presenter/`/`interactor/` → MVP/VIPER). Combine findings (e.g. `"MVVM with Clean Architecture"`). If unclear, ask the user. Persist: `mauto config set architecture "<pattern>"`.
 - **Business domain** — read `README.md`, app-store metadata, `pubspec.yaml`/`package.json` description, or the app display name to infer a one-sentence domain description. If you cannot tell, ask the user. Persist: `mauto config set business_domain "<one sentence>"`.
-- **Business-critical paths** — analyze navigation graphs, route/deep-link definitions, screen/Activity/Fragment/ViewController/page definitions, and feature modules to find the most important user flows (login, signup, onboarding, checkout, payment, search, profile, …). Confirm the list with the user. Persist a comma-separated value: `mauto config set business_critical_paths "<onboarding, login, checkout>"`.
+- **Business-critical paths** — analyze navigation graphs, route/deep-link definitions, screen/Activity/Fragment/ViewController/page definitions, and feature modules to find the most important user flows (login, signup, onboarding, checkout, payment, search, profile, …). Confirm the list with the user. Persist a comma-separated value (stored as a list): `mauto config set business_critical_paths "<onboarding, login, checkout>"`.
 - **Loading indicators** — grep for loading widgets/components (progress indicators, spinners, shimmer/skeleton placeholders) and any `*Loading*`/`*Spinner*`/`*Shimmer*`/`*Skeleton*` classes. Persist the found names, or a description like `"progress bars, spinners, shimmer effects"` if none found. Persist: `mauto config set loading_indicators "<list>"`.
-- **Protected directories** — list the source directories the QA tooling must NEVER modify (e.g. `app/src/`, `lib/`, `src/`, `shared/`, `composeApp/`, `iosApp/`). Confirm with the user. Persist a comma-separated value: `mauto config set protected_directories "<app/src/, lib/, core/>"`.
+- **Protected directories** — list the source directories the QA tooling must NEVER modify (e.g. `app/src/`, `lib/`, `src/`, `shared/`, `composeApp/`, `iosApp/`). Confirm with the user. Persist a comma-separated value (stored as a list): `mauto config set protected_directories "<app/src/, lib/, core/>"`.
 
 ## 5. Confirm the config
 

--- a/src/guide/emitter.js
+++ b/src/guide/emitter.js
@@ -29,6 +29,7 @@ const PORTED_TOPICS = new Set(['generate', 'execute', 'setup']);
 
 const SCENARIO_SCHEMA = path.resolve(__dirname, '../schemas/scenario_schema.json');
 const RESULT_SCHEMA = path.resolve(__dirname, '../schemas/result_schema.json');
+const CONFIG_SCHEMA = path.resolve(__dirname, '../schemas/config_schema.json');
 
 const TOPICS = {
   generate:
@@ -78,8 +79,14 @@ function emitGuide(topic, { mode = 'platform-aware', projectRoot } = {}) {
   return lines.join('\n');
 }
 
+const SCHEMA_FILES = {
+  scenario: SCENARIO_SCHEMA,
+  result: RESULT_SCHEMA,
+  config: CONFIG_SCHEMA,
+};
+
 function emitSchema(name) {
-  const file = name === 'scenario' ? SCENARIO_SCHEMA : name === 'result' ? RESULT_SCHEMA : null;
+  const file = SCHEMA_FILES[name];
   if (!file) {
     throw new Error(`unknown schema name: ${name}`);
   }

--- a/src/guide/emitter.js
+++ b/src/guide/emitter.js
@@ -114,7 +114,7 @@ function emitBootstrap() {
     ['setup', 'scaffold the workspace and write a config'],
     ['config', 'get/set values in the workspace config'],
     ['guide', 'print the guide for a workflow topic'],
-    ['schema', 'print the scenario or result JSON schema'],
+    ['schema', 'print the scenario, result, or config JSON schema'],
   ];
 
   const lines = [];

--- a/src/scenario/validator.js
+++ b/src/scenario/validator.js
@@ -4,22 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const Ajv = require('ajv');
 
+const { formatError } = require('../schemas/format-error');
+
 // Path to the canonical scenario schema, bundled inside the package.
 // src/scenario/validator.js -> ../schemas/scenario_schema.json
 const DEFAULT_SCHEMA_PATH = path.resolve(__dirname, '../schemas/scenario_schema.json');
-
-function formatError(err) {
-  const where = err.instancePath || '(root)';
-  let msg = `${where} ${err.message}`;
-  if (err.keyword === 'required' && err.params && err.params.missingProperty) {
-    msg = `${where} is missing required property '${err.params.missingProperty}'`;
-  } else if (err.keyword === 'enum' && err.params && Array.isArray(err.params.allowedValues)) {
-    msg = `${where} ${err.message}: ${err.params.allowedValues.join(', ')}`;
-  } else if (err.keyword === 'additionalProperties' && err.params) {
-    msg = `${where} has unexpected property '${err.params.additionalProperty}'`;
-  }
-  return msg;
-}
 
 class ScenarioValidator {
   constructor({ schemaPath = DEFAULT_SCHEMA_PATH } = {}) {

--- a/src/schemas/config_schema.json
+++ b/src/schemas/config_schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mobile Automator Workspace Config",
+  "description": "Schema for mobile-automator/config.json. Declares the type of every key `mauto config set` knows about. Unknown keys are permitted (additionalProperties: true) so agents can persist project knowledge this schema does not anticipate — the schema types keys, it does not gate them.",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "stringList": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "A list of strings. `mauto config set` accepts either a JSON array or a comma-separated value and stores a list either way."
+    },
+    "nullableString": {
+      "type": ["string", "null"],
+      "description": "A string, or null when the value is not yet configured."
+    }
+  },
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["platform-aware", "platform-agnostic"],
+      "description": "Selected at setup. Configs predating this field are treated as platform-aware."
+    },
+    "project_name": { "$ref": "#/definitions/nullableString" },
+    "platform": { "type": "string", "description": "Detected platform (platform-aware mode)." },
+    "platform_details": { "type": "string" },
+    "build_system": { "type": "string" },
+    "build_command": { "type": "string" },
+    "architecture": { "type": "string" },
+    "business_domain": { "type": "string" },
+    "loading_indicators": { "type": "string" },
+    "automation_extras": { "type": "string" },
+    "additional_resources": { "type": "string" },
+    "android_package": { "type": "string" },
+    "ios_bundle_id": { "type": "string" },
+    "default_environment": { "$ref": "#/definitions/nullableString" },
+    "environments": { "$ref": "#/definitions/stringList" },
+    "protected_directories": { "$ref": "#/definitions/stringList" },
+    "business_critical_paths": { "$ref": "#/definitions/stringList" },
+    "app": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Legacy nested shape written by pre-CLI setup. Read by the placeholder resolver.",
+      "properties": {
+        "android_package": { "type": "string" },
+        "ios_bundle_id": { "$ref": "#/definitions/nullableString" }
+      }
+    },
+    "knowledge": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Legacy nested shape written by pre-CLI setup. Read by the placeholder resolver.",
+      "properties": {
+        "project_name": { "$ref": "#/definitions/nullableString" },
+        "architecture": { "type": "string" },
+        "platform_details": { "type": "string" },
+        "build_system": { "type": "string" },
+        "build_command": { "type": "string" },
+        "business_domain": { "type": "string" },
+        "loading_indicators": { "type": "string" },
+        "automation_extras": { "type": "string" },
+        "additional_resources": { "type": "string" },
+        "protected_directories": { "$ref": "#/definitions/stringList" },
+        "business_critical_paths": { "$ref": "#/definitions/stringList" }
+      }
+    }
+  }
+}

--- a/src/schemas/format-error.js
+++ b/src/schemas/format-error.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Ajv error -> one human-readable sentence. Shared by the scenario validator
+// (`mauto validate`) and the config validator (`mauto config set`) so a schema
+// violation reads the same wherever it surfaces.
+function formatError(err) {
+  const where = err.instancePath || '(root)';
+  let msg = `${where} ${err.message}`;
+  if (err.keyword === 'required' && err.params && err.params.missingProperty) {
+    msg = `${where} is missing required property '${err.params.missingProperty}'`;
+  } else if (err.keyword === 'enum' && err.params && Array.isArray(err.params.allowedValues)) {
+    msg = `${where} ${err.message}: ${err.params.allowedValues.join(', ')}`;
+  } else if (err.keyword === 'additionalProperties' && err.params) {
+    msg = `${where} has unexpected property '${err.params.additionalProperty}'`;
+  }
+  return msg;
+}
+
+module.exports = { formatError };

--- a/tests/lint/config-schema.test.js
+++ b/tests/lint/config-schema.test.js
@@ -118,16 +118,18 @@ describe('config schema — structural agreement', () => {
     }
   });
 
-  test('the fresh scaffold skeleton conforms to the schema', () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-lint-'));
-    scaffold(root, { mode: 'platform-aware' });
-    const cfg = JSON.parse(
-      fs.readFileSync(path.join(root, 'mobile-automator', 'config.json'), 'utf8')
-    );
-    for (const key of Object.keys(cfg)) {
-      const { valid, errors } = validateAt(key, cfg[key]);
-      expect({ key, valid, errors }).toEqual({ key, valid: true, errors: [] });
-    }
+  describe.each(['platform-aware', 'platform-agnostic'])('mode: %s', (mode) => {
+    test('the fresh scaffold skeleton conforms to the schema', () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-lint-'));
+      scaffold(root, { mode });
+      const cfg = JSON.parse(
+        fs.readFileSync(path.join(root, 'mobile-automator', 'config.json'), 'utf8')
+      );
+      for (const key of Object.keys(cfg)) {
+        const { valid, errors } = validateAt(key, cfg[key]);
+        expect({ key, valid, errors }).toEqual({ key, valid: true, errors: [] });
+      }
+    });
   });
 
   test('the shipped config fixtures conform once healed', () => {

--- a/tests/lint/config-schema.test.js
+++ b/tests/lint/config-schema.test.js
@@ -88,6 +88,36 @@ describe('config schema — structural agreement', () => {
     expect(LIST_KEY_PATHS).toEqual(expect.arrayContaining(['environments']));
   });
 
+  test('every declared leaf under `properties` (walking nested objects) has a non-empty declaredTypesAt', () => {
+    // Deliberately does NOT resolve `$ref` at all — it only recurses into a
+    // child that carries an INLINE `properties` (the "app"/"knowledge"
+    // nested-object shape). Every other property (however many `$ref` hops
+    // away its real type sits) is asserted purely through the production
+    // `declaredTypesAt`. This is what makes the guard independent of
+    // `deref`'s own walk: a multi-hop `$ref`, a `patternProperties`, or an
+    // `allOf`/`anyOf` combinator all land here as "a declared key whose
+    // type must still resolve to something" rather than being silently
+    // skipped because some walker doesn't model that construct.
+    function collectDeclaredPaths(node, prefix, out) {
+      if (!node || !node.properties) return out;
+      for (const [name, child] of Object.entries(node.properties)) {
+        const childPath = prefix ? `${prefix}.${name}` : name;
+        out.push(childPath);
+        if (child && child.properties) collectDeclaredPaths(child, childPath, out);
+      }
+      return out;
+    }
+
+    const declaredPaths = collectDeclaredPaths(schema, '', []);
+    expect(declaredPaths.length).toBeGreaterThan(0);
+    for (const key of declaredPaths) {
+      expect({ key, types: declaredTypesAt(key) }).toEqual({
+        key,
+        types: expect.arrayContaining([expect.any(String)]),
+      });
+    }
+  });
+
   test('the fresh scaffold skeleton conforms to the schema', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-lint-'));
     scaffold(root, { mode: 'platform-aware' });

--- a/tests/lint/config-schema.test.js
+++ b/tests/lint/config-schema.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Structural guard: the config schema, the guide placeholder table, the
+// scaffold skeleton, the shipped fixtures, and the setup guide prose must
+// agree on what type each config key holds. #136 happened because that
+// knowledge was duplicated across modules and drifted. It fails HERE now.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { LIST_KEY_PATHS, subschemaAt, declaredTypesAt, validateAt } = require('../../src/config/schema');
+const { normalizeConfig } = require('../../src/config/coerce');
+const { PLACEHOLDER_KEYS } = require('../../src/guide/placeholders');
+const { scaffold } = require('../../src/setup/scaffold');
+
+const REPO = path.join(__dirname, '..', '..');
+const schema = require('../../src/schemas/config_schema.json');
+
+const guideFiles = ['setup.aware.md', 'setup.agnostic.md'].map((f) => ({
+  name: f,
+  text: fs.readFileSync(path.join(REPO, 'src', 'guide', 'content', f), 'utf8'),
+}));
+
+describe('config schema — structural agreement', () => {
+  test('every join:true placeholder key resolves to an array-typed schema path', () => {
+    for (const [name, spec] of Object.entries(PLACEHOLDER_KEYS)) {
+      if (!spec.join) continue;
+      // At least one of the candidate config paths must be declared as a list;
+      // otherwise the placeholder joins something the schema says is a scalar.
+      const arrayPaths = spec.keys.filter((k) => declaredTypesAt(k).includes('array'));
+      expect({ placeholder: name, arrayPaths }).toEqual({
+        placeholder: name,
+        arrayPaths: expect.arrayContaining([expect.any(String)]),
+      });
+      // And no candidate path may be declared as a non-array scalar.
+      for (const k of spec.keys) {
+        const types = declaredTypesAt(k);
+        if (types.length === 0) continue; // undeclared candidate paths are fine
+        expect(types).toContain('array');
+      }
+    }
+  });
+
+  test('no array-typed schema path is missing from LIST_KEY_PATHS', () => {
+    for (const listPath of LIST_KEY_PATHS) {
+      expect(subschemaAt(listPath).type).toBe('array');
+    }
+    expect(LIST_KEY_PATHS).toEqual(expect.arrayContaining(['environments']));
+  });
+
+  test('the fresh scaffold skeleton conforms to the schema', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-lint-'));
+    scaffold(root, { mode: 'platform-aware' });
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(root, 'mobile-automator', 'config.json'), 'utf8')
+    );
+    for (const key of Object.keys(cfg)) {
+      const { valid, errors } = validateAt(key, cfg[key]);
+      expect({ key, valid, errors }).toEqual({ key, valid: true, errors: [] });
+    }
+  });
+
+  test('the shipped config fixtures conform once healed', () => {
+    for (const name of ['config.platform-aware.json', 'config.platform-agnostic.json']) {
+      const raw = JSON.parse(fs.readFileSync(path.join(REPO, 'tests', 'fixtures', name), 'utf8'));
+      const healed = normalizeConfig(raw);
+      for (const key of Object.keys(healed)) {
+        const { valid, errors } = validateAt(key, healed[key]);
+        expect({ name, key, valid, errors }).toEqual({ name, key, valid: true, errors: [] });
+      }
+    }
+  });
+
+  describe.each(guideFiles)('$name', ({ text }) => {
+    test('every literal `mauto config set <key>` names a schema-declared key', () => {
+      // Matches `mauto config set some_key` but skips the generic
+      // `mauto config set <key> <value>` template form.
+      const found = [...text.matchAll(/mauto config set ([a-z_][a-z0-9_.]*)/g)].map((m) => m[1]);
+      expect(found.length).toBeGreaterThan(0);
+      const undeclared = [...new Set(found)].filter((k) => subschemaAt(k) === null);
+      expect(undeclared).toEqual([]);
+    });
+
+    test('the guide never tells the agent a list key holds a string', () => {
+      // Guard against prose regressing to "persist a comma-separated string".
+      expect(text).not.toMatch(/comma-separated string/i);
+    });
+  });
+});

--- a/tests/lint/config-schema.test.js
+++ b/tests/lint/config-schema.test.js
@@ -42,10 +42,49 @@ describe('config schema — structural agreement', () => {
     }
   });
 
-  test('no array-typed schema path is missing from LIST_KEY_PATHS', () => {
-    for (const listPath of LIST_KEY_PATHS) {
+  test('LIST_KEY_PATHS matches every array-typed path in the raw schema, independently derived', () => {
+    // Deliberately re-walks the raw config_schema.json here instead of
+    // importing collectListPaths/LIST_KEY_PATHS to build the expected set —
+    // asserting LIST_KEY_PATHS against a set built BY collectListPaths itself
+    // can never fail from a recursion bug or a dropped nesting level in that
+    // function, which is exactly the drift this guard exists to catch.
+
+    function resolveRefIndependently(node) {
+      if (!node || typeof node !== 'object' || typeof node.$ref !== 'string') return node;
+      const parts = node.$ref.replace(/^#\//, '').split('/');
+      let cur = schema;
+      for (const part of parts) {
+        if (cur == null) return node;
+        cur = cur[part];
+      }
+      return cur || node;
+    }
+
+    function collectArrayPathsIndependently(node, prefix, out) {
+      const resolved = resolveRefIndependently(node);
+      if (!resolved || !resolved.properties) return out;
+      for (const [name, child] of Object.entries(resolved.properties)) {
+        const childPath = prefix ? `${prefix}.${name}` : name;
+        const resolvedChild = resolveRefIndependently(child);
+        if (!resolvedChild) continue;
+        if (resolvedChild.type === 'array') out.push(childPath);
+        else if (resolvedChild.type === 'object' || resolvedChild.properties) {
+          collectArrayPathsIndependently(resolvedChild, childPath, out);
+        }
+      }
+      return out;
+    }
+
+    const expected = collectArrayPathsIndependently(schema, '', []).sort();
+    expect([...LIST_KEY_PATHS].sort()).toEqual(expected);
+
+    // Every path this test derives must actually be array-typed per
+    // subschemaAt too, so a false-positive in the independent walk itself
+    // (e.g. matching a property named "array") can't slip through unnoticed.
+    for (const listPath of expected) {
       expect(subschemaAt(listPath).type).toBe('array');
     }
+
     expect(LIST_KEY_PATHS).toEqual(expect.arrayContaining(['environments']));
   });
 

--- a/tests/lint/config-schema.test.js
+++ b/tests/lint/config-schema.test.js
@@ -42,52 +42,6 @@ describe('config schema — structural agreement', () => {
     }
   });
 
-  test('LIST_KEY_PATHS matches every array-typed path in the raw schema, independently derived', () => {
-    // Deliberately re-walks the raw config_schema.json here instead of
-    // importing collectListPaths/LIST_KEY_PATHS to build the expected set —
-    // asserting LIST_KEY_PATHS against a set built BY collectListPaths itself
-    // can never fail from a recursion bug or a dropped nesting level in that
-    // function, which is exactly the drift this guard exists to catch.
-
-    function resolveRefIndependently(node) {
-      if (!node || typeof node !== 'object' || typeof node.$ref !== 'string') return node;
-      const parts = node.$ref.replace(/^#\//, '').split('/');
-      let cur = schema;
-      for (const part of parts) {
-        if (cur == null) return node;
-        cur = cur[part];
-      }
-      return cur || node;
-    }
-
-    function collectArrayPathsIndependently(node, prefix, out) {
-      const resolved = resolveRefIndependently(node);
-      if (!resolved || !resolved.properties) return out;
-      for (const [name, child] of Object.entries(resolved.properties)) {
-        const childPath = prefix ? `${prefix}.${name}` : name;
-        const resolvedChild = resolveRefIndependently(child);
-        if (!resolvedChild) continue;
-        if (resolvedChild.type === 'array') out.push(childPath);
-        else if (resolvedChild.type === 'object' || resolvedChild.properties) {
-          collectArrayPathsIndependently(resolvedChild, childPath, out);
-        }
-      }
-      return out;
-    }
-
-    const expected = collectArrayPathsIndependently(schema, '', []).sort();
-    expect([...LIST_KEY_PATHS].sort()).toEqual(expected);
-
-    // Every path this test derives must actually be array-typed per
-    // subschemaAt too, so a false-positive in the independent walk itself
-    // (e.g. matching a property named "array") can't slip through unnoticed.
-    for (const listPath of expected) {
-      expect(subschemaAt(listPath).type).toBe('array');
-    }
-
-    expect(LIST_KEY_PATHS).toEqual(expect.arrayContaining(['environments']));
-  });
-
   test('every declared leaf under `properties` (walking nested objects) has a non-empty declaredTypesAt', () => {
     // Deliberately does NOT resolve `$ref` at all — it only recurses into a
     // child that carries an INLINE `properties` (the "app"/"knowledge"
@@ -116,6 +70,10 @@ describe('config schema — structural agreement', () => {
         types: expect.arrayContaining([expect.any(String)]),
       });
     }
+
+    // Sanity check: LIST_KEY_PATHS must actually contain a known array-typed
+    // key, not just be non-empty by accident.
+    expect(LIST_KEY_PATHS).toEqual(expect.arrayContaining(['environments']));
   });
 
   describe.each(['platform-aware', 'platform-agnostic'])('mode: %s', (mode) => {

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -645,6 +645,20 @@ describe('cli handlers', () => {
       );
     });
 
+    test('a rejected set against an EXISTING config leaves the file byte-identical (Minor 7)', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      fs.mkdirSync(path.join(projectRoot, 'mobile-automator'), { recursive: true });
+      const configPath = path.join(projectRoot, 'mobile-automator', 'config.json');
+      const before = JSON.stringify({ project_name: 'Demo', mode: 'platform-aware' });
+      fs.writeFileSync(configPath, before);
+      const r = handleConfigSet({ projectRoot }, 'mode', 'windows');
+      expect(r.exitKind).toBe('invalid_input');
+      // coerce -> validate -> early return; configManager.set is the only
+      // writer, so the file on disk must not have moved at all — not even a
+      // healing rewrite (load() heals on every read, this call never reads).
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(before);
+    });
+
     test('an unrelated pre-existing bad value does not block a valid write', () => {
       const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
       fs.mkdirSync(path.join(projectRoot, 'mobile-automator'), { recursive: true });

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -677,6 +677,29 @@ describe('cli handlers', () => {
       expect(r.exitKind).toBe('invalid_input');
       expect(r.envelope.error.kind).toBe('invalid_input');
     });
+
+    test('returns raw JSON for config', () => {
+      const r = handleSchema({}, 'config');
+      expect(r.exitKind).toBe('ok');
+      expect(r.envelope).toBeUndefined();
+      const parsed = JSON.parse(r.raw);
+      expect(parsed.title).toMatch(/Config/i);
+      expect(parsed.properties.environments).toBeDefined();
+    });
+
+    test('unknown schema name lists config among the valid names', () => {
+      const r = handleSchema({}, 'bogus');
+      expect(r.exitKind).toBe('invalid_input');
+      expect(r.envelope.hint).toMatch(/config/);
+    });
+
+    test('the config set rejection hint points at a command that works', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const rejected = handleConfigSet({ projectRoot }, 'mode', 'windows');
+      expect(rejected.envelope.hint).toMatch(/mauto schema config/);
+      // The command that hint names must actually succeed.
+      expect(handleSchema({}, 'config').exitKind).toBe('ok');
+    });
   });
 
   describe('handleBootstrap (raw text)', () => {

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -617,6 +617,25 @@ describe('cli handlers', () => {
       ).toBe(false);
     });
 
+    test('rejects a bare "null" on a non-nullable key instead of storing the string "null" (#136 fix-wave)', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const r = handleConfigSet({ projectRoot }, 'build_command', 'null');
+      expect(r.exitKind).toBe('invalid_input');
+      expect(r.envelope.ok).toBe(false);
+      expect(r.envelope.error.kind).toBe('invalid_input');
+      // Nothing was written.
+      expect(
+        fs.existsSync(path.join(projectRoot, 'mobile-automator', 'config.json'))
+      ).toBe(false);
+    });
+
+    test('a bare "null" on a nullable key stores JSON null', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const r = handleConfigSet({ projectRoot }, 'project_name', 'null');
+      expect(r.exitKind).toBe('ok');
+      expect(handleConfigGet({ projectRoot }, 'project_name').envelope.data.value).toBeNull();
+    });
+
     test('still accepts unknown keys leniently', () => {
       const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
       const r = handleConfigSet({ projectRoot }, 'team_convention', 'we test on Pixel 7');

--- a/tests/unit/cli.test.js
+++ b/tests/unit/cli.test.js
@@ -569,6 +569,73 @@ describe('cli handlers', () => {
       expect(getR.exitKind).toBe('ok');
       expect(getR.envelope.data.value).toBeUndefined();
     });
+
+    test('coerces a comma-separated list key into an array (#136)', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const setR = handleConfigSet({ projectRoot }, 'environments', 'stagingDebug,productionRelease');
+      expect(setR.exitKind).toBe('ok');
+      // The envelope echoes the coerced value, not the raw argument.
+      expect(setR.envelope.data.value).toEqual(['stagingDebug', 'productionRelease']);
+      // And it is a real JSON array on disk.
+      const onDisk = JSON.parse(
+        fs.readFileSync(path.join(projectRoot, 'mobile-automator', 'config.json'), 'utf8')
+      );
+      expect(onDisk.environments).toEqual(['stagingDebug', 'productionRelease']);
+    });
+
+    test('coerces the other two list keys the setup guide writes', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      handleConfigSet({ projectRoot }, 'protected_directories', 'src/, lib/');
+      handleConfigSet({ projectRoot }, 'business_critical_paths', 'onboarding, login, checkout');
+      expect(handleConfigGet({ projectRoot }, 'protected_directories').envelope.data.value).toEqual([
+        'src/',
+        'lib/',
+      ]);
+      expect(handleConfigGet({ projectRoot }, 'business_critical_paths').envelope.data.value).toEqual([
+        'onboarding',
+        'login',
+        'checkout',
+      ]);
+    });
+
+    test('keeps a numeric-looking string key a string', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      handleConfigSet({ projectRoot }, 'project_name', '12345');
+      expect(handleConfigGet({ projectRoot }, 'project_name').envelope.data.value).toBe('12345');
+    });
+
+    test('rejects a value that violates its declared type, with a hint', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const r = handleConfigSet({ projectRoot }, 'mode', 'windows');
+      expect(r.exitKind).toBe('invalid_input');
+      expect(r.envelope.ok).toBe(false);
+      expect(r.envelope.error.kind).toBe('invalid_input');
+      expect(r.envelope.hint).toMatch(/mauto schema config/);
+      // Nothing was written.
+      expect(
+        fs.existsSync(path.join(projectRoot, 'mobile-automator', 'config.json'))
+      ).toBe(false);
+    });
+
+    test('still accepts unknown keys leniently', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      const r = handleConfigSet({ projectRoot }, 'team_convention', 'we test on Pixel 7');
+      expect(r.exitKind).toBe('ok');
+      expect(handleConfigGet({ projectRoot }, 'team_convention').envelope.data.value).toBe(
+        'we test on Pixel 7'
+      );
+    });
+
+    test('an unrelated pre-existing bad value does not block a valid write', () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mauto-cfg-'));
+      fs.mkdirSync(path.join(projectRoot, 'mobile-automator'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectRoot, 'mobile-automator', 'config.json'),
+        JSON.stringify({ platform_details: 42 })
+      );
+      const r = handleConfigSet({ projectRoot }, 'project_name', 'Demo');
+      expect(r.exitKind).toBe('ok');
+    });
   });
 
   describe('handleGuide (raw content / fail on unknown)', () => {

--- a/tests/unit/config/coerce.test.js
+++ b/tests/unit/config/coerce.test.js
@@ -72,6 +72,18 @@ describe('config/coerce', () => {
     });
   });
 
+  describe('coerceValue — object-typed keys (the catch-all fallback IS reachable)', () => {
+    // declaredTypesAt('app') / declaredTypesAt('knowledge') return ['object'],
+    // not 'array' or 'string' — this is the branch that makes
+    // `mauto config set app '{"android_package":"com.x"}'` work. A prior
+    // progress-ledger entry claimed this branch was unreachable; it is live.
+    it('JSON-parses an object-typed key round-trip', () => {
+      expect(coerceValue('app', '{"android_package":"com.x"}')).toEqual({
+        android_package: 'com.x',
+      });
+    });
+  });
+
   describe('coerceValue — undeclared keys stay lenient', () => {
     it('JSON-parses when possible', () => {
       expect(coerceValue('made_up_key', '{"a":1}')).toEqual({ a: 1 });

--- a/tests/unit/config/coerce.test.js
+++ b/tests/unit/config/coerce.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const { coerceValue, normalizeConfig, splitList } = require('../../../src/config/coerce');
+
+describe('config/coerce', () => {
+  describe('splitList', () => {
+    it('splits on commas and trims', () => {
+      expect(splitList('a, b ,c')).toEqual(['a', 'b', 'c']);
+    });
+
+    it('drops empty segments', () => {
+      expect(splitList('a,,b, ,')).toEqual(['a', 'b']);
+    });
+
+    it('returns [] for an empty or whitespace-only string', () => {
+      expect(splitList('')).toEqual([]);
+      expect(splitList('  ')).toEqual([]);
+      expect(splitList(' , ')).toEqual([]);
+    });
+  });
+
+  describe('coerceValue — array keys (the #136 bug)', () => {
+    it('splits a comma-separated value into a list', () => {
+      expect(coerceValue('environments', 'stagingDebug,productionRelease')).toEqual([
+        'stagingDebug',
+        'productionRelease',
+      ]);
+    });
+
+    it('tolerates spaces after the commas', () => {
+      expect(coerceValue('protected_directories', 'src/, lib/')).toEqual(['src/', 'lib/']);
+    });
+
+    it('accepts a JSON array verbatim', () => {
+      expect(coerceValue('environments', '["a","b"]')).toEqual(['a', 'b']);
+    });
+
+    it('wraps a single value in a list', () => {
+      expect(coerceValue('environments', 'production')).toEqual(['production']);
+    });
+
+    it('yields an empty list for an empty value', () => {
+      expect(coerceValue('environments', '')).toEqual([]);
+    });
+
+    it('coerces nested legacy list paths too', () => {
+      expect(coerceValue('knowledge.business_critical_paths', 'login, checkout')).toEqual([
+        'login',
+        'checkout',
+      ]);
+    });
+  });
+
+  describe('coerceValue — string keys (the type-coercion bug)', () => {
+    it('keeps a numeric-looking project name a string', () => {
+      expect(coerceValue('project_name', '12345')).toBe('12345');
+    });
+
+    it('keeps a JSON-object-looking build command a string', () => {
+      expect(coerceValue('build_command', '{"a":1}')).toBe('{"a":1}');
+    });
+
+    it('keeps a boolean-looking value a string', () => {
+      expect(coerceValue('business_domain', 'true')).toBe('true');
+    });
+
+    it('maps the literal "null" to null only where null is allowed', () => {
+      expect(coerceValue('project_name', 'null')).toBeNull();
+      expect(coerceValue('default_environment', 'null')).toBeNull();
+      expect(coerceValue('build_command', 'null')).toBe('null');
+    });
+  });
+
+  describe('coerceValue — undeclared keys stay lenient', () => {
+    it('JSON-parses when possible', () => {
+      expect(coerceValue('made_up_key', '{"a":1}')).toEqual({ a: 1 });
+      expect(coerceValue('made_up_key', '42')).toBe(42);
+    });
+
+    it('falls back to the literal string', () => {
+      expect(coerceValue('made_up_key', 'hello there')).toBe('hello there');
+    });
+  });
+
+  describe('normalizeConfig — healing configs already on disk', () => {
+    it('heals a flat string list key', () => {
+      const healed = normalizeConfig({ environments: 'stagingDebug,productionRelease' });
+      expect(healed.environments).toEqual(['stagingDebug', 'productionRelease']);
+    });
+
+    it('heals a nested string list key', () => {
+      const healed = normalizeConfig({ knowledge: { business_critical_paths: 'login, checkout' } });
+      expect(healed.knowledge.business_critical_paths).toEqual(['login', 'checkout']);
+    });
+
+    it('leaves correct arrays untouched', () => {
+      const healed = normalizeConfig({ environments: ['a', 'b'] });
+      expect(healed.environments).toEqual(['a', 'b']);
+    });
+
+    it('leaves unrelated keys and shapes untouched', () => {
+      const cfg = { mode: 'platform-aware', project_name: null, app: { android_package: 'com.x' } };
+      expect(normalizeConfig(cfg)).toEqual(cfg);
+    });
+
+    it('does not mutate its input', () => {
+      const cfg = { environments: 'a,b' };
+      normalizeConfig(cfg);
+      expect(cfg.environments).toBe('a,b');
+    });
+
+    it('tolerates null/undefined', () => {
+      expect(normalizeConfig(null)).toBeNull();
+      expect(normalizeConfig(undefined)).toBeUndefined();
+    });
+
+    it('leaves a non-string, non-array value at a list path alone (validation reports it)', () => {
+      const healed = normalizeConfig({ environments: 42 });
+      expect(healed.environments).toBe(42);
+    });
+  });
+});

--- a/tests/unit/config/coerce.test.js
+++ b/tests/unit/config/coerce.test.js
@@ -64,10 +64,11 @@ describe('config/coerce', () => {
       expect(coerceValue('business_domain', 'true')).toBe('true');
     });
 
-    it('maps the literal "null" to null only where null is allowed', () => {
+    it('maps the literal "null" to JSON null unconditionally — validateAt gates which keys may hold it', () => {
       expect(coerceValue('project_name', 'null')).toBeNull();
       expect(coerceValue('default_environment', 'null')).toBeNull();
-      expect(coerceValue('build_command', 'null')).toBe('null');
+      expect(coerceValue('build_command', 'null')).toBeNull();
+      expect(coerceValue('android_package', 'null')).toBeNull();
     });
   });
 

--- a/tests/unit/config/manager.test.js
+++ b/tests/unit/config/manager.test.js
@@ -27,6 +27,26 @@ describe('config/manager', () => {
       fs.writeFileSync(configPath(root), JSON.stringify({ mode: 'platform-agnostic', app_package: 'com.x' }));
       expect(load(root)).toEqual({ mode: 'platform-agnostic', app_package: 'com.x' });
     });
+
+    it('heals a legacy comma-joined list key on read (#136)', () => {
+      const root = tmpRoot();
+      fs.mkdirSync(path.join(root, 'mobile-automator'), { recursive: true });
+      fs.writeFileSync(
+        configPath(root),
+        JSON.stringify({ mode: 'platform-aware', environments: 'stagingDebug,productionRelease' })
+      );
+      expect(load(root).environments).toEqual(['stagingDebug', 'productionRelease']);
+    });
+
+    it('heals a nested legacy list key on read', () => {
+      const root = tmpRoot();
+      fs.mkdirSync(path.join(root, 'mobile-automator'), { recursive: true });
+      fs.writeFileSync(
+        configPath(root),
+        JSON.stringify({ knowledge: { business_critical_paths: 'login, checkout' } })
+      );
+      expect(load(root).knowledge.business_critical_paths).toEqual(['login', 'checkout']);
+    });
   });
 
   describe('resolveMode', () => {
@@ -103,6 +123,18 @@ describe('config/manager', () => {
       set(root, 'mode', 'platform-aware');
       const raw = fs.readFileSync(configPath(root), 'utf8');
       expect(raw).toContain('\n  "mode"');
+    });
+  });
+
+  describe('self-repair', () => {
+    it('rewrites a legacy string list as an array on the next set', () => {
+      const root = tmpRoot();
+      fs.mkdirSync(path.join(root, 'mobile-automator'), { recursive: true });
+      fs.writeFileSync(configPath(root), JSON.stringify({ environments: 'a,b' }));
+      set(root, 'project_name', 'Demo'); // touching an unrelated key is enough
+      const raw = JSON.parse(fs.readFileSync(configPath(root), 'utf8'));
+      expect(raw.environments).toEqual(['a', 'b']);
+      expect(raw.project_name).toBe('Demo');
     });
   });
 });

--- a/tests/unit/config/schema.test.js
+++ b/tests/unit/config/schema.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const fs = require('fs');
+
+const {
+  CONFIG_SCHEMA_PATH,
+  subschemaAt,
+  declaredTypesAt,
+  LIST_KEY_PATHS,
+  validateAt,
+} = require('../../../src/config/schema');
+
+describe('config/schema', () => {
+  it('ships a readable draft-07 schema', () => {
+    const raw = JSON.parse(fs.readFileSync(CONFIG_SCHEMA_PATH, 'utf8'));
+    expect(raw.$schema).toBe('http://json-schema.org/draft-07/schema#');
+    expect(raw.type).toBe('object');
+    // Unknown keys must stay writable — the schema types keys, it does not gate them.
+    expect(raw.additionalProperties).toBe(true);
+  });
+
+  describe('declaredTypesAt', () => {
+    it('types the three list keys as arrays', () => {
+      expect(declaredTypesAt('environments')).toEqual(['array']);
+      expect(declaredTypesAt('protected_directories')).toEqual(['array']);
+      expect(declaredTypesAt('business_critical_paths')).toEqual(['array']);
+    });
+
+    it('types scalar knowledge keys as strings', () => {
+      expect(declaredTypesAt('build_command')).toEqual(['string']);
+      expect(declaredTypesAt('loading_indicators')).toEqual(['string']);
+      expect(declaredTypesAt('android_package')).toEqual(['string']);
+    });
+
+    it('allows null for the seeded-empty keys the scaffold writes', () => {
+      expect(declaredTypesAt('project_name').sort()).toEqual(['null', 'string']);
+      expect(declaredTypesAt('default_environment').sort()).toEqual(['null', 'string']);
+    });
+
+    it('resolves nested legacy paths', () => {
+      expect(declaredTypesAt('knowledge.business_critical_paths')).toEqual(['array']);
+      expect(declaredTypesAt('knowledge.project_name').sort()).toEqual(['null', 'string']);
+      expect(declaredTypesAt('app.android_package')).toEqual(['string']);
+    });
+
+    it('returns [] for an undeclared key', () => {
+      expect(declaredTypesAt('totally_made_up')).toEqual([]);
+      expect(declaredTypesAt('knowledge.totally_made_up')).toEqual([]);
+    });
+  });
+
+  describe('LIST_KEY_PATHS', () => {
+    it('lists every array-typed path, flat and nested', () => {
+      expect(LIST_KEY_PATHS).toEqual(
+        expect.arrayContaining([
+          'environments',
+          'protected_directories',
+          'business_critical_paths',
+          'knowledge.protected_directories',
+          'knowledge.business_critical_paths',
+        ])
+      );
+    });
+
+    it('contains no scalar paths', () => {
+      expect(LIST_KEY_PATHS).not.toContain('project_name');
+      expect(LIST_KEY_PATHS).not.toContain('mode');
+    });
+  });
+
+  describe('subschemaAt', () => {
+    it('returns the fragment for a declared path', () => {
+      expect(subschemaAt('environments')).toMatchObject({
+        type: 'array',
+        items: { type: 'string' },
+      });
+    });
+
+    it('returns null for an undeclared path', () => {
+      expect(subschemaAt('nope')).toBeNull();
+    });
+  });
+
+  describe('validateAt', () => {
+    it('accepts a conforming value', () => {
+      expect(validateAt('environments', ['a', 'b'])).toEqual({ valid: true, errors: [] });
+      expect(validateAt('project_name', null)).toEqual({ valid: true, errors: [] });
+      expect(validateAt('mode', 'platform-agnostic')).toEqual({ valid: true, errors: [] });
+    });
+
+    it('rejects a non-conforming value with a readable message', () => {
+      const r = validateAt('environments', 'a,b');
+      expect(r.valid).toBe(false);
+      expect(r.errors.join(' ')).toMatch(/array/);
+    });
+
+    it('rejects a value outside an enum', () => {
+      const r = validateAt('mode', 'windows');
+      expect(r.valid).toBe(false);
+      expect(r.errors.join(' ')).toMatch(/platform-aware/);
+    });
+
+    it('always passes an undeclared path', () => {
+      expect(validateAt('anything_at_all', { deeply: ['nested'] })).toEqual({ valid: true, errors: [] });
+    });
+  });
+});

--- a/tests/unit/config/schema.test.js
+++ b/tests/unit/config/schema.test.js
@@ -100,6 +100,11 @@ describe('config/schema', () => {
       expect(r.errors.join(' ')).toMatch(/platform-aware/);
     });
 
+    it('does not prefix a root-level error with the redundant "(root)" — the CLI message already names the key', () => {
+      const r = validateAt('mode', 'windows');
+      expect(r.errors.join(' ')).not.toMatch(/\(root\)/);
+    });
+
     it('always passes an undeclared path', () => {
       expect(validateAt('anything_at_all', { deeply: ['nested'] })).toEqual({ valid: true, errors: [] });
     });

--- a/tests/unit/config/schema.test.js
+++ b/tests/unit/config/schema.test.js
@@ -103,5 +103,22 @@ describe('config/schema', () => {
     it('always passes an undeclared path', () => {
       expect(validateAt('anything_at_all', { deeply: ['nested'] })).toEqual({ valid: true, errors: [] });
     });
+
+    // "app" and "knowledge" are object-typed keys whose OWN top-level $ref (if
+    // any) subschemaAt resolves, but whose nested properties (app.ios_bundle_id,
+    // knowledge.business_critical_paths, ...) still carry an unresolved local
+    // `#/definitions/...` $ref. Compiling that fragment on its own, without the
+    // root schema's `definitions`, previously threw "can't resolve reference"
+    // instead of returning a validation result.
+    it('validates an object-typed key whose nested properties still hold local $refs', () => {
+      expect(validateAt('app', { android_package: 'com.example.app', ios_bundle_id: null })).toEqual({
+        valid: true,
+        errors: [],
+      });
+      expect(validateAt('knowledge', { business_critical_paths: ['login', 'checkout'] })).toEqual({
+        valid: true,
+        errors: [],
+      });
+    });
   });
 });


### PR DESCRIPTION
## What

`mobile-automator/config.json` had no declared type contract. `mauto config set` opportunistically `JSON.parse`d its argument and fell back to the raw string, while the setup guide instructed agents to run `mauto config set environments <env1,env2,...>` — and comma-separated text never parses as JSON. So every list-typed key landed as a comma-joined **string**.

This adds `src/schemas/config_schema.json` as the single source of truth for config value types, and makes `config set` coerce and validate against it.

```
# before
$ mauto config set environments "stagingDebug,productionRelease"
{"ok":true,"data":{"key":"environments","value":"stagingDebug,productionRelease"}}
config.json → "environments": "stagingDebug,productionRelease"     ← a string

# after
$ mauto config set environments "stagingDebug,productionRelease"
{"ok":true,"data":{"key":"environments","value":["stagingDebug","productionRelease"]}}
config.json → "environments": ["stagingDebug", "productionRelease"]
```

## Why

Three keys were affected — `environments`, `protected_directories`, `business_critical_paths` — and the guide prose for the latter two *explicitly* said "persist a comma-separated value". The same untyped handler also retyped scalars: `config set project_name 12345` stored a number.

Nothing crashed, because the placeholder renderer tolerates both shapes. That is exactly why it shipped in v0.21.0 unnoticed — the damage was latent contract drift, invisible until something did real array work.

This is the config-layer instance of the failure class #116 named — a link the agent is *told* to bridge with nothing mechanically enforcing it — and it takes the same shape of fix as #117/PR #118 did for the action surface: a declared catalog plus a structural guard.

## Approach

**Schema, not a bespoke table.** Reuses machinery already here: Ajv (already a dependency), the `src/schemas/*.json` convention, and the `mauto schema <name>` verb. A hand-rolled key table would have been a *third* place encoding config types, alongside `join: true` in `placeholders.js` and `environments: []` in `scaffold.js` — the very duplication that caused the bug.

**Coerce, then validate.** JSON Schema validates but does not coerce, and Ajv's `coerceTypes: 'array'` wraps rather than splits (`"a,b"` → `["a,b"]`), so comma-splitting is our own step — driven by the schema's declared types, not a duplicate list. This makes the long-standing guide prose correct as written instead of requiring every agent to learn a new form.

**Per-key validation, not whole-document**, so a config carrying unrelated pre-existing drift never blocks an otherwise-valid write. Upgrading users would otherwise have to hand-edit JSON before any `config set` would work.

**Unknown keys stay writable** (`additionalProperties: true`). The schema types keys; it does not gate them. Agents must remain able to persist knowledge the schema does not anticipate.

**Zero-touch migration.** `manager.load()` heals legacy comma-joined list keys on read, and `set()` is load-mutate-write, so the next write of any key rewrites the file in healed form. No migration command.

**`mauto schema config`** closes the asymmetry where config was the one contract an agent had to write blind, inferring types from prose while pulling every other contract on demand.

## Notable behavior changes

- A bare `null` argument now always means JSON `null`, gated by the schema: `config set default_environment null` stores `null`; `config set build_command null` returns a loud `invalid_input`. Previously a non-nullable key would have silently stored the **string** `"null"`, which `placeholders.js` treats as a present value — leaking the literal word `null` into emitted guide prose.
- `config set` rejects values that violate a declared type, with a hint pointing at `mauto schema config`.

## The guard

`tests/lint/config-schema.test.js` holds the schema, the placeholder table, the scaffold skeleton, the shipped fixtures, and the setup guide prose in agreement. It earned its keep before merge — it caught two real defects in code that had already passed review:

- `validateAt` compiled subschema fragments without the root `definitions`, so nested `$ref`s in object-typed keys (`app`, `knowledge`) could not resolve and it threw. The envelope contract still held (`withEnvelope` catches), but the error was misclassified as `internal` with a stack trace on stderr instead of a clean `invalid_input`.
- `deref` resolved only one `$ref` hop, so a two-hop reference would have made `declaredTypesAt` report "undeclared, be lenient" while Ajv rejected the value — the two halves of `handleConfigSet` disagreeing, reproducing #136 for a future schema edit.

## Test plan

- `tests/unit/config/schema.test.js` — type + subschema lookup, flat / nested / declared / undeclared, and the `definitions` regression.
- `tests/unit/config/coerce.test.js` — every row of the coercion table; healing is non-mutating, tolerates `null`/`undefined`, and leaves correct values alone.
- `tests/unit/config/manager.test.js` — legacy configs heal on read and are rewritten healed by the next `set`.
- `tests/unit/cli.test.js` — all three list keys coerce; scalars keep their type; type violations return `invalid_input` and write nothing (including against an existing config, byte-identical); unknown keys stay lenient; the rejection hint's referenced command actually succeeds.
- `tests/lint/config-schema.test.js` — the structural guard, verified non-vacuous by mutation probes (reverting `environments` to `type: string` fails 4 assertions; breaking `collectListPaths`' recursion fails the completeness check).

```
$ npm test
Test Suites: 60 passed, 60 total
Tests:       642 passed, 642 total

$ npm run lint:guides
Test Suites: 7 passed, 7 total
Tests:       43 passed, 43 total

$ npm run lint:schema-additive
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

Manual end-to-end against the built CLI:

```
config set environments "stagingDebug,productionRelease" → ["stagingDebug","productionRelease"]
config set protected_directories "src/, lib/"            → ["src/","lib/"]
config set business_critical_paths "a, b, c"             → ["a","b","c"]
config set project_name 12345                            → "12345"   (string, not number)
config set default_environment null                      → null      (nullable)
config set build_command null                            → ok:false, invalid_input, nothing written
config set team_convention "we test on Pixel 7"          → written   (unknown keys stay lenient)
legacy config, flat + nested                             → heals on read, file self-repairs on next write
mauto schema config                                      → prints the schema
```

## Follow-up noted, not fixed here

Three further stale `mauto schema <scenario|result>` enumerations exist outside this PR's scope: `docs/index.md:135`, `docs/contributing.md:169`, `docs/concepts/skills.md:532`.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
