### PR TITLE
fix(ci): make the release pipeline reachable — App-token tagging + broader release triggers

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,13 +10,57 @@ jobs:
     name: Create version tag
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Required to push tags
+      contents: read  # the App token below performs the write, not GITHUB_TOKEN
 
     steps:
+      # The tag this job pushes must be able to trigger `release.yml`, which
+      # listens for a tag push. Actions deliberately suppresses that event when
+      # the push is made with the built-in GITHUB_TOKEN (loop prevention), so a
+      # GITHUB_TOKEN-pushed tag silently reaches nobody — the tag lands, this
+      # job reports success, and the release never happens. See #170.
+      #
+      # A GitHub App installation token is a distinct identity, so its pushes
+      # are not suppressed. It is preferred over a PAT: short-lived (~1h),
+      # scoped to this repo, and nothing to rotate.
+      # Secrets go through env, never string interpolation: the private key is a
+      # multiline PEM and would break the shell if pasted into the script body.
+      - name: Fail early if the release App is not configured
+        env:
+          APP_ID: ${{ secrets.RELEASE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        run: |
+          MISSING=""
+          if [ -z "$APP_ID" ]; then MISSING="$MISSING RELEASE_APP_ID"; fi
+          if [ -z "$APP_PRIVATE_KEY" ]; then MISSING="$MISSING RELEASE_APP_PRIVATE_KEY"; fi
+
+          if [ -n "$MISSING" ]; then
+            echo "❌ Missing repository secret(s):$MISSING"
+            echo ""
+            echo "  Tagging is intentionally hard-failed rather than falling back to"
+            echo "  GITHUB_TOKEN. A fallback would push the tag and silently fail to"
+            echo "  trigger release.yml — the exact invisible breakage of #170."
+            echo ""
+            echo "  Create a GitHub App with Repository permissions > Contents: Read"
+            echo "  and write, install it on this repo, then add its App ID and"
+            echo "  private key as the secrets above."
+            exit 1
+          fi
+          echo "✅ Release App secrets present."
+
+      - name: Mint a GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Required to fetch all existing tags
+          # Persisted so the tag push below uses the App identity, not
+          # GITHUB_TOKEN. This is the whole point of the job.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Read version from package.json
         id: get_version
@@ -53,7 +97,7 @@ jobs:
           git push origin "$TAG"
 
           echo ""
-          echo "🏷️ Tag created and pushed"
+          echo "🏷️ Tag created and pushed (as the release App, so release.yml will fire)"
           echo "────────────────────────────────────────"
           echo "  Tag:     $TAG"
           echo "  Version: $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,66 @@
 name: Release
 
+# Three ways in, deliberately:
+#   push.tags       — the normal path: auto-tag.yml pushes vX.Y.Z (as the
+#                     release App, so the event is not suppressed — see #170).
+#   release         — a Release created by hand in the UI. Before #170 this
+#                     reached nobody: attaching a Release to an existing tag
+#                     pushes nothing, so no tag-push event was ever emitted.
+#   workflow_dispatch — a manual escape hatch. Pick the *tag* in the ref
+#                     dropdown; the resolve job rejects branch refs.
+#
+# NOTE: the release job below must keep using GITHUB_TOKEN. Actions suppresses
+# events raised by GITHUB_TOKEN, which is exactly what stops the Release it
+# creates from re-triggering this workflow on `release: published`. Handing it
+# the App token would turn that suppression off and create an infinite loop.
 on:
   push:
     tags:
       - 'v*.*.*'  # Triggers on version tags like v0.1.0, v1.0.0, etc.
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
+  resolve:
+    name: Resolve release ref
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.get_version.outputs.tag }}
+    steps:
+      # Every entry point must land on a tag ref. push.tags and release always
+      # do; workflow_dispatch does not have to, so a branch ref is rejected
+      # here rather than silently producing a garbage version like
+      # "refs/heads/main" and publishing it.
+      - name: Validate the ref is a version tag
+        run: |
+          if [[ "$GITHUB_REF" != refs/tags/v*.*.* ]]; then
+            echo "❌ Expected a version tag ref, got: $GITHUB_REF"
+            echo ""
+            echo "  This workflow publishes whatever the ref points at, so it"
+            echo "  only runs on a vX.Y.Z tag. If you triggered it manually,"
+            echo "  re-run it and pick the tag (not a branch) in the"
+            echo "  'Use workflow from' dropdown."
+            exit 1
+          fi
+          echo "✅ Ref is a version tag: $GITHUB_REF"
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          # Remove 'v' prefix from tag (v0.1.0 -> 0.1.0)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "Resolved version $VERSION from ${GITHUB_REF#refs/tags/}"
+
   release:
     name: Create Release
