### PR TITLE
chore(ci): publish via trusted publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,23 +140,46 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # Required for npm publish --provenance
+      # The OIDC identity IS the credential now: npm exchanges this token for a
+      # short-lived publish grant via the trusted publisher configured on the
+      # package. No NPM_TOKEN is involved.
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing needs npm >= 11.5.1, and Node 22 LTS bundles npm
+      # 10.x — the Node version alone does NOT satisfy the floor. Upgrade
+      # explicitly and assert it, so a future runner image change surfaces as a
+      # clear failure here rather than as an authentication error at publish
+      # time.
+      - name: Install an npm that supports trusted publishing
+        run: |
+          npm install -g npm@latest
+          NPM_VERSION="$(npm --version)"
+          echo "npm $NPM_VERSION"
+          MIN=11.5.1
+          if [ "$(printf '%s\n%s\n' "$MIN" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN" ]; then
+            echo "npm $NPM_VERSION is below the $MIN required for trusted publishing"
+            exit 1
+          fi
+          echo "npm $NPM_VERSION satisfies the >= $MIN floor"
+
       - run: npm ci
       - run: npm test
       - run: ./scripts/pack-smoke.sh
-      # NPM_TOKEN must be configured in the repo's secrets (Settings > Secrets
-      # and variables > Actions) with an npm *granular* access token that has
-      # publish rights. npm removed classic/automation tokens in November 2025.
-      # For a package that does not exist yet the token must be scoped to
-      # "All Packages" — a not-yet-published name cannot be selected
-      # individually. Once published, migrate to trusted publishing (OIDC) and
-      # delete this secret.
+
+      # Published via trusted publishing (OIDC) — no NPM_TOKEN, nothing to
+      # rotate, and no long-lived credential in repository secrets. The trust
+      # relationship is configured on the package itself and names this
+      # repository and this workflow file, so renaming release.yml or moving
+      # the publish to another workflow will break it until the trusted
+      # publisher is updated (`npm trust list mobile-automator`).
+      #
+      # --provenance is kept deliberately. OIDC generates provenance anyway,
+      # but the explicit flag makes a failure to attest fail the publish rather
+      # than silently shipping an unattested tarball.
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.23.9]
+
+### 🔒 Changed
+
+- **npm publishing moved to trusted publishing (OIDC); the `NPM_TOKEN` secret is gone.** 0.23.8 published with a granular access token that had to be scoped to **All Packages**, because npm cannot scope a token to a package that does not exist yet — a broad, long-lived credential sitting in repository secrets purely to bootstrap the first release. That constraint is gone now that the package exists, so `publish-npm` authenticates with the workflow's own OIDC identity instead: npm exchanges the `id-token` for a short-lived publish grant via a trusted publisher configured on the package, naming this repository and this workflow file. Nothing long-lived remains, and there is nothing to rotate. The job moves from Node 18 to **Node 22**, and — because Node 22 LTS bundles npm 10.x while trusted publishing requires **npm >= 11.5.1** — npm is upgraded explicitly and the floor is asserted, so a future runner image change fails loudly at a named step rather than surfacing as an opaque authentication error at publish time. `--provenance` is kept deliberately: OIDC generates provenance regardless, but the explicit flag makes a failure to attest fail the publish rather than silently shipping an unattested tarball. Note the trust relationship names `release.yml` specifically — renaming that file, or moving the publish step into another workflow, breaks publishing until the trusted publisher is updated (`npm trust list mobile-automator`). ([#170](https://github.com/sh3lan93/mobile-automator/issues/170))
+
+---
+
 ## [0.23.8]
 
 ### 🐛 Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-automator",
-  "version": "0.23.8",
+  "version": "0.23.9",
   "description": "Host-agnostic mauto CLI for AI-driven mobile QA automation — analyzes a mobile project and drives devices through mobile-mcp.",
   "homepage": "https://github.com/sh3lan93/mobile-automator#readme",
   "repository": {


### PR DESCRIPTION
## What / why

0.23.8 published with a granular access token scoped to **All Packages** — npm cannot scope a token to a package that does not exist yet, so the first publish required a broad, long-lived credential sitting in repository secrets purely to bootstrap. The package exists now, so that constraint is gone.

`publish-npm` now authenticates with the workflow's **own OIDC identity**. npm exchanges the `id-token` for a short-lived publish grant via a trusted publisher configured on the package. No `NPM_TOKEN`, nothing to rotate, no long-lived credential anywhere.

## The non-obvious part

**Node 22 alone does not satisfy the requirement.** Trusted publishing needs **npm ≥ 11.5.1**, and Node 22 LTS bundles npm 10.x. Bumping `node-version` and stopping there is a common way to get an opaque authentication failure at publish time.

So npm is upgraded explicitly and the floor is **asserted**:

```
npm 10.9.2  → REJECTED (below 11.5.1)
npm 11.5.0  → REJECTED
npm 11.5.1  → accepted
npm 11.12.1 → accepted
```

A future runner image change now fails at a named step with a clear message, instead of surfacing as `ENEEDAUTH` from `npm publish`.

`--provenance` is kept deliberately. OIDC attests regardless, but the explicit flag makes a *failure* to attest fail the publish rather than silently shipping an unattested tarball.

## ⚠️ Required before merge — configure the trusted publisher

Publishing will fail until the package has a trusted publisher pointing at this workflow. Your local npm is 11.12.1, so this works from the CLI:

```bash
npm login
npm trust github mobile-automator --file release.yml --repo sh3lan93/mobile-automator
npm trust list mobile-automator     # verify it registered
```

Or on npmjs.com: package page → **Settings** → **Trusted Publisher**.

> The trust relationship names **`release.yml` specifically**. Renaming that file, or moving the publish step into another workflow, breaks publishing until the trusted publisher is updated.

## Why this bumps the version

Merging this bumps to **0.23.9**, so the OIDC path is exercised end to end immediately — while `NPM_TOKEN` still exists as a fallback if something is wrong. The secret gets deleted only after a green publish proves OIDC works. Order matters: **configure the publisher → merge → confirm 0.23.9 publishes → then revoke.**

## Test plan

- [x] `release.yml` parses; no `NODE_AUTH_TOKEN` / `NPM_TOKEN` references remain (only explanatory comments)
- [x] Every `run` block passes `bash -n`
- [x] Version floor logic verified at the boundary (11.5.0 rejected / 11.5.1 accepted)
- [x] `v0.23.9` not present in `git tag`; changelog `sed` extracts 1534 chars
- [x] 829 tests / 70 suites green
- [x] `./scripts/pack-smoke.sh` → OK

Refs #170
