### PR TITLE
ci: cache npm downloads and scope test.yml's pull_request trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,7 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
 
       # Trusted publishing needs npm >= 11.5.1, and Node 22 LTS bundles npm
       # 10.x — the Node version alone does NOT satisfy the floor. Upgrade

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   test:
@@ -18,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: npm ci
       - run: npm run test:all
 
@@ -33,5 +35,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: npm ci
       - run: ./scripts/pack-smoke.sh


### PR DESCRIPTION
## What

Two workflow changes, each a single line per site, both bringing `test.yml` in line with patterns the repo already uses elsewhere:

1. **`cache: 'npm'`** on `setup-node` in `test.yml`'s `test` and `pack-smoke` jobs (6 matrix legs) and in `release.yml`'s `publish-npm`.
2. **`branches: [main]`** on `test.yml`'s `pull_request` trigger.

No `src/`, `bin/`, or `package.json` changes, so `version-check.yml` does not fire, no version bump is required, and no release is triggered. Same shape as #183, which was also workflows-only.

## Why the cache: reliability, not speed

**This does not make CI meaningfully faster, so don't merge it for the seconds.** Measured on CI (details in [this comment](https://github.com/sh3lan93/mobile-automator/pull/185#issuecomment-5546948566)): `setup-node` + `npm ci` across the three `Test` legs went from 32s cold to 28s with a cache hit, n=1 each. `npm ci` itself dropped ~35%, but the cache restore adds 2–6s to `setup-node`, and one warm pack-smoke leg ran slower than any cold leg. At this scale, runner variance dominates.

**What it buys: when the lockfile hasn't changed, a registry outage can no longer red CI.** Checked locally against this branch's `package-lock.json`, with the registry pointed at an unreachable address:

```
warm cache + registry at 127.0.0.1:9  →  added 442 packages in 2s   ✅
cold cache + registry at 127.0.0.1:9  →  npm error                  ❌ (control)
```

`npm ci` makes no registry request at all when the cache is warm. The lockfile already records each package's exact URL and checksum, and npm's cache is organized by checksum, so every tarball comes from disk. The control failing proves the registry really was unreachable.

That matters because six jobs per event each fetched 466 packages cold, and a registry blip reds a check that has nothing to do with the diff under review. Per #179's own reasoning, a check that fails for unrelated reasons trains people to ignore it.

### Where the protection does not apply

- **Lockfile changes miss the cache.** The key is `node-cache-<os>-<arch>-npm-<lockfile-hash>`, so a PR that adds or bumps a dependency installs cold. Those are exactly the PRs #161's Dependabot work would produce.
- **PR caches are not shared.** GitHub scopes a cache saved on a PR to that PR; only default-branch caches are shared. The warm key comes from `test.yml`'s `push: [main]` run, so after a lockfile change every PR stays cold until the change reaches `main`. `release.yml` runs on a tag ref, which can read `main`'s cache, so the publish job does benefit.

### The shared key is intentional

The cache key does not include the Node version, so on a cold key all six legs race to save one entry, one wins, and the other five log `Failed to save: Unable to reserve cache … another job may be creating this cache`. This is non-fatal and **correct**: the npm cache holds tarballs, which don't depend on the Node version, so one ~64 MB entry serves all six legs. Adding the Node version to the key would triple storage against the repo's cache quota just to silence a warning that only appears on a cold key.

## Why the branch filter

Every other `pull_request` trigger in the repo is scoped:

| Workflow | scoping |
|---|---|
| `lint-prompts.yml`, `validate-schemas.yml`, `version-check.yml` | `branches: [main]` |
| `docs.yml`, `sample-app.yml`, `sample-app-e2e-android.yml` | `paths:` |
| **`test.yml`** (before this PR) | **none** |

So the full six-leg matrix fired on PRs targeting *any* base, including stacked PRs between two feature branches. Stacked work is still tested when its final PR targets `main`. There is deliberately **no** `paths:` filter: path-filtering a test workflow is how a green PR comes to mean "the files I filtered on didn't change."

## What I deliberately did not touch

**`validate-schemas.yml`** was in the issue's original scope and was removed after checking the job body. It runs `npm install ajv ajv-formats`, not `npm ci`, and `setup-node`'s cache keys on `package-lock.json`, so the cache key would not match what that job actually installs.

Related, and worth its own issue: `ajv` **is** a declared dependency (`^8.20.0`), so that separate `npm install` resolves the newest matching version rather than the locked one. The schema validator can run against a different `ajv` than the test suite.

## Risk note for review

`release.yml` is the one file here with real consequences: trusted publishing names this workflow file, and it holds the only real gate on `npm publish` (#186). This PR adds a single `cache: 'npm'` input to its `setup-node` step. It doesn't rename the file, move the publish step, or change the OIDC path, so the trusted-publisher relationship is untouched. The cache is restored inside `setup-node`, before the in-job `npm install -g npm@latest`, and `~/.npm`'s format is stable from npm 10 to 11. The job still runs `npm ci → npm test → pack-smoke.sh` before publishing.

The hunk is kept for reliability, not speed: a registry blip there would fail a publish job that has already started. The two hunks are independent if you'd rather drop it.

## Test plan

Local, on this branch:

- `python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`: all 9 workflows parse.
- `npx jest tests/lint/node-version-agreement.test.js`: **23/23 pass.** #179's guard reads `step.with['node-version']` out of every workflow, so a malformed `with:` block would fail it.
- `npm run lint:guides`: **16 suites, 206 tests, all pass.**
- `npm run test:all`: **73 suites, 884 tests, all pass.**
- `./scripts/pack-smoke.sh`: `pack-smoke OK`.
- Offline `npm ci` with a warm cache vs a cold cache: results above.

On CI:

- [x] Cold run (33923535671) saved the cache; the re-run logged `Cache hit … Cache restored successfully` (~64 MB).
- [x] All six legs green after merging `main` (run 34884848470).

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMPdqAATn5CRat339q9HDn