+    needs: resolve
+    # On the `release` entry point the Release already exists — that event is
+    # what triggered us. Re-creating it is a no-op at best.
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required to create releases
@@ -18,19 +71,11 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for changelog extraction
 
-      - name: Extract version from tag
-        id: get_version
-        run: |
-          # Remove 'v' prefix from tag (v0.1.0 -> 0.1.0)
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
       - name: Extract changelog for this version
         id: changelog
         run: |
           # Extract the changelog section for this specific version
-          VERSION="${{ steps.get_version.outputs.version }}"
+          VERSION="${{ needs.resolve.outputs.version }}"
 
           # Find the section between ## [$VERSION] and the next ## [
           CHANGELOG=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d' | tail -n +2)
@@ -45,15 +90,19 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      # Replaces actions/create-release@v1, which was archived in 2021 and
+      # declares runs.using: node12 — a runtime current runners no longer
+      # provide. It also failed outright when the release already existed;
+      # this one updates in place, so re-runs are safe.
       - name: Create GitHub Release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.get_version.outputs.tag }}
-          release_name: Release ${{ steps.get_version.outputs.tag }}
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          name: Release ${{ needs.resolve.outputs.tag }}
           body: |
-            ## Mobile Automator ${{ steps.get_version.outputs.tag }}
+            ## Mobile Automator ${{ needs.resolve.outputs.tag }}
 
             ${{ steps.changelog.outputs.content }}
 
@@ -73,18 +122,21 @@ jobs:
 
             ### 📚 Documentation
 
-            - [README](https://github.com/${{ github.repository }}/blob/${{ steps.get_version.outputs.tag }}/README.md)
-            - [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ steps.get_version.outputs.tag }}/CHANGELOG.md)
-            - [Troubleshooting Guide](https://github.com/${{ github.repository }}/blob/${{ steps.get_version.outputs.tag }}/TROUBLESHOOTING.md)
+            - [README](https://github.com/${{ github.repository }}/blob/${{ needs.resolve.outputs.tag }}/README.md)
+            - [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ needs.resolve.outputs.tag }}/CHANGELOG.md)
+            - [Troubleshooting Guide](https://github.com/${{ github.repository }}/blob/${{ needs.resolve.outputs.tag }}/TROUBLESHOOTING.md)
           draft: false
-          prerelease: ${{ contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'alpha') || startsWith(steps.get_version.outputs.version, '0.') }}
+          prerelease: ${{ contains(needs.resolve.outputs.version, 'beta') || contains(needs.resolve.outputs.version, 'alpha') || startsWith(needs.resolve.outputs.version, '0.') }}
 
   publish-npm:
     name: Publish to npm
-    # Only publish graduated (non-prerelease) tags. The workflow triggers on
+    needs: resolve
+    # Only publish graduated (non-prerelease) versions. The workflow triggers on
     # v*.*.* which also matches rc tags like v0.21.0-rc.13; this guard skips
