### PR TITLE
chore(release): bump to 0.23.8 to exercise the fixed release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.23.8]
+
+### 🐛 Fixed
+
+- **The release pipeline is reachable for the first time since v0.1.0.** `release.yml` had produced exactly one run in the repository's history — `v0.1.0` in February 2026, from a hand-pushed tag — so no tag from `v0.22.0` onward ever produced a GitHub Release or an npm publish, and nothing ever reported an error, because a workflow that is never triggered emits no failure. Two independent walls caused it. **(1)** `auto-tag.yml` pushed tags using the built-in `GITHUB_TOKEN`, and Actions deliberately does not start workflow runs from events raised with `GITHUB_TOKEN` (loop prevention) — the tag landed, the job printed `🏷️ Tag created and pushed`, and the push event reached nobody. Tags are now pushed with a **GitHub App installation token** (`actions/create-github-app-token`), a distinct identity whose pushes are not suppressed; it is preferred over a PAT because it is repo-scoped, lives about an hour, and needs no rotation. Missing App secrets hard-fail with an actionable message rather than falling back to `GITHUB_TOKEN`, since a fallback would recreate exactly the invisible breakage being fixed. **(2)** `release.yml` listened only for `push.tags`, so a Release created by hand from an existing tag — which pushes nothing, and therefore emits no tag-push event — could not trigger it either; `release: [published]` and `workflow_dispatch` are now accepted as entry points. The release job deliberately keeps `GITHUB_TOKEN`: that same suppression is what stops the Release it creates from re-triggering the workflow on `release: published`. A new `resolve` job validates that the ref is a `vX.Y.Z` tag and exports the version once for both jobs — `workflow_dispatch` can target a branch, which would otherwise resolve a version of `refs/heads/main` and publish it — and the release-candidate guard now reads that resolved version instead of `github.ref`, so a hyphen elsewhere in the ref cannot let an rc reach the registry. `actions/create-release@v1` (archived in 2021, `runs.using: node12`, a runtime current runners no longer provide, and hard-fails when the release already exists) is replaced by `softprops/action-gh-release@v2`, which updates in place so re-runs are safe. ([#170](https://github.com/sh3lan93/mobile-automator/issues/170))
+
+---
+
 ## [0.23.7]
 
 ### 🐛 Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.23.7",
+  "version": "0.23.8",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {


### PR DESCRIPTION
## What / why

#172 made `release.yml` reachable. This bump is what lets that fix actually run.

**The fix cannot apply to any existing tag.** For `push`(tags), `release` and `workflow_dispatch`, Actions executes the workflow file **from the ref the run is associated with**, not from the default branch. `v0.23.7` points at `97ff194`, which predates #172, so its copy of `release.yml` has neither the `release:` trigger nor `workflow_dispatch`:

```console
$ git show v0.23.7:.github/workflows/release.yml | sed -n '/^on:/,/^jobs:/p'
on:
  push:
    tags:
      - 'v*.*.*'

$ git show main:.github/workflows/release.yml | sed -n '/^on:/,/^jobs:/p'
on:
  push:
    tags: ['v*.*.*']
  release:
    types: [published]
  workflow_dispatch:
```

That is why deleting and re-creating the v0.23.7 Release did nothing: the event fired and was recorded (`ReleaseEvent published` at `19:56:52`), but GitHub consulted the tag's copy of the workflow, which has nothing listening.

`main` is at `0.23.7` with `v0.23.7` already tagged, so `auto-tag` skips indefinitely. A version bump is the only way to get a tag at a commit that carries the fixed workflow.

## Also adds the missing changelog entry

#170/#172 shipped with **no release note** — workflow-only changes skip the version gate, so nothing forced one. The `[0.23.8]` section documents both walls, why the release job deliberately keeps `GITHUB_TOKEN` (its suppression is what prevents an infinite `release: published` loop), the new `resolve` ref guard, and the `actions/create-release@v1` → `softprops/action-gh-release@v2` swap.

## What should happen on merge

This is the first end-to-end run of the whole chain:

```
merge → auto-tag mints the App token → pushes v0.23.8 (at a commit that HAS the fixed workflow)
      → push event fires (App identity, not suppressed)
      → release.yml: resolve → release (GitHub Release) → publish-npm (first npm publish)
```

## Test plan

- [x] `0.23.8` is not present in `git tag`
- [x] `release.yml`'s changelog `sed` extracts 2282 chars for `0.23.8` (the release body will not be empty)
- [x] `resolve` guard accepts `refs/tags/v0.23.8`; rc guard resolves to publish
- [x] 829 tests / 70 suites green
- [x] `./scripts/pack-smoke.sh` → `pack-smoke OK: tarball mobile-automator-0.23.8.tgz installed and CLI verified`

## Out of scope

`CHANGELOG.md` still has an `[Unreleased]` section sitting *below* `[0.23.4]`, holding the entries for #151/#148/#149 that shipped as 0.23.1–0.23.3 and were never moved into version sections. Pre-existing; worth a separate tidy-up.

Refs #170
