### PR TITLE
ci: move the two release-critical actions to node24 runtimes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -49,7 +49,13 @@ jobs:
 
       - name: Mint a GitHub App installation token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        # v3 keeps `app-id` working but marks it deprecated in favour of
+        # `client-id`. Those are DIFFERENT identifiers — the App ID is numeric,
+        # the Client ID looks like `Iv23li…` — so migrating means storing a new
+        # secret value, not renaming this input. Passing RELEASE_APP_ID as
+        # `client-id` would fail auth and silently stop tagging. Staying on
+        # `app-id` until that secret exists. See #182.
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       # provide. It also failed outright when the release already existed;
       # this one updates in place, so re-runs are safe.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Moves the two release-critical actions off the deprecated Node 20 Actions runtime. These two are split out from the six ordinary bumps in #182 because their failure modes are **invisible** — a broken release pipeline reports success and simply reaches nobody, which is how #170 stayed hidden across seven versions.

## What changed

| File | Action | From | To |
|---|---|---|---|
| `release.yml` | `softprops/action-gh-release` | `v2` (node20) | `v3` (node24) |
| `auto-tag.yml` | `actions/create-github-app-token` | `v2` (node20) | `v3` (node24) |

Plus a comment in `auto-tag.yml` recording why `app-id` deliberately stays.

## Why this is safe — evidence, not assumption

Each action's `action.yml` was diffed between the pinned ref and `v3`, and the release notes read for breaking changes.

**`action-gh-release` v2 → v3 — drop-in.** Zero inputs added or removed. All five this workflow passes (`tag_name`, `name`, `body`, `draft`, `prerelease`) unchanged. v3.0.0's notes describe a runtime-only major: *"moves the action runtime from Node 20 to Node 24."*

The constraint that mattered most is preserved: v3's `token` input defaults to `${{ github.token }}` and its description confirms an explicit token overrides `GITHUB_TOKEN`, so the `env: GITHUB_TOKEN` here still resolves to the same token. **This step must keep `GITHUB_TOKEN`** — that suppression is what stops the Release it creates from re-triggering this workflow via its own `release: [published]` trigger. No token change was made and none should be.

Reviewed and ruled out: v3.0.2 changed republishing of an existing **draft** release ([#801](https://github.com/softprops/action-gh-release/pull/801)); this workflow passes `draft: false`. The "updates in place, so re-runs are safe" property that `workflow_dispatch` depends on still holds.

**`create-github-app-token` v2 → v3 — safe, `app-id` stays.** Nothing removed; `private-key` and outputs `token` / `installation-id` / `app-slug` unchanged. Both v3.0.0 breaking changes are inapplicable: proxy handling now needs `NODE_USE_ENV_PROXY` (no proxy vars anywhere in this repo), and the Actions Runner ≥ 2.327.1 floor applies only to self-hosted runners (this job is `ubuntu-latest`).

Nothing changed in the minted token's permission scope, repository scope, or App identity semantics — so the #170 property is untouched.

v3.1.0 deprecated `app-id` in favour of `client-id`. `app-id` still functions, so this stays on it **on purpose**: an App's **App ID** (numeric) and **Client ID** (`Iv23li…`) are different identifiers, so migrating requires storing a new secret value, not renaming the input. Feeding `RELEASE_APP_ID` to `client-id` would fail auth and silently stop tagging. The added comment says so, so nobody "fixes" the deprecation warning into an outage.

## Test plan

- `npm test` — **858 passed / 71 suites**.
- Both workflows re-parsed with `js-yaml` after editing to confirm the steps and their inputs survived intact (they were edited by regex).
- No version bump: the gate watches `src/`, `bin/`, `package.json`; this touches only `.github/workflows/`.

## What this PR does *not* prove

`auto-tag.yml` going green is **not** evidence the App token still triggers `release.yml` — that job reports success whether or not its tag reached anyone. Proving it end-to-end needs a throwaway `test-apptoken-*` tag (`release.yml` listens only on `v*.*.*`, so such a tag cannot fire the release pipeline) plus a trivial workflow listening for it. That is [written up on #182](https://github.com/sh3lan93/mobile-automator/issues/182#issuecomment-5546428079) and deliberately not bundled here.

The remaining six pins in #182 (`checkout`, `setup-node`, `upload-artifact`, `setup-java`, `setup-python`, `paths-filter`) fail loudly on the PR that bumps them and can move separately.

Refs #182
Refs #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ak78wKiYxGikwxLCgoPxV6