-    # those so release candidates are never published to the registry.
-    if: ${{ !contains(github.ref, '-') }}
+    # those so release candidates are never published to the registry. It reads
+    # the resolved version rather than github.ref so it cannot be fooled by a
+    # hyphen elsewhere in the ref.
+    if: ${{ !contains(needs.resolve.outputs.version, '-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -99,8 +151,12 @@ jobs:
       - run: npm test
       - run: ./scripts/pack-smoke.sh
       # NPM_TOKEN must be configured in the repo's secrets (Settings > Secrets
-      # and variables > Actions) with an npm automation token that has publish
-      # rights for the mobile-automator package.
+      # and variables > Actions) with an npm *granular* access token that has
+      # publish rights. npm removed classic/automation tokens in November 2025.
+      # For a package that does not exist yet the token must be scoped to
+      # "All Packages" — a not-yet-published name cannot be selected
+      # individually. Once published, migrate to trusted publishing (OIDC) and
+      # delete this secret.
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What / why

`release.yml` has produced **exactly one run in this repository's history** — `v0.1.0`, February 2026, from a hand-pushed tag. Every tag since `v0.22.0` produced no GitHub Release and no npm publish, and nothing ever reported an error, because a workflow that is never triggered emits no failure.

Two independent walls caused it.

### Wall 1 — the tag push was suppressed

`auto-tag.yml` pushed tags using the built-in `GITHUB_TOKEN`. Actions deliberately **does not start workflow runs from events raised with `GITHUB_TOKEN`** (loop prevention). So the tag landed, the job printed `🏷️ Tag created and pushed`, and the push event reached nobody.

Fixed by minting a **GitHub App installation token** and handing it to `actions/checkout`, so the push comes from a distinct identity. Chosen over a PAT: ~1 hour lifetime, scoped to this repo, nothing to rotate.

Missing App secrets **hard-fail with an actionable message** rather than falling back to `GITHUB_TOKEN`. A fallback would push the tag and silently fail to trigger the release — precisely the invisible breakage this PR exists to remove.

### Wall 2 — a hand-created Release couldn't trigger it either

`release.yml` listened only for `push.tags`. Attaching a Release to an **existing** tag pushes nothing, so it emits no tag-push event. That is why creating the `v0.23.7` Release by hand also did nothing.

Added `release: [published]` and `workflow_dispatch`.

> The `release` job deliberately **keeps** `GITHUB_TOKEN`. That same suppression rule is what stops the Release it creates from re-triggering this workflow on `release: published`. Giving that step the App token would loop forever.

## Also in this PR

- **New `resolve` job** validates the ref is a `vX.Y.Z` tag and exports `version`/`tag` once, shared by both jobs. `workflow_dispatch` can target a branch, which would otherwise yield `version="refs/heads/main"` — and publish it.
- **The rc guard reads the resolved version**, not `github.ref`, so a hyphen elsewhere in the ref cannot fool it into publishing a release candidate.
- **`actions/create-release@v1` → `softprops/action-gh-release@v2`.** The former was archived in 2021 and declares `runs.using: node12`, a runtime current runners no longer provide. It also failed outright when the release already existed; the replacement updates in place, so re-runs and the `release` entry point are both safe.
- **Secrets reach the shell through `env`, never interpolation** — the private key is a multiline PEM and would break the script body.

## ⚠️ Before merge — required setup

`auto-tag` will **fail loudly** until these exist (by design):

1. **Create a GitHub App** — Settings → Developer settings → GitHub Apps → New GitHub App. Name it anything (e.g. `mobile-automator-release`); homepage URL can be this repo.
2. **Permissions** — Repository permissions → **Contents: Read and write**. Nothing else. Uncheck "Active" under Webhook.
3. **Install it** on `sh3lan93/mobile-automator` (App settings → Install App → Only select repositories).
4. **Generate a private key** (App settings → Private keys → Generate) — downloads a `.pem`.
5. **Add two repo secrets** (Settings → Secrets and variables → Actions):
   - `RELEASE_APP_ID` — the App ID from the App's General page
   - `RELEASE_APP_PRIVATE_KEY` — the **entire** `.pem` contents, including the `-----BEGIN...` and `-----END...` lines

## Test plan

Not runnable in CI (the paths only execute on a tag), so verified locally:

- [x] Both workflows parse as valid YAML; job graph is `resolve` → {`release`, `publish-npm`}
- [x] Every `run` block passes `bash -n`
- [x] Ref guard accepts `refs/tags/v0.23.7`, `v1.0.0`, `v0.24.0-rc.1`; rejects `refs/heads/main`, `refs/tags/nightly`
- [x] rc guard publishes `0.23.7` / `1.0.0`, skips `0.24.0-rc.1` / `0.21.0-rc.13`
- [x] Changelog `sed` extracts 1813 chars for `0.23.7`
- [x] No version bump needed — `version-check.yml` filters on `src/`, `bin/`, `package.json`, none of which this touches

**The real test is the first tag after merge.** `main` is at `0.23.7` and `v0.23.7` already exists, so merging this alone will not trigger anything — `auto-tag` skips an existing tag. To exercise it end to end, delete the `v0.23.7` tag and Release after merging and let the next push to `main` recreate it, or push the next version normally.

Refs #170
