### PR TITLE
docs: resync CLAUDE.md, correct action counts, refresh ROADMAP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
 # CLAUDE.md
 
-Developer guide for maintaining the `mauto` CLI. User-facing docs live in `README.md`; debugging recipes live in `TROUBLESHOOTING.md`.
+Developer guide for maintaining the `mauto` CLI. User-facing docs live in `README.md` and the MkDocs site under `docs/` (deployed to GitHub Pages by `.github/workflows/docs.yml`); debugging recipes live in `TROUBLESHOOTING.md`.
 
 ## What this is
 
-mobile-automator is a **host-agnostic `mauto` CLI** for AI-driven mobile QA automation. Any AI agent drives a device through `mauto` verbs (which wrap mobile-mcp); reasoning is pulled on demand via `mauto guide`. Production-ready.
+mobile-automator is a **host-agnostic `mauto` CLI** for AI-driven mobile QA automation. Any AI agent drives a device through `mauto` verbs (which wrap mobile-mcp); reasoning is pulled on demand via `mauto guide`.
+
+**Status (v0.23.7): feature-complete, not yet released.** The package is **not on npm** — `npm view mobile-automator` returns 404, so every install path is from source (`git clone` + `npm link`). Milestone `production-ready` (gate issue [#168](https://github.com/sh3lan93/mobile-automator/issues/168)) tracks what stands between here and a first published release. Do not describe the tool as installable from the registry until the publish actually lands.
 
 ## Architecture
 
@@ -24,18 +26,33 @@ bin/
   mauto.js                    # entry point for `mauto` and `mobile-automator` bin aliases
   mauto-session-daemon.js     # entry point for `mauto-session-daemon`
 src/
-  cli.js                      # verb registration + handlers
-  assertion/  config/  device/  guide/  init/  mcp/  output/  result/  scenario/  schemas/  setup/
+  cli.js                      # verb registration + handlers (commander)
+  assertion/  config/  guide/  init/  mcp/  output/  result/  scenario/  setup/
+  device/
+    action-catalog.js         # schema action → execution contract (drift guard, see below)
+    session-daemon.js         # persistent mobile-mcp session behind a Unix socket
+    session-client.js  session-spawn.js  session-paths.js  session-protocol.js
+    bridge.js  mobile-mcp-client.js  semantic-press/  device-resolver.js  selection.js
+  result/
+    capability-catalog.js     # result field → verb → store method → schema pointer (drift guard)
+    store.js                  # ResultStore, mutations serialized per runId
+  memory/                     # cross-session memory store (run-history, app-knowledge, preferences)
+  util/
+    lock.js                   # advisory file lock shared by memory + result stores
+    atomic.js                 # atomic file writes
   guide/content/
     <topic>.aware.md          # guide prose for platform-aware mode
     <topic>.agnostic.md       # guide prose for platform-agnostic mode
+    <topic>.invariants.md     # placeholder-free, OS-free prose for installed Agent Skills
   schemas/
-    scenario_schema.json      # v2.1
+    scenario_schema.json      # $schema_version "2.0" | "2.1"
     result_schema.json
     config_schema.json
+tests/
+  unit/  integration/  lint/  fixtures/
 mobile-automator/             # created in user's project by `mauto setup`
   config.json  scenarios/  screenshots/  results/  .session/
-  memory/                      # cross-session memory (run-history.md)
+  memory/                     # cross-session memory (run-history.md, …)
 ```
 
 ## Modes
@@ -47,13 +64,13 @@ Selected during setup; stored as `mode` in `mobile-automator/config.json`. Confi
 | `platform-aware` | Single-OS or OS-specific UI tests |
 | `platform-agnostic` | Cross-platform (Flutter/RN/KMP/CMP) |
 
-Agnostic mode maps OS gestures to four semantic actions resolved to per-platform mechanics at replay time: `press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`. Schema 2.1 is additive over 2.0 (adds `mode` field + semantic actions). Each guide topic has `.aware.md` and `.agnostic.md` variants in `src/guide/content/`.
+Agnostic mode maps OS gestures to four semantic actions resolved to per-platform mechanics at replay time: `press_back`, `dismiss_keyboard`, `grant_permission`, `deny_permission`. Schema 2.1 is additive over 2.0 (adds `mode` field + semantic actions); `tests/lint/schema-additive.test.js` enforces that. Each guide topic has `.aware.md` and `.agnostic.md` variants in `src/guide/content/`.
 
 ## Verbs
 
-All verbs emit `{ok,data,error,hint,schema_version}`; `--human` is an opt-in readable flag.
+All verbs emit `{ok,data,error,hint,schema_version}`; `--human` is an opt-in readable flag. Commander parse failures are routed through the same envelope (#146) — a bad flag must never print bare text.
 
-- **Device actions:** `elements`, `tap`, `type <text>`, `swipe`, `press <button>`, `screenshot <path>`
+- **Device actions:** `elements`, `tap`, `long-press`, `double-tap`, `type <text>`, `swipe`, `press <button>`, `screenshot <path>`, `launch <appId>`, `install <path>`, `uninstall <appId>`, `open-url <url>`, `orientation <orientation>`
 - **Author & verify:** `validate <file>`, `assert <type>`, `result add-step`, `result add-assertion`, `result finalize`
 - **Workspace:** `setup`, `config get <key>`, `config set <key> <value>`
 - **Reasoning** (agent pulls on demand): `guide <topic>` (topics: `generate`, `execute`, `setup`); `bootstrap` (verb map + invariants); `schema <name>` (names: `scenario`, `result`, `config`)
@@ -61,59 +78,96 @@ All verbs emit `{ok,data,error,hint,schema_version}`; `--human` is an opt-in rea
 - **Device session:** `session start|status|end`; `devices` (list); `devices use <id>`; `devices clear`
 - **Memory:** `memory show` (read), `memory add <text> --kind <app-knowledge|preferences>` / `memory forget --kind <k> --match <substr>` (agent-authored); run-history is auto-harvested on `result finalize`
 
+## Drift guards (read before touching actions or result fields)
+
+Two catalogs are the single source of truth for "does this capability actually reach the device / the result file". Both are consumed by lint tests, so a capability that loses its CLI reach **fails the build** instead of silently degrading.
+
+**`src/device/action-catalog.js`** (#117) binds all **23** scenario-schema actions to *how* they execute, via a `resolution` field. Guard: `tests/lint/action-coverage.test.js`.
+
+| resolution | count | meaning |
+|---|---|---|
+| `verb` | 11 | dedicated one-shot `mauto` verb → DeviceBridge → one mobile-mcp primitive |
+| `semantic` | 4 | invoked as `mauto press <action>`, resolved per-platform by `src/device/semantic-press/` |
+| `composed` | 5 | no verb; the agent composes it from existing verbs (the execute guide documents how) |
+| `unsupported` | 3 | mobile-mcp 0.0.55 exposes no primitive (`clear_app_data`, `enable_wifi`, `disable_wifi`) — guides must **not** promise a verb |
+
+**`src/result/capability-catalog.js`** (#140) binds every fact a result file can carry to the result schema, the `ResultStore` method that writes it, and the `mauto result` flag that supplies it. Guard: `tests/lint/result-coverage.test.js`. This exists because `assertion_results` silently stayed empty for months — the schema had a home for it and no verb could fill it.
+
+When you add an action or a result field, add its catalog entry in the same change. Do not hand-restate these counts in prose; derive them.
+
 ## Placeholder contract
 
-Guide content in `src/guide/content/<topic>.<aware|agnostic>.md` carries `{{placeholder}}` tokens filled by `src/guide/placeholders.js` (`interpolate`) from `mobile-automator/config.json` at emit time. A fallback ensures no `{{` survives in emitted output. Lint guards in `tests/lint/guide-*.test.js` enforce: no surviving `{{placeholders}}`, no leaked `mobile_*` tool names, and (agnostic files) no OS names.
+Guide content in `src/guide/content/<topic>.<aware|agnostic>.md` carries `{{placeholder}}` tokens filled by `src/guide/placeholders.js` (`interpolate`) from `mobile-automator/config.json` at emit time. Unset placeholders render per slot kind rather than emitting a bare token, and the emitted output is guarded so nothing `{{`-shaped survives (#143). Lint guards in `tests/lint/` enforce: no surviving `{{placeholders}}`, no leaked `mobile_*` tool names, agnostic files name no OS, skill invariants stay placeholder-free, and skill frontmatter stays valid.
 
-## Sample-app milestone workflow (mandatory for any agent)
+## Locked invariants — non-negotiable, all work
 
-PRD [#44](https://github.com/sh3lan93/mobile-automator/issues/44) · milestone `sample-app` · slices #45–#49. **Any agent picking up a `sample-app`-milestone issue MUST follow this workflow in order — it is not optional:**
+These were locked by PRD #69 and outlive it. Any change that breaks one is wrong regardless of what it fixes.
 
-1. **Load full context first.** Fetch the slice issue **and** PRD #44 together (`gh issue view <slice>` + `gh issue view 44`) before doing anything. Slice bodies are deliberately thin; the PRD holds the locked decisions, the slice ladder, and cross-slice constraints. Never act on a slice issue alone.
-2. **Isolate the workspace.** Before any edit, create a dedicated worktree on a new branch named `sample-app/<issue-number>-<short-slug>`. Do not work directly in an existing checkout or on a shared branch.
-3. **Plan before code.** Produce a written implementation plan (file structure, deps, screen/widget tree, CI changes, test list) and surface it for explicit user approval. No implementation before the user confirms the plan.
-4. **Implement via subagents.** After plan approval, dispatch the implementation through subagents so the main agent's context window stays unbloated. The main agent orchestrates and reviews; it does not hand-write the bulk of the slice itself.
-5. **Open a draft PR.** When implementation is complete, open a GitHub PR in **draft** status with a full description (what/why, test plan). Put `Closes #<slice-issue>` on its own line with no intervening words; reference the PRD as `Refs #44` (never `Closes #44` — the PRD closes only when slice 5 merges).
+- **Platform-agnostic selectors.** Never use `resource-id` or OS-specific element IDs.
+- **Uniform envelope.** Every verb emits `{ok,data,error,hint,schema_version}`; `--human` is opt-in only.
+- **One-shot verbs only.** No interactive `run` co-routine.
+- **Reasoning is pulled, never ambient.** Delivered via `mauto guide <topic>` at explicit invocation, never an always-loaded skill.
+- **The device is driven only through `mauto` verbs** (which wrap mobile-mcp). Never call mobile-mcp tools directly.
+- **Backwards compatibility.** Preserve the `mobile-automator/` workspace layout, scenario schema 2.0/2.1, and the result schema — existing data must keep working.
 
-This workflow lives here (not in per-slice issue bodies) so it applies uniformly and survives issue edits.
+There is also a **three-layer model** worth keeping straight: (1) the CLI contract, (2) the per-host invocation surface (slash commands, rules, skills — host-specific, e.g. `$ARGUMENTS` is Claude-only), (3) the guide prose. Never put a contract in layer 2.
 
-## CLI migration milestone workflow (mandatory for any agent)
+## Milestone workflow (mandatory for any agent)
 
-PRD [#69](https://github.com/sh3lan93/mobile-automator/issues/69) · milestone `cli` · slices #70–#78. This milestone migrates the tool from a Gemini extension to a host-agnostic **`mauto` CLI** usable by any AI agent. **Any agent picking up a `cli`-milestone issue MUST follow this workflow in order — it is not optional:**
+| Milestone | PRD / gate | Branch prefix | State |
+|---|---|---|---|
+| `production-ready` | gate issue [#168](https://github.com/sh3lan93/mobile-automator/issues/168) | `fix/<issue>-<slug>`, `feat/…`, `docs/…`, `chore/…` | **active** — 13 open |
+| `sample-app` | PRD [#44](https://github.com/sh3lan93/mobile-automator/issues/44), slices #45–#49 | `sample-app/<issue-number>-<short-slug>` | active — slices 4–5 open |
+| `cli` | PRD [#69](https://github.com/sh3lan93/mobile-automator/issues/69), slices #70–#78 | — | **complete** (all 23 closed) |
+| `interactive-recording` | — | — | **dead** — recorder excised in v0.20.0 (PR #110) |
 
-1. **Load full context first.** Fetch the slice issue **and** PRD #69 together (`gh issue view <slice>` + `gh issue view 69`) before doing anything. Slice bodies are deliberately thin; the PRD holds the locked design decisions and cross-slice constraints. Never act on a slice issue alone.
-2. **Isolate the workspace.** Before any edit, create a dedicated worktree on a new branch named `cli/<issue-number>-<short-slug>`. Do not work directly in an existing checkout or on a shared branch. (Dispatched subagents start at the repo root, not the worktree — force `cd` into the worktree and verify before any commit.)
-3. **Plan before code.** Produce a written implementation plan (file structure, deps, module interfaces, test list) and surface it for explicit user approval. No implementation before the user confirms the plan.
-4. **Implement via subagents (TDD for non-trivial work).** Dispatch implementation through subagents so the main agent's context stays lean. The main agent orchestrates and reviews; it does not hand-write the bulk of the slice.
-5. **Honor the locked invariants — non-negotiable.** Platform-agnostic; **never** use `resource-id` / OS-specific element IDs. Every CLI verb emits the uniform JSON envelope `{ok,data,error,hint,schema_version}` (a `--human` flag is opt-in). One-shot verbs only — no interactive `run` co-routine. Reasoning is delivered via `mauto guide <topic>` at explicit invocation, never an ambient always-loaded skill. The device is driven **only** through `mauto` verbs (which wrap mobile-mcp). Preserve the `mobile-automator/` workspace layout + scenario schema 2.1 + result schema (existing data must keep working).
-6. **Guide ports must pass lint guards.** When porting `SKILL.md` prose into `mauto guide` content: no surviving `{{placeholders}}`, no leaked `mobile_*` tool names, agnostic guides name no OS. Add/extend the lint tests alongside the port.
-7. **Verify before claiming done.** Run the test suite and the lint guards and show the output before any success claim or PR.
-8. **Per-task commits; open a draft PR early** with a full description (what/why, test plan). Put `Closes #<slice-issue>` on its own line with no intervening words; reference the PRD as `Refs #69` (never `Closes #69` — the PRD closes only when slice #78 merges). Re-point the CI version-bump gate from extension paths to the CLI package where a slice touches it.
+**Any agent picking up a milestone issue MUST follow this workflow in order — it is not optional:**
 
-This workflow lives here (not in per-slice issue bodies) so it applies uniformly and survives issue edits.
+1. **Load full context first.** Fetch the issue **and** its PRD/gate issue together (`gh issue view <issue>` + `gh issue view 44|168`) before doing anything. Issue bodies are deliberately thin; the PRD holds the locked decisions, the slice ladder, and cross-issue constraints. Never act on a slice issue alone.
+2. **Isolate the workspace.** Before any edit, create a dedicated worktree on a new branch using the prefix above. Do not work directly in an existing checkout or on a shared branch. (Dispatched subagents start at the repo root, not the worktree — force `cd` into the worktree and verify before any commit.)
+3. **Plan before code.** Produce a written implementation plan (file structure, deps, module interfaces, CI changes, test list) and surface it for explicit user approval. No implementation before the user confirms the plan.
+4. **Implement via subagents (TDD for non-trivial work).** Dispatch implementation through subagents so the main agent's context stays lean. The main agent orchestrates and reviews; it does not hand-write the bulk of the work.
+5. **Honor the locked invariants** above.
+6. **Guide changes must pass the lint guards** (see Placeholder contract). Add or extend the lint tests alongside the change.
+7. **Verify before claiming done.** Run the test suite and the lint guards and **show the output** before any success claim or PR.
+8. **Per-task commits; open a draft PR early** with a full description (what/why, test plan). Put `Closes #<issue>` on its own line with no intervening words; reference a PRD as `Refs #<prd>` — never `Closes` a PRD, which closes only when its last slice merges.
+
+This workflow lives here (not in per-issue bodies) so it applies uniformly and survives issue edits.
 
 ## Schemas
 
-- Scenario: `src/schemas/scenario_schema.json` (v2.1, 14 actions, 27 assertions, named string IDs, root-level `variables`/`preconditions`). Print with `mauto schema scenario`; validate a file with `mauto validate <file>`.
-- Result: `src/schemas/result_schema.json` (typed `observations`: `regression`, `flakiness`, `state_context`). Print with `mauto schema result`.
+- Scenario: `src/schemas/scenario_schema.json` (`$schema_version` `"2.0"` or `"2.1"`; **18** step actions + **6** precondition device actions, **27** assertion types, named string IDs, root-level `variables`/`preconditions`). Print with `mauto schema scenario`; validate a file with `mauto validate <file>`. Note: `validate` accepts actions the action-catalog marks `unsupported` — known gap, issue #166.
+- Result: `src/schemas/result_schema.json` (typed root-level `observations`: `regression`, `flakiness`, `state_context`). Print with `mauto schema result`.
+- Config: `src/schemas/config_schema.json`. Print with `mauto schema config`.
 
 ## Adding a verb or guide topic
 
 1. Register the verb handler in `src/cli.js`.
-2. For a new guide topic, add `src/guide/content/<topic>.aware.md` and `<topic>.agnostic.md`.
-3. Register the topic in `src/guide/emitter.js`, `src/mcp/prompts.js`, and `src/init/adapters.js`.
-4. For a topic exposed as a skill, add `src/guide/content/<topic>.invariants.md` (placeholder-free, OS-free) and register the topic in `src/init/skill-meta.js` + `src/init/skill-renderer.js`.
-5. Extend the lint guards in `tests/lint/`.
+2. If it executes a scenario action, add the entry to `src/device/action-catalog.js`; if it writes a result field, add it to `src/result/capability-catalog.js`. The coverage lint tests derive from these.
+3. For a new guide topic, add `src/guide/content/<topic>.aware.md` and `<topic>.agnostic.md`.
+4. Register the topic in `src/guide/emitter.js`, `src/mcp/prompts.js`, and `src/init/adapters.js`.
+5. For a topic exposed as a skill, add `src/guide/content/<topic>.invariants.md` (placeholder-free, OS-free) and register the topic in `src/init/skill-meta.js` + `src/init/skill-renderer.js`.
+6. Extend the lint guards in `tests/lint/`.
 
 ## Releasing & version handling
 
-Users install via `npm i -g mobile-automator` (or run ad-hoc with `npx mobile-automator <verb>`). mobile-mcp is pinned as a dependency (`@mobilenext/mobile-mcp@0.0.55`) and spawned from `node_modules` — never fetched at runtime.
+The package is **not yet published**; users install from source. mobile-mcp is pinned as a dependency (`@mobilenext/mobile-mcp@0.0.55`) and spawned from `node_modules` — never fetched at runtime. `package.json` `files` ships only `bin/` and `src/`.
 
-**Gate-then-graduate** for multi-PR features: ship behind an opt-in env var so partial states are invisible. Append slice entries under `## [Unreleased]`.
+**The pipeline, as it actually behaves:**
 
-**CI version-bump gate.** The `Verify version is bumped` workflow fails any PR touching `src/`, `bin/`, or `package.json` without bumping `package.json`'s `version` to a value not yet in `git tag` (tags are `vX.Y.Z`). Under the gate, **the first slice PR bumps to a release-candidate semver** (e.g. `0.12.0-rc.0`); each subsequent slice increments the rc counter (`-rc.1`, `-rc.2`, …). The `vX.Y.Z` tag namespace is reserved for graduated releases — rc.N values are never tagged.
+1. Merge to `main` → `auto-tag.yml` reads `package.json` `version` and pushes tag `v<version>` if it does not already exist.
+2. Tag push → `release.yml` cuts a GitHub Release with the matching `CHANGELOG.md` section.
+3. `release.yml`'s `publish-npm` job runs `npm ci` → `npm test` → `scripts/pack-smoke.sh` → `npm publish --provenance`, but only for graduated tags (`if: !contains(github.ref, '-')`), so `-rc.N` tags are never published.
 
-**Graduation PR** removes the env-var gate, bumps `vX.Y.Z-rc.N` → `vX.Y.Z`, collapses `[Unreleased]` into the new release section, and creates the tag. Keeps `main` mergeable and preserves the "fully-formed feature per release" pattern (see v0.10/v0.11).
+**Two caveats, both real:**
+
+- **rc versions *are* tagged.** `auto-tag.yml` has no prerelease guard, so `v0.21.0-rc.13` and 20 other rc tags exist in the repo. Only *npm publishing* is gated on graduation, not tagging.
+- **`release.yml` currently can never fire** — `auto-tag.yml` pushes the tag with the default `GITHUB_TOKEN`, which does not re-trigger workflows, so `publish-npm` is unreachable. Tracked as issue [#170](https://github.com/sh3lan93/mobile-automator/issues/170); releases have been cut by hand.
+
+**CI version-bump gate.** The `Verify version is bumped` workflow fails any PR touching `src/`, `bin/`, or `package.json` without bumping `package.json`'s `version` to a value not yet in `git tag`.
+
+- **Single-PR bugfix:** bump straight to a graduated `vX.Y.Z` and rename `[Unreleased]` to that release in `CHANGELOG.md`.
+- **Multi-PR feature (gate-then-graduate):** ship behind an opt-in env var so partial states are invisible; the first slice PR bumps to `X.Y.Z-rc.0` and each subsequent slice increments the rc counter. Append slice entries under `## [Unreleased]`. The **graduation PR** removes the env-var gate, bumps `X.Y.Z-rc.N` → `X.Y.Z`, and collapses `[Unreleased]` into the new release section. This keeps `main` mergeable and preserves the "fully-formed feature per release" pattern (see v0.10/v0.11).
 
 ## Local development
 
@@ -123,7 +177,28 @@ npm link                                              # exposes `mauto` / `mobil
 cd /path/to/test-mobile-app && mauto <verb>           # drive a device, e.g. mauto devices
 ```
 
+```bash
+npm test                  # full jest suite (also runs on prepublishOnly)
+npm run test:unit         # tests/unit
+npm run test:integration  # tests/integration (CLI smoke over the real binary)
+npm run lint:guides       # guide + skill + coverage lint guards
+npm run lint:schema-additive
+./scripts/pack-smoke.sh   # install the packed tarball and exercise the bin — CI gates on this
+```
+
 The mobile-mcp version is pinned in `package.json` (`@mobilenext/mobile-mcp`) and resolved from `node_modules` at runtime (see `src/device/mobile-mcp-client.js`). Bump the pin there if you need a newer engine.
+
+Note: `jest.config` `testPathIgnorePatterns` must stay `<rootDir>`-anchored — an unanchored pattern makes `npm test` silently match zero tests inside a worktree checkout.
+
+## Known rough edges
+
+Tracked under the `production-ready` milestone; worth knowing before you debug something.
+
+- Daemon stderr is discarded (`stdio: 'ignore'`), so engine crash diagnostics are unreadable — #163.
+- Windows is silently unsupported: the session daemon binds a Unix domain socket — #165.
+- No JavaScript linter is configured (no ESLint config, dep, or script) — #164.
+- CI tests Node 18 only while `engines` declares `>=18` — #162.
+- Production dependencies carry high-severity advisories; no audit gate, no Dependabot — #161.
 
 ## Conventions
 
@@ -133,4 +208,4 @@ The mobile-mcp version is pinned in `package.json` (`@mobilenext/mobile-mcp`) an
 
 ## Metadata
 
-Repo: https://github.com/sh3lan93/mobile-automator · Version: see `package.json` · License: Apache 2.0 · Status: production-ready.
+Repo: https://github.com/sh3lan93/mobile-automator · Version: see `package.json` (0.23.7 at last edit) · License: Apache 2.0 (note: `LICENSE` currently ships a stub, not the full text — #160) · Status: feature-complete, unreleased.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,22 +4,25 @@ Features and improvements currently on the radar for Mobile Automator.
 
 ---
 
-## 🎯 Near Term
+> **Current focus:** the [`production-ready`](https://github.com/sh3lan93/mobile-automator/milestone/4)
+> milestone — the work between today's source-only install and a first published
+> npm release. Gate issue:
+> [#168](https://github.com/sh3lan93/mobile-automator/issues/168).
 
 ### Testing Features
 - [x] Tag-based test filtering and execution
+- [x] Retry logic for flaky tests — per-step `retry_policy` in the schema; `mauto result add-step --attempts` records a `flakiness` observation
 - [ ] Test suite organization (folders, groups)
-- [ ] Retry logic for flaky tests
 - [ ] Screenshot comparison improvements
 
 ### Developer Experience
-- [ ] Better error messages
+- [x] Better error messages — every verb emits the uniform `{ok,data,error,hint,schema_version}` envelope with an actionable `hint`, and commander parse failures are routed through it too
 - [x] Device-visibility check (`mauto devices`); deeper setup health checks still open
 - [ ] Faster scenario generation
 - [ ] Test scenario templates
 
 ### Integrations
-- [ ] CI/CD examples (GitHub Actions, CircleCI)
+- [x] CI/CD example for GitHub Actions — see the [FAQ](docs/faq.md); a CircleCI example is still open
 - [ ] JIRA integration for bug reporting
 - [ ] Slack notifications for test results
 
@@ -65,4 +68,4 @@ Have a feature request? [Open an issue](https://github.com/sh3lan93/mobile-autom
 
 ---
 
-*Last updated: June 2026*
+*Last updated: August 2026 (v0.23.7)*

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -138,7 +138,7 @@ Reasoning is delivered via `mauto guide <topic>` at explicit invocation, never a
 
 The test scenario schema provides rich, expressive capabilities:
 
-- **14 action types** — scroll, scroll_to_element, wait_for_loading_complete, capture_value, clear_app_data, and more
+- **18 action types** — tap, swipe, scroll_to_element, wait_for_loading_complete, capture_value, and the four semantic actions used by platform-agnostic mode
 - **27 assertion types** — comprehensive coverage across text, visibility, collections, visual, navigation
 - **Advanced control** — retry policies, conditions, sub-steps
 - **Better debugging** — capture values for later assertion, detailed step context

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Testing mobile apps manually is **tedious and error-prone**. Cross-platform test
 - **Any Agent**: Claude Code, Cursor, Gemini CLI, GitHub Copilot, and OpenAI Agents get one-command setup via `mauto init`; any MCP-capable agent connects via `mauto mcp`
 - **Platform Detection**: Auto-discovers Android, iOS, Flutter, React Native, Kotlin Multiplatform, and Compose Multiplatform projects
 - **Platform-Agnostic by Default**: One scenario runs on Android and iOS, with OS gestures mapped to semantic actions
-- **Schema**: 14 action types, 27 assertion types, and advanced retry/condition logic
+- **Schema**: 18 action types, 27 assertion types, and advanced retry/condition logic
 - **Result Observations**: Captures flakiness, regressions, and state context for smarter debugging
 - **Cross-Session Memory**: The agent remembers app-knowledge, preferences, and run-history across sessions ([`mauto memory`](concepts/memory.md))
 - **Semantic Vision**: AI-powered visual assertions that tolerate cosmetic changes
@@ -128,7 +128,7 @@ Because the contract is just verbs + JSON, **no agent is special** — any agent
 
 - **One-Command Setup**: `mauto init` ships native Agent Skills for Claude Code, Cursor, Gemini CLI, GitHub Copilot, and OpenAI Agents
 - **Platform Modes**: platform-aware (default) and platform-agnostic (`--mode agnostic`) with four semantic actions for cross-platform scenarios
-- **Schema**: 14 action types, 27 assertion types, advanced retry/condition logic
+- **Schema**: 18 action types, 27 assertion types, advanced retry/condition logic
 - **Result Observations**: Captures flakiness, regressions, and execution context
 - **Cross-Session Memory**: The agent remembers app-knowledge, preferences, and run-history across sessions via [`mauto memory`](concepts/memory.md) — so it gets smarter about *your* app over time
 - **Persistent Device Session**: One warm mobile-mcp daemon behind `mauto session` and `mauto devices` keeps device state across verbs

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Reference & Schemas"
-description: "Complete reference documentation for mobile-automator schemas, 27 assertion types, 14 action types, and MCP automation tools."
+description: "Complete reference documentation for mobile-automator schemas, 27 assertion types, 18 action types, and MCP automation tools."
 ---
 
 # Reference Documentation
@@ -13,7 +13,7 @@ Complete reference for all schemas, assertion types, and automation tools used b
 
 **Create test scenarios with:**
 - [27 Assertion Types](assertions.md) — Element visibility, text content, visual state, and more
-- [14 Action Types](schema.md#action-types-14-total) — Launch app, tap, type, wait, capture values, etc.
+- [18 Action Types](schema.md#action-types-18-total) — Launch app, tap, type, wait, capture values, etc.
 - [Schema Documentation](schema.md) — Complete scenario structure and all fields
 
 ### For Test Executors
@@ -83,7 +83,7 @@ The default schema for test scenarios. Defines structure for steps, assertions, 
 
 **Key features:**
 - Named string step IDs (not integer indices)
-- 14 action types and 27 assertion types
+- 18 action types and 27 assertion types
 - Variables and value capture
 - Conditional execution and retry policies
 - Structured preconditions
@@ -172,7 +172,7 @@ How mobile-automator learns across sessions: the auto-harvested `run-history` pl
 
 ### Creating test scenarios?
 
-1. [Schema — Step Reference](schema.md#action-types-14-total) — All 14 action types
+1. [Schema — Step Reference](schema.md#action-types-18-total) — All 18 action types
 2. [Assertion Types](assertions.md) — All 27 assertion types with examples
 3. [Schema — Complete Example](schema.md#complete-example-login-scenario-with-variables) — Full working scenario
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1,5 +1,5 @@
 ---
-description: "Test Scenario Schema reference - named step IDs, 14 action types, 27 assertion types, variables, retry policies, and conditional logic."
+description: "Test Scenario Schema reference - named step IDs, 18 action types, 27 assertion types, variables, retry policies, and conditional logic."
 ---
 
 # Test Scenario Schema Reference
@@ -11,7 +11,7 @@ The schema for test scenarios. Defines the complete structure for test steps, as
 The scenario schema defines the format for mobile test scenarios:
 
 - **Named string step IDs** — `tap_login`, `wait_for_home` (not integer indices)
-- **14 action types** — From simple tap/type to advanced waits and variable capture
+- **18 action types** — From simple tap/type to advanced waits and variable capture
 - **27 assertion types** — Comprehensive UI, content, visual, and accessibility checks
 - **Variables & capture** — Extract dynamic values during execution for later assertions
 - **Conditional execution** — Optional steps, conditional branching, retry policies
@@ -112,9 +112,11 @@ The `steps` field is an **ordered array** of step objects. Each object requires 
 - Examples: `tap_login`, `wait_for_home`, `type_email_address`
 - Unique within the scenario; used for screenshot naming and `after_step` references
 
-### Action Types (14 total)
+### Action Types (18 total)
 
-Each step's `action` field is one of these values. In platform-agnostic (`mode: "platform-agnostic"`) scenarios you can additionally use the four semantic actions `press_back`, `dismiss_keyboard`, `grant_permission`, and `deny_permission`, which resolve to the right per-platform mechanics at replay time.
+Each step's `action` field is one of these values: the **14 core actions** documented below, plus **4 semantic actions** available in platform-agnostic (`mode: "platform-agnostic"`) scenarios — `press_back`, `dismiss_keyboard`, `grant_permission`, and `deny_permission` — which resolve to the right per-platform mechanics at replay time.
+
+Note that `clear_app_data` is accepted by the schema but is **not mechanically executable** — the underlying automation engine exposes no primitive for it, so a scenario using it cannot replay unattended. The same applies to the `enable_wifi` and `disable_wifi` precondition device actions.
 
 #### 1. launch_app
 Launch the app under test on the device.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mobile-automator",
-  "version": "0.23.0",
+  "version": "0.23.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobile-automator",
-      "version": "0.23.0",
+      "version": "0.23.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@mobilenext/mobile-mcp": "0.0.55",

--- a/tests/lint/docs-counts.test.js
+++ b/tests/lint/docs-counts.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const scenarioSchema = require('../../src/schemas/scenario_schema.json');
+const { ACTION_CATALOG } = require('../../src/device/action-catalog');
+
+// Hand-maintained capability counts in prose drift the moment the schema grows.
+// They already did once: #117 wired 7 stranded mobile-mcp primitives into flat
+// verbs and every doc kept saying "14 action types" (issue #167), which
+// understated the surface by four and led an audit astray. This guard derives
+// the true counts from the schema + action catalog and fails any shipping doc
+// that states a different number, so a count can never silently rot again.
+//
+// Excluded by design: changelog files and docs/plans/** are historical records
+// — "14 actions" was TRUE when those entries were written and must not be
+// rewritten.
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// --- Derived truth (never hardcode these) ---------------------------------
+
+const STEP_ACTIONS = scenarioSchema.definitions.step.properties.action.enum;
+const PRECONDITION_ACTIONS =
+  scenarioSchema.properties.preconditions.properties.device_actions.items.properties.action.enum;
+const ASSERTION_TYPES = scenarioSchema.definitions.assertion.properties.type.enum;
+
+const SEMANTIC_ACTIONS = Object.entries(ACTION_CATALOG)
+  .filter(([, entry]) => entry.resolution === 'semantic')
+  .map(([action]) => action);
+
+const COUNTS = {
+  // Every value a step's `action` field may take (core + semantic).
+  stepActions: STEP_ACTIONS.length,
+  // The subset documented as numbered entries in docs/reference/schema.md,
+  // i.e. everything except the platform-agnostic semantic actions.
+  coreActions: STEP_ACTIONS.length - SEMANTIC_ACTIONS.length,
+  assertionTypes: ASSERTION_TYPES.length,
+  // The catalog covers the union of both action enums (clear_app_data is in
+  // both), which is why it is not simply the sum.
+  catalogEntries: new Set([...STEP_ACTIONS, ...PRECONDITION_ACTIONS]).size,
+};
+
+// --- Claims found in prose, and the count each must equal ------------------
+
+const CLAIM_PATTERNS = [
+  {
+    name: '"N action types"',
+    regex: /(\d+)\s+action types/gi,
+    expected: () => COUNTS.stepActions,
+  },
+  {
+    name: '"Action Types (N total)" heading',
+    regex: /Action Types \((\d+) total\)/gi,
+    expected: () => COUNTS.stepActions,
+  },
+  {
+    name: '"N core actions"',
+    regex: /(\d+)\s+core actions/gi,
+    expected: () => COUNTS.coreActions,
+  },
+  {
+    name: '"N assertion types"',
+    regex: /(\d+)\s+assertion types/gi,
+    expected: () => COUNTS.assertionTypes,
+  },
+];
+
+const EXCLUDED = [
+  'docs/changelog.md',
+  'CHANGELOG.md',
+  'docs/plans',
+  'docs/superpowers/plans',
+  'docs/superpowers/specs',
+];
+
+function isExcluded(relPath) {
+  const posix = relPath.split(path.sep).join('/');
+  return EXCLUDED.some((ex) => posix === ex || posix.startsWith(ex + '/'));
+}
+
+function collectDocs() {
+  const files = [];
+
+  for (const top of ['README.md', 'CLAUDE.md', 'ROADMAP.md', 'TROUBLESHOOTING.md', 'CONTRIBUTING.md']) {
+    const abs = path.join(REPO_ROOT, top);
+    if (fs.existsSync(abs)) files.push(abs);
+  }
+
+  const docsRoot = path.join(REPO_ROOT, 'docs');
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      if (isExcluded(path.relative(REPO_ROOT, abs))) continue;
+      if (entry.isDirectory()) walk(abs);
+      else if (entry.isFile() && entry.name.endsWith('.md')) files.push(abs);
+    }
+  };
+  if (fs.existsSync(docsRoot)) walk(docsRoot);
+
+  return files;
+}
+
+describe('shipping docs state capability counts that match the schema', () => {
+  const files = collectDocs();
+
+  it('finds docs to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const { name, regex, expected } of CLAIM_PATTERNS) {
+    it(`every ${name} claim equals the derived count`, () => {
+      const want = expected();
+      const offenders = [];
+
+      for (const abs of files) {
+        const lines = fs.readFileSync(abs, 'utf8').split('\n');
+        lines.forEach((line, i) => {
+          for (const m of line.matchAll(regex)) {
+            if (Number(m[1]) !== want) {
+              offenders.push(
+                `${path.relative(REPO_ROOT, abs)}:${i + 1}: says ${m[1]}, schema says ${want} — ${line.trim()}`
+              );
+            }
+          }
+        });
+      }
+
+      expect(offenders).toEqual([]);
+    });
+  }
+
+  it('the action catalog covers every action in both schema enums', () => {
+    const union = [...new Set([...STEP_ACTIONS, ...PRECONDITION_ACTIONS])];
+    const missing = union.filter((a) => !ACTION_CATALOG[a]);
+    expect(missing).toEqual([]);
+    expect(Object.keys(ACTION_CATALOG).length).toBe(COUNTS.catalogEntries);
+  });
+});


### PR DESCRIPTION
## What

Brings the three documents #167 flagged back in line with `main` at v0.23.7, and adds a lint guard so the counts cannot drift again.

Closes #167

Refs #168

## Why

### 1. CLAUDE.md carried two claims that were false, not merely stale

| Claim | Reality |
|---|---|
| "Users install via `npm i -g mobile-automator`" | Never published — `npm view mobile-automator` returns 404. README and the docs site were already honest, so CLAUDE.md was the outlier. |
| "rc.N values are never tagged" | `auto-tag.yml` has no prerelease guard; **21 rc tags** exist (`v0.21.0-rc.13`, …). Only *npm publishing* is gated on graduation. |

This matters more than ordinary staleness: CLAUDE.md is what agents load as authoritative context, and #167 records that the npm line "sent this audit down a wrong path before the registry was checked."

Also resynced: the 7 flat device verbs from #117 (`long-press`, `double-tap`, `launch`, `install`, `uninstall`, `open-url`, `orientation`); a new **Drift guards** section covering `device/action-catalog.js` and `result/capability-catalog.js`; the completed `cli` milestone and dead `interactive-recording` milestone collapsed into one table, with the locked invariants promoted out of the finished section since they still bind all work; the real auto-tag → release → publish chain including #170; and a **Known rough edges** section (#160–#165).

### 2. The action count was wrong in six live places, not one

Every doc said **14 action types**; the schema's step enum has **18** and the catalog covers **23** across both enums. #167 recorded only the `architecture.md` occurrence.

`docs/reference/schema.md` turned out to be substantively complete — its 14 numbered entries are exactly the 18 minus the 4 semantic actions, which it already described in prose. Only the framing was wrong, so this reframes it as "18 total (14 core + 4 semantic)" rather than adding content. The heading rename moves its anchor, so both inbound links are updated with it.

`architecture.md` also led its capability list with `clear_app_data` — one of the three actions the catalog marks `unsupported`. Dropped, and the schema reference now states plainly that those three cannot replay.

### 3. Counts are now enforced, not asserted

Per #167's "ideally enforced rather than asserted", `tests/lint/docs-counts.test.js` derives the counts from the scenario schema plus the action catalog and fails any shipping doc stating a different number. It paid for itself on its first run by catching a title-case `14 Action Types` link that the case-sensitive substitution had missed. Changelogs and `docs/plans/**` are excluded — "14 actions" was true when those were written.

### 4. ROADMAP

Ticked with evidence: retry logic (`retry_policy` + `--attempts` flakiness observations) and better error messages (the envelope's `hint`; #120, #146, #155/#157/#158).

**One correction to the issue:** #167 argues CI/CD examples shipped because "the repo has nine workflows" — but those are this project's own CI, not examples for users running `mauto` in their pipelines. The real evidence is a GitHub Actions example in the FAQ, so the item is scoped to GitHub Actions with CircleCI left open rather than fully ticked.

## Test plan

- `npm test` — **829 passed, 70 suites** (up from 823/69; the new guard adds 6).
- `npm run lint:guides` — 124 passed, 9 suites.
- `npm run test:integration` — CLI smoke over the real binary.
- Claims verified against the repo rather than from memory: `npm view` (404), `git tag` (21 rc tags), `wc -c LICENSE` (644-byte stub), `stdio: 'ignore'` in `session-spawn.js:38`, the Unix socket bind in `session-paths.js`, absence of any ESLint config, and `mauto --help` for the verb list.

## Notes for the reviewer

- **No version bump.** The gate watches `src/**`, `bin/**`, `package.json`; this PR touches only docs and `tests/`, so `Verify version is bumped` is skipped.
- **`package-lock.json`** is included in its own commit: it still recorded `0.23.0` while `package.json` is at `0.23.7`, so any `npm` invocation resynced it. No dependency resolution changed.
- **The new guard is not in the `lint:guides` script** — adding it would touch `package.json` and trip the version gate for a docs-only PR. It runs in CI via `npm run test:all`. Happy to fold it in if you'd rather take the bump.
- No CHANGELOG entry, as there is no `[Unreleased]` section and this ships no code. Say the word if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDGCPu8RfvesK5BQaGrTj2